### PR TITLE
Make log entry timestamp in 24-hour format. 

### DIFF
--- a/src/org/traccar/Server.java
+++ b/src/org/traccar/Server.java
@@ -184,7 +184,7 @@ public class Server {
                             System.getProperty("line.separator", "\n");
 
                     private final DateFormat dateFormat =
-                            new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
                     public String format(LogRecord record) {
                         StringBuffer line = new StringBuffer();


### PR DESCRIPTION
The current timestamp is 12-hour format without AM/PM suffix, making it harder to tell the exact time. This change makes it 24-hour format.
