### PR TITLE
Add basic support of overspeeding inside geofences.

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -464,7 +464,8 @@ public final class Context {
         motionEventHandler = new MotionEventHandler(tripsConfig);
         overspeedEventHandler = new OverspeedEventHandler(
                 Context.getConfig().getLong("event.overspeed.minimalDuration") * 1000,
-                Context.getConfig().getBoolean("event.overspeed.notRepeat"));
+                Context.getConfig().getBoolean("event.overspeed.notRepeat"),
+                Context.getConfig().getBoolean("event.overspeed.geofenceMinimal"));
     }
 
     public static void init(IdentityManager testIdentityManager) {

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2018 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +24,7 @@ import org.traccar.Context;
 import org.traccar.model.Device;
 import org.traccar.model.DeviceState;
 import org.traccar.model.Event;
+import org.traccar.model.Geofence;
 import org.traccar.model.Position;
 
 public class OverspeedEventHandler extends BaseEventHandler {
@@ -30,11 +32,13 @@ public class OverspeedEventHandler extends BaseEventHandler {
     public static final String ATTRIBUTE_SPEED_LIMIT = "speedLimit";
 
     private boolean notRepeat;
+    private boolean geofenceMinimal;
     private long minimalDuration;
 
-    public OverspeedEventHandler(long minimalDuration, boolean notRepeat) {
+    public OverspeedEventHandler(long minimalDuration, boolean notRepeat, boolean geofenceMinimal) {
         this.notRepeat = notRepeat;
         this.minimalDuration = minimalDuration;
+        this.geofenceMinimal = geofenceMinimal;
     }
 
     private Map<Event, Position> newEvent(DeviceState deviceState, double speedLimit) {
@@ -42,8 +46,10 @@ public class OverspeedEventHandler extends BaseEventHandler {
         Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, position.getDeviceId(), position.getId());
         event.set("speed", deviceState.getOverspeedPosition().getSpeed());
         event.set(ATTRIBUTE_SPEED_LIMIT, speedLimit);
+        event.setGeofenceId(deviceState.getOverspeedGeofenceId());
         deviceState.setOverspeedState(notRepeat);
         deviceState.setOverspeedPosition(null);
+        deviceState.setOverspeedGeofenceId(0);
         return Collections.singletonMap(event, position);
     }
 
@@ -61,7 +67,8 @@ public class OverspeedEventHandler extends BaseEventHandler {
         return result;
     }
 
-    public Map<Event, Position> updateOverspeedState(DeviceState deviceState, Position position, double speedLimit) {
+    public Map<Event, Position> updateOverspeedState(
+            DeviceState deviceState, Position position, double speedLimit, long geofenceId) {
         Map<Event, Position> result = null;
 
         Boolean oldOverspeed = deviceState.getOverspeedState();
@@ -71,12 +78,15 @@ public class OverspeedEventHandler extends BaseEventHandler {
         if (newOverspeed && !oldOverspeed) {
             if (deviceState.getOverspeedPosition() == null) {
                 deviceState.setOverspeedPosition(position);
+                deviceState.setOverspeedGeofenceId(geofenceId);
             }
         } else if (oldOverspeed && !newOverspeed) {
             deviceState.setOverspeedState(false);
             deviceState.setOverspeedPosition(null);
+            deviceState.setOverspeedGeofenceId(0);
         } else {
             deviceState.setOverspeedPosition(null);
+            deviceState.setOverspeedGeofenceId(0);
         }
         Position overspeedPosition = deviceState.getOverspeedPosition();
         if (overspeedPosition != null) {
@@ -101,6 +111,28 @@ public class OverspeedEventHandler extends BaseEventHandler {
         }
 
         double speedLimit = Context.getDeviceManager().lookupAttributeDouble(deviceId, ATTRIBUTE_SPEED_LIMIT, 0, false);
+
+        double geofenceSpeedLimit = 0;
+        long overspeedGeofenceId = 0;
+
+        if (Context.getGeofenceManager() != null) {
+            for (long geofenceId : device.getGeofenceIds()) {
+                Geofence geofence = Context.getGeofenceManager().getById(geofenceId);
+                if (geofence != null) {
+                    double currentSpeedLimit = geofence.getDouble(ATTRIBUTE_SPEED_LIMIT);
+                    if (currentSpeedLimit > 0 && geofenceSpeedLimit == 0
+                            || geofenceMinimal && currentSpeedLimit < geofenceSpeedLimit
+                            || !geofenceMinimal && currentSpeedLimit > geofenceSpeedLimit) {
+                        geofenceSpeedLimit = currentSpeedLimit;
+                        overspeedGeofenceId = geofenceId;
+                    }
+                }
+            }
+        }
+        if (geofenceSpeedLimit > 0) {
+            speedLimit = geofenceSpeedLimit;
+        }
+
         if (speedLimit == 0) {
             return null;
         }
@@ -110,8 +142,9 @@ public class OverspeedEventHandler extends BaseEventHandler {
 
         if (deviceState.getOverspeedState() == null) {
             deviceState.setOverspeedState(position.getSpeed() > speedLimit);
+            deviceState.setOverspeedGeofenceId(position.getSpeed() > speedLimit ? overspeedGeofenceId : 0);
         } else {
-            result = updateOverspeedState(deviceState, position, speedLimit);
+            result = updateOverspeedState(deviceState, position, speedLimit, overspeedGeofenceId);
         }
 
         Context.getDeviceManager().setDeviceState(deviceId, deviceState);

--- a/src/org/traccar/model/DeviceState.java
+++ b/src/org/traccar/model/DeviceState.java
@@ -58,4 +58,14 @@ public class DeviceState {
         return overspeedPosition;
     }
 
+    private long overspeedGeofenceId;
+
+    public void setOverspeedGeofenceId(long overspeedGeofenceId) {
+        this.overspeedGeofenceId = overspeedGeofenceId;
+    }
+
+    public long getOverspeedGeofenceId() {
+        return overspeedGeofenceId;
+    }
+
 }

--- a/templates/mail/deviceOverspeed.vm
+++ b/templates/mail/deviceOverspeed.vm
@@ -12,7 +12,7 @@
 <html>
 <body>
 Device: $device.name<br>
-Exceeds the speed: $speedString<br>
+Exceeds the speed: $speedString#{if}($geofence) in $geofence.name#{else}#{end}<br>
 Time: $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)<br>
 Point: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 </body>

--- a/templates/sms/deviceOverspeed.vm
+++ b/templates/sms/deviceOverspeed.vm
@@ -7,4 +7,4 @@
 #else
 #set($speedString = $numberTool.format("0.0 kn", $position.speed))
 #end
-$device.name exceeds the speed $speedString at $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)
+$device.name exceeds the speed $speedString#{if}($geofence) in $geofence.name#{else}#{end} at $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)


### PR DESCRIPTION
It is basic implementation with some known limits:

- Geofence speed limit has priority over device speed limit
- Basic selection of speed limit of overlapped geofences, minimal or maximum are selected (according to `event.overspeed.geofenceMinimal` flag)
- If device started overspeeding inside a Geofence and continued outside without gap, event will be related to the Geofence. It might be confusing in some cases if user do not have access to the Geofence.


fix #3850 