### PR TITLE
Store engine hours in milliseconds for the rest of protocols

### DIFF
--- a/src/org/traccar/helper/UnitsConverter.java
+++ b/src/org/traccar/helper/UnitsConverter.java
@@ -24,6 +24,7 @@ public final class UnitsConverter {
     private static final double METERS_TO_FEET_RATIO = 0.3048;
     private static final double METERS_TO_MILE_RATIO = 1609.34;
     private static final long MILLISECONDS_TO_HOURS_RATIO = 3600000;
+    private static final long MILLISECONDS_TO_MINUTES_RATIO = 60000;
 
     private UnitsConverter() {
     }
@@ -78,6 +79,10 @@ public final class UnitsConverter {
 
     public static long msFromHours(double value) {
         return (long) (value * MILLISECONDS_TO_HOURS_RATIO);
+    }
+
+    public static long msFromMinutes(long value) {
+        return value * MILLISECONDS_TO_MINUTES_RATIO;
     }
 
 }

--- a/src/org/traccar/helper/UnitsConverter.java
+++ b/src/org/traccar/helper/UnitsConverter.java
@@ -72,11 +72,11 @@ public final class UnitsConverter {
         return value * METERS_TO_MILE_RATIO;
     }
 
-    public static long millisecondsFromHours(int value) {
+    public static long msFromHours(long value) {
         return value * MILLISECONDS_TO_HOURS_RATIO;
     }
 
-    public static long millisecondsFromHours(double value) {
+    public static long msFromHours(double value) {
         return (long) (value * MILLISECONDS_TO_HOURS_RATIO);
     }
 

--- a/src/org/traccar/helper/UnitsConverter.java
+++ b/src/org/traccar/helper/UnitsConverter.java
@@ -23,6 +23,7 @@ public final class UnitsConverter {
     private static final double KNOTS_TO_CPS_RATIO = 0.0194384449;
     private static final double METERS_TO_FEET_RATIO = 0.3048;
     private static final double METERS_TO_MILE_RATIO = 1609.34;
+    private static final long MILLISECONDS_TO_HOURS_RATIO = 3600000;
 
     private UnitsConverter() {
     }
@@ -69,6 +70,14 @@ public final class UnitsConverter {
 
     public static double metersFromMiles(double value) {
         return value * METERS_TO_MILE_RATIO;
+    }
+
+    public static long millisecondsFromHours(int value) {
+        return value * MILLISECONDS_TO_HOURS_RATIO;
+    }
+
+    public static long millisecondsFromHours(double value) {
+        return (long) (value * MILLISECONDS_TO_HOURS_RATIO);
     }
 
 }

--- a/src/org/traccar/protocol/AplicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/AplicomProtocolDecoder.java
@@ -549,7 +549,7 @@ public class AplicomProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if ((selector & 0x0020) != 0) {
-            position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(buf.readUnsignedInt()));
+            position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(buf.readUnsignedInt()));
             position.set("serviceDistance", buf.readInt());
             position.set("driverActivity", buf.readUnsignedByte());
             position.set(Position.KEY_THROTTLE, buf.readUnsignedByte());

--- a/src/org/traccar/protocol/AplicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/AplicomProtocolDecoder.java
@@ -549,7 +549,7 @@ public class AplicomProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if ((selector & 0x0020) != 0) {
-            position.set(Position.KEY_HOURS, buf.readUnsignedInt() * 3600000);
+            position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(buf.readUnsignedInt()));
             position.set("serviceDistance", buf.readInt());
             position.set("driverActivity", buf.readUnsignedByte());
             position.set(Position.KEY_THROTTLE, buf.readUnsignedByte());

--- a/src/org/traccar/protocol/AplicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/AplicomProtocolDecoder.java
@@ -549,7 +549,7 @@ public class AplicomProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if ((selector & 0x0020) != 0) {
-            position.set(Position.KEY_HOURS, buf.readUnsignedInt());
+            position.set(Position.KEY_HOURS, buf.readUnsignedInt() * 3600000);
             position.set("serviceDistance", buf.readInt());
             position.set("driverActivity", buf.readUnsignedByte());
             position.set(Position.KEY_THROTTLE, buf.readUnsignedByte());

--- a/src/org/traccar/protocol/AstraProtocolDecoder.java
+++ b/src/org/traccar/protocol/AstraProtocolDecoder.java
@@ -106,7 +106,7 @@ public class AstraProtocolDecoder extends BaseProtocolDecoder {
             if (BitUtil.check(status, 8)) {
                 position.set(Position.KEY_DRIVER_UNIQUE_ID, buf.readBytes(7).toString(StandardCharsets.US_ASCII));
                 position.set(Position.KEY_ODOMETER, buf.readUnsignedMedium() * 1000);
-                position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(buf.readUnsignedShort()));
+                position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(buf.readUnsignedShort()));
             }
 
             if (BitUtil.check(status, 6)) {

--- a/src/org/traccar/protocol/AstraProtocolDecoder.java
+++ b/src/org/traccar/protocol/AstraProtocolDecoder.java
@@ -106,7 +106,7 @@ public class AstraProtocolDecoder extends BaseProtocolDecoder {
             if (BitUtil.check(status, 8)) {
                 position.set(Position.KEY_DRIVER_UNIQUE_ID, buf.readBytes(7).toString(StandardCharsets.US_ASCII));
                 position.set(Position.KEY_ODOMETER, buf.readUnsignedMedium() * 1000);
-                position.set(Position.KEY_HOURS, buf.readUnsignedShort() * 3600000);
+                position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(buf.readUnsignedShort()));
             }
 
             if (BitUtil.check(status, 6)) {

--- a/src/org/traccar/protocol/AstraProtocolDecoder.java
+++ b/src/org/traccar/protocol/AstraProtocolDecoder.java
@@ -106,7 +106,7 @@ public class AstraProtocolDecoder extends BaseProtocolDecoder {
             if (BitUtil.check(status, 8)) {
                 position.set(Position.KEY_DRIVER_UNIQUE_ID, buf.readBytes(7).toString(StandardCharsets.US_ASCII));
                 position.set(Position.KEY_ODOMETER, buf.readUnsignedMedium() * 1000);
-                position.set(Position.KEY_HOURS, buf.readUnsignedShort());
+                position.set(Position.KEY_HOURS, buf.readUnsignedShort() * 3600000);
             }
 
             if (BitUtil.check(status, 6)) {

--- a/src/org/traccar/protocol/ContinentalProtocolDecoder.java
+++ b/src/org/traccar/protocol/ContinentalProtocolDecoder.java
@@ -94,7 +94,7 @@ public class ContinentalProtocolDecoder extends BaseProtocolDecoder {
             }
 
             if (buf.readableBytes() > 4) {
-                position.set(Position.KEY_HOURS, buf.readUnsignedInt() * 3600000);
+                position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(buf.readUnsignedInt()));
             }
 
             return position;

--- a/src/org/traccar/protocol/ContinentalProtocolDecoder.java
+++ b/src/org/traccar/protocol/ContinentalProtocolDecoder.java
@@ -94,7 +94,7 @@ public class ContinentalProtocolDecoder extends BaseProtocolDecoder {
             }
 
             if (buf.readableBytes() > 4) {
-                position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(buf.readUnsignedInt()));
+                position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(buf.readUnsignedInt()));
             }
 
             return position;

--- a/src/org/traccar/protocol/ContinentalProtocolDecoder.java
+++ b/src/org/traccar/protocol/ContinentalProtocolDecoder.java
@@ -94,7 +94,7 @@ public class ContinentalProtocolDecoder extends BaseProtocolDecoder {
             }
 
             if (buf.readableBytes() > 4) {
-                position.set(Position.KEY_HOURS, buf.readUnsignedInt());
+                position.set(Position.KEY_HOURS, buf.readUnsignedInt() * 3600000);
             }
 
             return position;

--- a/src/org/traccar/protocol/Gl200TextProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200TextProtocolDecoder.java
@@ -609,7 +609,8 @@ public class Gl200TextProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_THROTTLE, Integer.parseInt(values[index - 1]));
         }
         if (BitUtil.check(reportMask, 11)) {
-            position.set(Position.KEY_HOURS, (long) Double.parseDouble(values[index++]) * 3600000);
+            position.set(
+                    Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(Double.parseDouble(values[index++])));
         }
         if (BitUtil.check(reportMask, 12)) {
             position.set("drivingHours", Double.parseDouble(values[index++]));

--- a/src/org/traccar/protocol/Gl200TextProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200TextProtocolDecoder.java
@@ -609,8 +609,7 @@ public class Gl200TextProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_THROTTLE, Integer.parseInt(values[index - 1]));
         }
         if (BitUtil.check(reportMask, 11)) {
-            position.set(
-                    Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(Double.parseDouble(values[index++])));
+            position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(Double.parseDouble(values[index++])));
         }
         if (BitUtil.check(reportMask, 12)) {
             position.set("drivingHours", Double.parseDouble(values[index++]));

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -256,7 +256,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_FUEL_CONSUMPTION, parser.nextDouble(0));
         Integer hours = parser.nextInt();
         if (hours != null) {
-            position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(hours));
+            position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(hours));
         }
         position.set(Position.KEY_OBD_SPEED, parser.nextInt(0));
         position.set(Position.KEY_ENGINE_LOAD, parser.next());

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -21,6 +21,7 @@ import org.traccar.DeviceSession;
 import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
