### PR TITLE
org.traccar.ServerManager: ignore stray files in the jar archive

### DIFF
--- a/src/org/traccar/ServerManager.java
+++ b/src/org/traccar/ServerManager.java
@@ -46,7 +46,8 @@ public class ServerManager {
                 Enumeration<JarEntry> jarEntries = jf.entries();
                 while (jarEntries.hasMoreElements()) {
                     String entryName = jarEntries.nextElement().getName();
-                    if (entryName.startsWith(packagePath) && entryName.length() > packagePath.length() + 5) {
+                    if (entryName.startsWith(packagePath)
+                            && entryName.endsWith(".class")) {
                         names.add(entryName.substring(packagePath.length() + 1, entryName.lastIndexOf('.')));
                     }
                 }
@@ -57,7 +58,9 @@ public class ServerManager {
             if (files != null) {
                 for (File actual: files) {
                     String entryName = actual.getName();
-                    names.add(entryName.substring(0, entryName.lastIndexOf('.')));
+                    if (entryName.endsWith(".class")) {
+                        names.add(entryName.substring(0, entryName.lastIndexOf('.')));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Somehow, non-class files may find their way into the jar archive.
For example, I had Tk103ProtocolDecoder.java open in Vim. Vim created a
temporary file called .Tk103ProtocolDecoder.java.swp which was imported
into the .jar archive.  ServerManager then tried to load a class named
.Tk103ProtocolDecoder.java and failed.
This patch prevents ServerManager from trying to load such bogus files.

This work was funded by Partner Security, http://www.partnersecurity.pl/ but code is owned by me.