### PR TITLE
Possibility to obtain information about the "neighborhood" in Google's reverse geocoding.

### DIFF
--- a/src/org/traccar/geocoder/Address.java
+++ b/src/org/traccar/geocoder/Address.java
@@ -77,6 +77,16 @@ public class Address {
         this.suburb = suburb;
     }
 
+    private String political;
+    
+    public String getPolitical() {
+        return political;
+    }
+    
+    public void setPolitical(String political) {
+        this.political = political;
+    }
+    
     private String street;
 
     public String getStreet() {

--- a/src/org/traccar/geocoder/Address.java
+++ b/src/org/traccar/geocoder/Address.java
@@ -11,6 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
+ *
  * limitations under the License.
  */
 package org.traccar.geocoder;

--- a/src/org/traccar/geocoder/Address.java
+++ b/src/org/traccar/geocoder/Address.java
@@ -78,15 +78,15 @@ public class Address {
     }
 
     private String political;
-    
+
     public String getPolitical() {
         return political;
     }
-    
+
     public void setPolitical(String political) {
         this.political = political;
     }
-    
+
     private String street;
 
     public String getStreet() {

--- a/src/org/traccar/geocoder/AddressFormat.java
+++ b/src/org/traccar/geocoder/AddressFormat.java
@@ -28,6 +28,7 @@ import java.text.ParsePosition;
  * %d - district
  * %t - settlement (town)
  * %u - suburb
+ * %n - political (neighborhood)
  * %r - street (road)
  * %h - house
  *
@@ -37,7 +38,7 @@ public class AddressFormat extends Format {
     private final String format;
 
     public AddressFormat() {
-        this("%h %r, %t, %s, %c");
+        this("%h %r, %n, %t, %s, %c");
     }
 
     public AddressFormat(String format) {
@@ -64,6 +65,7 @@ public class AddressFormat extends Format {
         result = replace(result, "%d", address.getDistrict());
         result = replace(result, "%t", address.getSettlement());
         result = replace(result, "%u", address.getSuburb());
+        result = replace(result, "%n", address.getPolitical());
         result = replace(result, "%r", address.getStreet());
         result = replace(result, "%h", address.getHouse());
 

--- a/src/org/traccar/geocoder/GoogleGeocoder.java
+++ b/src/org/traccar/geocoder/GoogleGeocoder.java
@@ -59,6 +59,9 @@ public class GoogleGeocoder extends JsonGeocoder {
                         case "route":
                             address.setStreet(value);
                             break typesLoop;
+                        case "political":
+                            address.setPolitical(value);
+                            break typesLoop;
                         case "locality":
                             address.setSettlement(value);
                             break typesLoop;


### PR DESCRIPTION
Added the possibility of obtaining information about the "**neighborhood**" in Google's reverse geocoding.

Before:
197-223 R. Our Lady of the Rosary, Vila Velha, ES, BR

After:
197-223 R. Our Lady of the Rosary, "**Santa Paula II**", Vila Velha, ES, BR, 29126250

Note:
* In Brazil this information is very important
* You need to update the documentation for the "geocoder.format" parameter, including "% n"