### PR TITLE
Tolerate Xexun2 data with low power level; Tolerate phone number without "+" prefix

### DIFF
--- a/src/org/traccar/protocol/Xexun2ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Xexun2ProtocolDecoder.java
@@ -44,7 +44,7 @@ public class Xexun2ProtocolDecoder extends GenericProtocolDecoder {
     static private Pattern pattern = Pattern.compile(
             "[\r\n]*" +
             "(\\d+)," +                         // Serial
-            "(\\+\\d+)," +                      // Number
+            "(\\+?\\d+)," +                      // Number
             "GPRMC," +
             "(\\d{2})(\\d{2})(\\d{2})\\.(\\d{3})," + // Time (HHMMSS.SSS)
             "([AV])," +                         // Validity

--- a/test/org/traccar/protocol/Xexun2ProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/Xexun2ProtocolDecoderTest.java
@@ -19,6 +19,8 @@ public class Xexun2ProtocolDecoderTest {
         assertNotNull(decoder.decode(null, null,
                 "111111120009,+436763737552,GPRMC,120600.000,A,6000.0000,N,13000.0000,E,0.00,0.00,010112,,,A*68,F,help me!, imei:123456789012345,04,481.2,L:3.5V,0,139,2689,232,03,2725,0576"));
 
+        assertNotNull(decoder.decode(null, null,
+                "111111120009,436763737552,GPRMC,120600.000,A,6000.0000,N,13000.0000,E,0.00,0.00,010112,,,A*68,F,help me!, imei:123456789012345,04,481.2,L:3.5V,0,139,2689,232,03,2725,0576"));
     }
 
 }


### PR DESCRIPTION
- Some data came with L:3.5V field but is still a valid GPS record. Keep it.
-   Tolerate phone number without "+" prefix in Xexun2 data.
