### PR TITLE
fixes in v680:

### DIFF
--- a/src/org/traccar/ServerManager.java
+++ b/src/org/traccar/ServerManager.java
@@ -463,7 +463,7 @@ public class ServerManager {
             serverList.add(new TrackerServer(this, new ServerBootstrap(), protocol) {
                 @Override
                 protected void addSpecificHandlers(ChannelPipeline pipeline) {
-                    byte delimiter[] = { (byte) '#', (byte) '#' };
+                    byte delimiter[] = { (byte) '0', (byte) '#', (byte) '#' };
                     pipeline.addLast("frameDecoder",
                             new DelimiterBasedFrameDecoder(1024, ChannelBuffers.wrappedBuffer(delimiter)));
                     pipeline.addLast("stringDecoder", new StringDecoder());

--- a/src/org/traccar/protocol/V680ProtocolDecoder.java
+++ b/src/org/traccar/protocol/V680ProtocolDecoder.java
@@ -60,7 +60,8 @@ public class V680ProtocolDecoder extends BaseProtocolDecoder {
             throws Exception {
 
         String sentence = (String) msg;
-        
+        sentence = sentence.trim();
+       
         // Detect device ID
         if (sentence.length() == 16) {
             String imei = sentence.substring(1, sentence.length());


### PR DESCRIPTION
1) changed frame delimiter from '##' to '0##' because of 'dropped'
messages caused by the null value after imei that turned in an ## after
the imei. I am not sure if there is always a 0 before the final ## but
in hours of testing it was always true for my v680 clone.

2) trimmed sentence in v680 protocol decoder to fix 'dropped' messages
caused by line feeds that my v680 clone was receiving before the message
itself.
