### PR TITLE
fix in v680:

### DIFF
--- a/src/org/traccar/protocol/V680ProtocolDecoder.java
+++ b/src/org/traccar/protocol/V680ProtocolDecoder.java
@@ -60,7 +60,8 @@ public class V680ProtocolDecoder extends BaseProtocolDecoder {
             throws Exception {
 
         String sentence = (String) msg;
-        
+        sentence = sentence.trim();
+       
         // Detect device ID
         if (sentence.length() == 16) {
             String imei = sentence.substring(1, sentence.length());


### PR DESCRIPTION
1) trimmed sentence in v680 protocol decoder to fix 'dropped' messages
caused by line feeds that my v680 clone was receiving before the message
itself.