+import org.traccar.helper.UnitsConverter;
 import org.traccar.model.CellTower;
 import org.traccar.model.Network;
 import org.traccar.model.Position;
@@ -255,7 +256,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_FUEL_CONSUMPTION, parser.nextDouble(0));
         Integer hours = parser.nextInt();
         if (hours != null) {
-            position.set(Position.KEY_HOURS, hours * 3600000);
+            position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(hours));
         }
         position.set(Position.KEY_OBD_SPEED, parser.nextInt(0));
         position.set(Position.KEY_ENGINE_LOAD, parser.next());

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -253,7 +253,10 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_ODOMETER, parser.nextInt(0));
         parser.nextDouble(0); // instant fuel consumption
         position.set(Position.KEY_FUEL_CONSUMPTION, parser.nextDouble(0));
-        position.set(Position.KEY_HOURS, parser.nextInt());
+        Integer hours = parser.nextInt();
+        if (hours != null) {
+            position.set(Position.KEY_HOURS, hours * 3600000);
+        }
         position.set(Position.KEY_OBD_SPEED, parser.nextInt(0));
         position.set(Position.KEY_ENGINE_LOAD, parser.next());
         position.set(Position.KEY_COOLANT_TEMP, parser.nextInt());

--- a/src/org/traccar/protocol/Mta6ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Mta6ProtocolDecoder.java
@@ -232,8 +232,7 @@ public class Mta6ProtocolDecoder extends BaseProtocolDecoder {
 
         if (BitUtil.check(flags, 1)) {
             position.set(Position.KEY_FUEL_CONSUMPTION, new FloatReader().readFloat(buf));
-            position.set(
-                    Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(new FloatReader().readFloat(buf)));
+            position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(new FloatReader().readFloat(buf)));
             position.set("tank", buf.readUnsignedByte() * 0.4);
         }
 

