### PR TITLE
Fix parser for LKGPS (H02) protocol.

### DIFF
--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -227,6 +227,14 @@ public class FilterHandler extends BaseDataHandler {
         }
 
         if (filterType.length() > 0) {
+            if (last != null && !filterZero(last) && !filterInvalid(last)) {
+                if (position.getLong(Position.KEY_STATUS) != last.getLong(Position.KEY_STATUS)) {
+                    position.setLatitude(last.getLatitude());
+                    position.setLongitude(last.getLongitude());
+                    position.setFixTime(last.getFixTime());
+                    return false;
+                }
+            }
 
             StringBuilder message = new StringBuilder();
             message.append("Position filtered by ");

--- a/test/org/traccar/protocol/H02ProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/H02ProtocolDecoderTest.java
@@ -128,7 +128,7 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, buffer(
                 "*HQ,1451316485,V1,121557,A,-23-35.3408,S,-48-2.8926,W,0.1,158,241115,FFFFFFFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*HQ,355488020119695,V1,050418,,2827.61232,N,07703.84822,E,0.00,0,031015,FFFEFBFF#"),
                 position("2015-10-03 05:04:18.000", false, 28.46021, 77.06414));
@@ -142,49 +142,49 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, buffer(
                 "*HQ,3800008786,V1,062507,V,3048.2437,N,03058.5617,E,000.00,000,250413,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*HQ,4300256455,V1,111817,A,1935.5128,N,04656.3243,E,0.00,100,170913,FFE7FBFF#"));
 
         verifyPosition(decoder, buffer(
                 "*HQ,123456789012345,V1,155850,A,5214.5346,N,2117.4683,E,0.00,270.90,131012,ffffffff,000000,000000,000000,000000#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*HQ,353588010001689,V1,221116,A,1548.8220,S,4753.1679,W,0.00,0.00,300413,ffffffff,0002d4,000004,0001cd,000047#"));
 
         verifyPosition(decoder, buffer(
                 "*HQ,354188045498669,V1,195200,A,701.8915,S,3450.3399,W,0.00,205.70,050213,ffffffff,000243,000000,000000#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*HQ,2705171109,V1,213324,A,5002.5849,N,01433.7822,E,0.00,000,140613,FFFFFFFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V1,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#\r\n"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S17,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S14,100,10,1,3,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S20,ERROR,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S20,DONE,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,F7FFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,R8,ERROR,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S23,165.165.33.250:8800,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S24,thit.gd,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFF#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*TH,2020916012,V4,S1,OK,pass_word,130305,050316,A,2212.8745,N,11346.6574,E,14.28,028,220902,FFFFFBFD#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*HQ,353588020068342,V1,062840,A,5241.1249,N,954.9490,E,0.00,0.00,231013,ffffffff,000106,000002,000203,004c87,24#"));
 
@@ -193,7 +193,7 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, buffer(
                 "*HQ,353505220903211,V1,140817,A,5239.3538,N,01003.5292,E,21.03,312,221013,FFFBFFFF,106,14, 203,1cd#"));
-        
+
         verifyPosition(decoder, buffer(
                 "*HQ,356823035368767,V1,083618,A,0955.6392,N,07809.0796,E,0.00,0,070414,FFFBFFFF,194,3b5,  71,c9a9#"));
 
@@ -224,9 +224,12 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, binary(
                 "2441091144271222470112142233983006114026520E000000FFFFFBFFFF0014060000000001CC00262B0F170A"));
-        
+
         verifyPosition(decoder, binary(
                 "24971305007205201916101533335008000073206976000000effffbffff000252776566060000000000000000000049"));
+
+        verifyAttributes(decoder, buffer(
+                "*HQ,4710008873,NBR,120639,232,3,0,2,12010,13489,-29,12010,13489,-29,020518,FFFFF9FF,5#"));
 
     }
 
@@ -246,6 +249,36 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
         verifyAttribute(decoder, buffer(
                 "*HQ,4210051415,V1,164549,A,0956.3869,N,08406.7068,W,000.00,000,221215,FFFFFBFF,712,01,0,0,6#"),
                 Position.KEY_STATUS, 0xFFFFFBFFL);
+
+        verifyAttribute(decoder, binary(
+                "2447100088730948052304182234048906113518349e007076fffdf9feff000a"),
+                Position.KEY_ARMED, true);
+        verifyAttribute(decoder, binary(
+                "2447100088730948052304182234048906113518349e007076fffdf9feff000a"),
+                Position.KEY_ALARM, "vibration");
+        verifyAttribute(decoder, binary(
+                "2447100088730948052304182234048906113518349e007076fffdf9feff000a"),
+                Position.KEY_CHARGE, true);
+
+        verifyAttribute(decoder, binary(
+                "2447100088730857432304182233956706113517038e000209ffe7fbffff000e"),
+                Position.KEY_ARMED, false);
+        verifyAttribute(decoder, binary(
+                "2447100088730857432304182233956706113517038e000209ffe7fbffff000e"),
+                Position.KEY_ALARM, null);
+        verifyAttribute(decoder, binary(
+                "2447100088730857432304182233956706113517038e000209ffe7fbffff000e"),
+                Position.KEY_CHARGE, false);
+
+        verifyAttribute(decoder, binary(
+                "2447100088730944452304182234048906113518349e007076fffff9ffff0007"),
+                Position.KEY_ARMED, true);
+        verifyAttribute(decoder, binary(
+                "2447100088730944452304182234048906113518349e007076fffff9ffff0007"),
+                Position.KEY_ALARM, null);
+        verifyAttribute(decoder, binary(
+                "2447100088730944452304182234048906113518349e007076fffff9ffff0007"),
+                Position.KEY_CHARGE, true);
 
     }
 


### PR DESCRIPTION
Properly parse alarms, LBS message and read battery level when available

Prevent status update messages from being filtered and use last position if current is invalid / zero.

[LKGPS protocol.pdf](https://github.com/traccar/traccar/files/2041404/LKGPS.protocol.pdf)