### PR TITLE
Update HaicomProtocolDecoder.java

### DIFF
--- a/src/org/traccar/protocol/HaicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/HaicomProtocolDecoder.java
@@ -48,11 +48,11 @@ public class HaicomProtocolDecoder extends BaseProtocolDecoder {
             "(\\d+)," +                   // Speed
             "(\\d+)," +                   // Course
             "(\\d+)," +                   // Status
-            "(\\d+)," +                   // GPRS counting value
-            "(\\d+)," +                   // GPS power saving counting value
+            "(\\d*)," +                   // GPRS counting value
+            "(\\d*)," +                   // GPS power saving counting value
             "(\\d+)," +                   // Switch status
             "(\\d+)" +                    // Relay status
-            "[LH]{2}" +                   // Power status
+            "[LH]{0,2}" +                   // Power status
             "\\#V(\\d+)");                // Battery
 
     @Override


### PR DESCRIPTION
A customer wanted to use traccar with a HI-602X device. The device was properly recognized but there were no recording of position.

Using the debug log and hex converter, I found that the haicom regex is too strict for the HI-602X message scheme, which doesn't send GPRS counting value and GPS power saving counting value (delimiters are here but no value), doesn't have le LH characters and ends with a *

So I changed the Regex according to a HI-602X device message, keeping it compatible with the test message seen in the test directory.

I don't know if this regex is the best for the haicom protocol.

Here is an anonymised message from a HI-602X device : 

$GPRS123456789012345,T100001,141112,090751,7240649312041079,0002,1530,000001,,,1,00#V039*

I haven't rebuild traccar from source as I haven't got a Java environment at work, but I check the regex itself with an online regex test page.