--- a/src/org/traccar/protocol/Mta6ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Mta6ProtocolDecoder.java
@@ -29,6 +29,7 @@ import org.traccar.Protocol;
 import org.traccar.helper.BitUtil;
 import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Log;
+import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
@@ -231,7 +232,8 @@ public class Mta6ProtocolDecoder extends BaseProtocolDecoder {
 
         if (BitUtil.check(flags, 1)) {
             position.set(Position.KEY_FUEL_CONSUMPTION, new FloatReader().readFloat(buf));
-            position.set(Position.KEY_HOURS, (long) (new FloatReader().readFloat(buf) * 3600000));
+            position.set(
+                    Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(new FloatReader().readFloat(buf)));
             position.set("tank", buf.readUnsignedByte() * 0.4);
         }
 

--- a/src/org/traccar/protocol/Mta6ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Mta6ProtocolDecoder.java
@@ -231,7 +231,7 @@ public class Mta6ProtocolDecoder extends BaseProtocolDecoder {
 
         if (BitUtil.check(flags, 1)) {
             position.set(Position.KEY_FUEL_CONSUMPTION, new FloatReader().readFloat(buf));
-            position.set(Position.KEY_HOURS, new FloatReader().readFloat(buf));
+            position.set(Position.KEY_HOURS, (long) (new FloatReader().readFloat(buf) * 3600000));
             position.set("tank", buf.readUnsignedByte() * 0.4);
         }
 

--- a/src/org/traccar/protocol/MxtProtocolDecoder.java
+++ b/src/org/traccar/protocol/MxtProtocolDecoder.java
@@ -145,7 +145,7 @@ public class MxtProtocolDecoder extends BaseProtocolDecoder {
             }
 
             if (BitUtil.check(infoGroups, 4)) {
-                position.set(Position.KEY_HOURS, buf.readUnsignedInt() * 60000);
+                position.set(Position.KEY_HOURS, UnitsConverter.msFromMinutes(buf.readUnsignedInt()));
             }
 
             if (BitUtil.check(infoGroups, 5)) {

--- a/src/org/traccar/protocol/MxtProtocolDecoder.java
+++ b/src/org/traccar/protocol/MxtProtocolDecoder.java
@@ -145,7 +145,7 @@ public class MxtProtocolDecoder extends BaseProtocolDecoder {
             }
 
             if (BitUtil.check(infoGroups, 4)) {
-                position.set(Position.KEY_HOURS, buf.readUnsignedInt());
+                position.set(Position.KEY_HOURS, buf.readUnsignedInt() * 60000);
             }
 
             if (BitUtil.check(infoGroups, 5)) {

--- a/src/org/traccar/protocol/SuntechProtocolDecoder.java
+++ b/src/org/traccar/protocol/SuntechProtocolDecoder.java
@@ -239,7 +239,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
         if (hbm) {
 
             if (index < values.length) {
-                position.set(Position.KEY_HOURS, Integer.parseInt(values[index++]));
+                position.set(Position.KEY_HOURS, Integer.parseInt(values[index++]) * 60000);
             }
 
             if (index < values.length) {

--- a/src/org/traccar/protocol/SuntechProtocolDecoder.java
+++ b/src/org/traccar/protocol/SuntechProtocolDecoder.java
@@ -239,7 +239,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
         if (hbm) {
 
             if (index < values.length) {
-                position.set(Position.KEY_HOURS, Integer.parseInt(values[index++]) * 60000);
+                position.set(Position.KEY_HOURS, UnitsConverter.msFromMinutes(Integer.parseInt(values[index++])));
             }
 
             if (index < values.length) {

--- a/src/org/traccar/protocol/VtfmsProtocolDecoder.java
+++ b/src/org/traccar/protocol/VtfmsProtocolDecoder.java
@@ -133,7 +133,7 @@ public class VtfmsProtocolDecoder extends BaseProtocolDecoder {
 
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble(0)));
 
-        position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(parser.nextInt()));
+        position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(parser.nextInt()));
         position.set("idleHours", parser.nextInt());
         position.set(Position.KEY_ODOMETER, parser.nextInt() * 100);
         position.set(Position.KEY_CHARGE, parser.next().equals("1"));

--- a/src/org/traccar/protocol/VtfmsProtocolDecoder.java
+++ b/src/org/traccar/protocol/VtfmsProtocolDecoder.java
@@ -133,7 +133,7 @@ public class VtfmsProtocolDecoder extends BaseProtocolDecoder {
 
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble(0)));
 
-        position.set(Position.KEY_HOURS, parser.nextInt());
+        position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(parser.nextInt()));
         position.set("idleHours", parser.nextInt());
         position.set(Position.KEY_ODOMETER, parser.nextInt() * 100);
         position.set(Position.KEY_CHARGE, parser.next().equals("1"));

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -232,7 +232,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.PREFIX_OUT + 1, parser.nextInt());
             position.set(Position.PREFIX_ADC + 1, parser.nextDouble());
             position.set(Position.KEY_FUEL_LEVEL, parser.nextDouble());
-            position.set(Position.KEY_HOURS, parser.nextInt());
+            position.set(Position.KEY_HOURS, parser.nextInt() * 3600000);
             position.set("oilPressure", parser.nextInt());
             position.set("oilLevel", parser.nextInt());
             position.set("oilTemp", parser.nextInt());

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -232,7 +232,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.PREFIX_OUT + 1, parser.nextInt());
             position.set(Position.PREFIX_ADC + 1, parser.nextDouble());
             position.set(Position.KEY_FUEL_LEVEL, parser.nextDouble());
-            position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(parser.nextInt()));
+            position.set(Position.KEY_HOURS, UnitsConverter.msFromHours(parser.nextInt()));
             position.set("oilPressure", parser.nextInt());
             position.set("oilLevel", parser.nextInt());
             position.set("oilTemp", parser.nextInt());

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -232,7 +232,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.PREFIX_OUT + 1, parser.nextInt());
             position.set(Position.PREFIX_ADC + 1, parser.nextDouble());
             position.set(Position.KEY_FUEL_LEVEL, parser.nextDouble());
-            position.set(Position.KEY_HOURS, parser.nextInt() * 3600000);
+            position.set(Position.KEY_HOURS, UnitsConverter.millisecondsFromHours(parser.nextInt()));
             position.set("oilPressure", parser.nextInt());
             position.set("oilLevel", parser.nextInt());
             position.set("oilTemp", parser.nextInt());


### PR DESCRIPTION
Next step for #3532 

Assumed that most of protocol reports in hours.