### PR TITLE
org.traccar.DistanceHandler: add parameter coordinates.minErrorStatic 

### DIFF
--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -204,13 +204,9 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
             pipeline.addLast("hemisphere", hemisphereHandler);
         }
 
-        if (motionHandler != null) {
-            pipeline.addLast("motion", motionHandler);
-        }
+        pipeline.addLast("motion", motionHandler);
 
-        if (distanceHandler != null) {
-            pipeline.addLast("distance", distanceHandler);
-        }
+        pipeline.addLast("distance", distanceHandler);
 
         if (remoteAddressHandler != null) {
             pipeline.addLast("remoteAddress", remoteAddressHandler);

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -131,7 +131,8 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
         distanceHandler = new DistanceHandler(
                 Context.getConfig().getBoolean("coordinates.filter"),
                 Context.getConfig().getInteger("coordinates.minError"),
-                Context.getConfig().getInteger("coordinates.maxError"));
+                Context.getConfig().getInteger("coordinates.maxError"),
+                Context.getConfig().getInteger("coordinates.minErrorStatic", -1));
 
         if (Context.getConfig().getBoolean("processing.remoteAddress.enable")) {
             remoteAddressHandler = new RemoteAddressHandler();

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -204,6 +204,10 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
             pipeline.addLast("hemisphere", hemisphereHandler);
         }
 
+        if (motionHandler != null) {
+            pipeline.addLast("motion", motionHandler);
+        }
+
         if (distanceHandler != null) {
             pipeline.addLast("distance", distanceHandler);
         }
