### PR TITLE
Adding event handler for detecting engine start or stop using car's power voltage

### DIFF
--- a/src/org/traccar/events/EngineStartStopEventHandler.java
+++ b/src/org/traccar/events/EngineStartStopEventHandler.java
@@ -51,7 +51,7 @@ public class EngineStartStopEventHandler extends BaseEventHandler {
 
         // Getting current power
         double power = position.getAttributes().containsKey(Position.KEY_POWER);
-        
+
         // Getting old power
         double oldPower = 0;
         Position lastPosition = Context.getIdentityManager().getLastPosition(position.getDeviceId());

--- a/src/org/traccar/events/EngineStartStopEventHandler.java
+++ b/src/org/traccar/events/EngineStartStopEventHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.events;
+
+import org.traccar.BaseEventHandler;
+import org.traccar.Context;
+import org.traccar.model.Device;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class EngineStartStopEventHandler extends BaseEventHandler {
+
+    // Define new attribute
+    public static final String ATTRIBUTE_ENGINE_START_STOP_POWER_THRESHOLD = "engineStartStopPowerThreshold";
+
+    @Override
+    protected Collection<Event> analyzePosition(Position position) {
+
+        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        if (device == null) {
+            return null;
+        }
+        if (!Context.getIdentityManager().isLatestPosition(position)) {
+            return null;
+        }
+
+        // Getting ATTRIBUTE_ENGINE_START_STOP_POWER_THRESHOLD value
+        double engineStartStopPowerThreshold = Context.getDeviceManager()
+                .lookupAttributeDouble(device.getId(), ATTRIBUTE_ENGINE_START_STOP_POWER_THRESHOLD, 0, false);
+
+        // If no power threshold specified for current device using attributes
+        if (engineStartStopPowerThreshold == 0) {
+            return null;
+       }
+
+        // Getting current power
+        double power = position.getAttributes().containsKey(Position.KEY_POWER);
+        
+        // Getting old power
+        double oldPower = 0;
+        Position lastPosition = Context.getIdentityManager().getLastPosition(position.getDeviceId());
+        if (lastPosition != null) {
+            oldPower = lastPosition.getAttributes().containsKey(Position.KEY_POWER);
+        }
+
+        // Here comes the logic to determine if engine has started or stopped
+        if (power > engineStartStopPowerThreshold && oldPower < engineStartStopPowerThreshold) {
+            return Collections.singleton(
+                    new Event(Event.TYPE_ENGINE_STARTED, position.getDeviceId(), position.getId()));
+        } else if (power < engineStartStopPowerThreshold && oldPower > engineStartStopPowerThreshold) {
+            return Collections.singleton(
+                    new Event(Event.TYPE_ENGINE_STOPPED, position.getDeviceId(), position.getId()));
+        }
+        return null;
+
+
+
+        if (position.getAttributes().containsKey(Position.KEY_POWER)
+                && lastPosition != null && lastPosition.getAttributes().containsKey(Position.KEY_POWER)) {
+
+            double drop = lastPosition.getDouble(Position.KEY_POWER) - position.getDouble(Position.KEY_POWER);
+            if (drop >= fuelDropThreshold) {
+                Event event = new Event(Event.TYPE_DEVICE_FUEL_DROP, position.getDeviceId(), position.getId());
+                event.set(ATTRIBUTE_FUEL_DROP_THRESHOLD, fuelDropThreshold);
+                return Collections.singleton(event);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/org/traccar/events/EngineStartStopEventHandler.java
+++ b/src/org/traccar/events/EngineStartStopEventHandler.java
@@ -47,7 +47,7 @@ public class EngineStartStopEventHandler extends BaseEventHandler {
         // If no power threshold specified for current device using attributes
         if (engineStartStopPowerThreshold == 0) {
             return null;
-       }
+        }
 
         // Getting current power
         double power = position.getAttributes().containsKey(Position.KEY_POWER);
@@ -69,20 +69,6 @@ public class EngineStartStopEventHandler extends BaseEventHandler {
         }
         return null;
 
-
-
-        if (position.getAttributes().containsKey(Position.KEY_POWER)
-                && lastPosition != null && lastPosition.getAttributes().containsKey(Position.KEY_POWER)) {
-
-            double drop = lastPosition.getDouble(Position.KEY_POWER) - position.getDouble(Position.KEY_POWER);
-            if (drop >= fuelDropThreshold) {
-                Event event = new Event(Event.TYPE_DEVICE_FUEL_DROP, position.getDeviceId(), position.getId());
-                event.set(ATTRIBUTE_FUEL_DROP_THRESHOLD, fuelDropThreshold);
-                return Collections.singleton(event);
-            }
-        }
-
-        return null;
     }
 
 }

--- a/src/org/traccar/model/Event.java
+++ b/src/org/traccar/model/Event.java
@@ -48,7 +48,7 @@ public class Event extends Message {
 
     public static final String TYPE_ENGINE_STARTED = "engineStarted";
     public static final String TYPE_ENGINE_STOPPED = "engineStopped";
-    
+
     public static final String TYPE_DEVICE_OVERSPEED = "deviceOverspeed";
     public static final String TYPE_DEVICE_FUEL_DROP = "deviceFuelDrop";
 

--- a/src/org/traccar/model/Event.java
+++ b/src/org/traccar/model/Event.java
@@ -46,6 +46,9 @@ public class Event extends Message {
     public static final String TYPE_DEVICE_MOVING = "deviceMoving";
     public static final String TYPE_DEVICE_STOPPED = "deviceStopped";
 
+    public static final String TYPE_ENGINE_STARTED = "engineStarted";
+    public static final String TYPE_ENGINE_STOPPED = "engineStopped";
+    
     public static final String TYPE_DEVICE_OVERSPEED = "deviceOverspeed";
     public static final String TYPE_DEVICE_FUEL_DROP = "deviceFuelDrop";
 


### PR DESCRIPTION
This event handler is for detecting engine start or stop using car's power voltage.

ATTRIBUTE_ENGINE_START_STOP_POWER_THRESHOLD can be defined with a specific voltage level of car power.
According to my measures 14.00V can be working level.

If this voltage drops below the threshold and previously it was higher, it means engine has stopped (car's power generator does not operate)
If voltage gets higher than threshold and previously it was lower, it means engine has started (car's power generator operates)

May need to change code in other files as well. 