@@ -220,10 +224,6 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         if (geocoderHandler != null) {
             pipeline.addLast("geocoder", geocoderHandler);
-        }
-
-        if (motionHandler != null) {
-            pipeline.addLast("motion", motionHandler);
         }
 
         if (copyAttributesHandler != null) {

--- a/src/org/traccar/DistanceHandler.java
+++ b/src/org/traccar/DistanceHandler.java
@@ -27,11 +27,19 @@ public class DistanceHandler extends BaseDataHandler {
     private final boolean filter;
     private final int coordinatesMinError;
     private final int coordinatesMaxError;
+    private final int coordinatesMinErrorStatic;
 
-    public DistanceHandler(boolean filter, int coordinatesMinError, int coordinatesMaxError) {
+    public DistanceHandler(boolean filter, int coordinatesMinError,
+                int coordinatesMaxError, int coordinatesMinErrorStatic) {
         this.filter = filter;
         this.coordinatesMinError = coordinatesMinError;
         this.coordinatesMaxError = coordinatesMaxError;
+        if (coordinatesMinErrorStatic == -1) {
+            // use a default value
+            this.coordinatesMinErrorStatic = coordinatesMinError;
+        } else {
+            this.coordinatesMinErrorStatic = coordinatesMinErrorStatic;
+        }
     }
 
     private Position getLastPosition(long deviceId) {
@@ -71,7 +79,14 @@ public class DistanceHandler extends BaseDataHandler {
                         last.getLatitude(), last.getLongitude());
             }
             if (filter && last.getValid() && last.getLatitude() != 0 && last.getLongitude() != 0) {
-                boolean satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;
+                double speed = position.getSpeed();
+                boolean satisfiesMin;
+                if (speed < 0.01) {
+                    satisfiesMin = coordinatesMinErrorStatic == 0 || distance > coordinatesMinErrorStatic;
+                } else {
+                    satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;
+                }
+
                 boolean satisfiesMax = coordinatesMaxError == 0
                         || distance < coordinatesMaxError || position.getValid();
                 if (!satisfiesMin || !satisfiesMax) {

--- a/src/org/traccar/DistanceHandler.java
+++ b/src/org/traccar/DistanceHandler.java
@@ -79,9 +79,10 @@ public class DistanceHandler extends BaseDataHandler {
                         last.getLatitude(), last.getLongitude());
             }
             if (filter && last.getValid() && last.getLatitude() != 0 && last.getLongitude() != 0) {
-                double speed = position.getSpeed();
                 boolean satisfiesMin;
-                if (speed < 0.01) {
+                boolean isInMotion = position.getBoolean(Position.KEY_MOTION);
+                boolean isStatic = !isInMotion;
+                if (isStatic) {
                     satisfiesMin = coordinatesMinErrorStatic == 0 || distance > coordinatesMinErrorStatic;
                 } else {
                     satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;

--- a/src/org/traccar/DistanceHandler.java
+++ b/src/org/traccar/DistanceHandler.java
@@ -41,6 +41,18 @@ public class DistanceHandler extends BaseDataHandler {
         return null;
     }
 
+    /*
+     * HACK:
+     * Round distance and totalDistance to two
+     * fractional decimal digits to save space when storing these values
+     * in JSON.
+     */
+    private double roundDistance(double distance) {
+        return BigDecimal.valueOf(distance)
+                         .setScale(2, RoundingMode.HALF_EVEN)
+                         .doubleValue();
+    }
+
     @Override
     protected Position handlePosition(Position position) {
 
@@ -57,7 +69,6 @@ public class DistanceHandler extends BaseDataHandler {
                 distance = DistanceCalculator.distance(
                         position.getLatitude(), position.getLongitude(),
                         last.getLatitude(), last.getLongitude());
-                distance = BigDecimal.valueOf(distance).setScale(2, RoundingMode.HALF_EVEN).doubleValue();
             }
             if (filter && last.getValid() && last.getLatitude() != 0 && last.getLongitude() != 0) {
                 boolean satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;
@@ -70,9 +81,10 @@ public class DistanceHandler extends BaseDataHandler {
                 }
             }
         }
-        position.set(Position.KEY_DISTANCE, distance);
-        totalDistance = BigDecimal.valueOf(totalDistance + distance).setScale(2, RoundingMode.HALF_EVEN).doubleValue();
-        position.set(Position.KEY_TOTAL_DISTANCE, totalDistance);
+        totalDistance = totalDistance + distance;
+
+        position.set(Position.KEY_DISTANCE, roundDistance(distance));
+        position.set(Position.KEY_TOTAL_DISTANCE, roundDistance(totalDistance));
 
         return position;
     }

--- a/src/org/traccar/MotionHandler.java
+++ b/src/org/traccar/MotionHandler.java
@@ -20,7 +20,7 @@ import org.traccar.model.Position;
 
 public class MotionHandler extends BaseDataHandler {
 
-    private double speedThreshold;
+    private final double speedThreshold;
 
     public MotionHandler(double speedThreshold) {
         this.speedThreshold = speedThreshold;

--- a/test/org/traccar/DistanceHandlerTest.java
+++ b/test/org/traccar/DistanceHandlerTest.java
@@ -10,7 +10,7 @@ public class DistanceHandlerTest {
     @Test
     public void testCalculateDistance() throws Exception {
 
-        DistanceHandler distanceHandler = new DistanceHandler(false, 0, 0);
+        DistanceHandler distanceHandler = new DistanceHandler(false, 0, 0, -1);
 
         Position position = distanceHandler.handlePosition(new Position());
 


### PR DESCRIPTION
This commit adds the following configuration parameter:

coordinates.minErrorStatic

        Distance in meters. Value of `coordinates.minErrorStatic` that
        applies when the speed *as reported by the device* is equal to
        zero (or, more exactly, less then 0.01 knots). By default this
        value is equal to `coordinates.minErrorStatic`.

Using this parameter works very well for filtering out erroneous position changes
when the device is static. As we all know, GPS is imprecise and using it
introduces position errors. When the device is static, every position
recorded by GPS is slightly different and position history - when displayed
on a map - looks like a distinctive "star".
In this situation, most device position updates feature a speed of (exactly) 0.0 knots.
By replacing all positions with a speed of 0.0 knots with last
position, we can make the device appear almost "static" on the map.

It is safe to use much higher values of `coordinates.minErrorStatic` than
values of `coordinates.minError`.

This filtering mechanism works very well in practice. It is not
necessary to make the threshold speed user-configurable.
It worked very well even if the comparison

    speed == 0.0

was used.

This work was funded by Partner Security (www.partnersecurity.pl) but
copyright remains with me (Mateusz Jończyk). Additionally, I have
obtained permission to release my work as open source.