### PR TITLE
Implement engine hours accumulation

### DIFF
--- a/setup/default.xml
+++ b/setup/default.xml
@@ -21,6 +21,8 @@
     <entry key='filter.enable'>true</entry>
     <entry key='filter.future'>3600</entry>
 
+    <entry key='engineHours.enable'>true</entry>
+
     <entry key='event.enable'>true</entry>
     <entry key='event.ignoreDuplicateAlerts'>true</entry>
     <entry key='processing.computedAttributes.enable'>true</entry>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -21,11 +21,10 @@
     <entry key='filter.enable'>true</entry>
     <entry key='filter.future'>3600</entry>
 
-    <entry key='engineHours.enable'>true</entry>
-
     <entry key='event.enable'>true</entry>
     <entry key='event.ignoreDuplicateAlerts'>true</entry>
     <entry key='processing.computedAttributes.enable'>true</entry>
+    <entry key='processing.engineHours.enable'>true</entry>
 
     <entry key='media.path'>./media</entry>
 

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -156,7 +156,7 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         motionHandler = new MotionHandler(Context.getTripsConfig().getSpeedThreshold());
 
-        if (Context.getConfig().getBoolean("engineHours.enable")) {
+        if (Context.getConfig().getBoolean("processing.engineHours.enable")) {
             engineHoursHandler = new EngineHoursHandler();
         }
 

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -51,6 +51,7 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
     private FilterHandler filterHandler;
     private DistanceHandler distanceHandler;
+    private EngineHoursHandler engineHoursHandler;
     private RemoteAddressHandler remoteAddressHandler;
     private MotionHandler motionHandler;
     private GeocoderHandler geocoderHandler;
@@ -155,6 +156,10 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         motionHandler = new MotionHandler(Context.getTripsConfig().getSpeedThreshold());
 
+        if (Context.getConfig().getBoolean("engineHours.enable")) {
+            engineHoursHandler = new EngineHoursHandler();
+        }
+
         if (Context.getConfig().hasKey("location.latitudeHemisphere")
                 || Context.getConfig().hasKey("location.longitudeHemisphere")) {
             hemisphereHandler = new HemisphereHandler();
@@ -223,6 +228,10 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         if (motionHandler != null) {
             pipeline.addLast("motion", motionHandler);
+        }
+
+        if (engineHoursHandler != null) {
+            pipeline.addLast("engineHours", engineHoursHandler);
         }
 
         if (copyAttributesHandler != null) {

--- a/src/org/traccar/EngineHoursHandler.java
+++ b/src/org/traccar/EngineHoursHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2018 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar;
+
+import org.traccar.model.Position;
+
+public class EngineHoursHandler extends BaseDataHandler {
+
+    @Override
+    protected Position handlePosition(Position position) {
+        if (!position.getAttributes().containsKey(Position.KEY_HOURS)) {
+            Position last = Context.getIdentityManager().getLastPosition(position.getDeviceId());
+            if (last != null) {
+                long hours = last.getLong(Position.KEY_HOURS);
+                if (last.getBoolean(Position.KEY_IGNITION) && position.getBoolean(Position.KEY_IGNITION)) {
+                    hours += position.getFixTime().getTime() - last.getFixTime().getTime();
+                }
+                if (hours != 0) {
+                    position.set(Position.KEY_HOURS, hours);
+                }
+            }
+        }
+        return position;
+    }
+
+}

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -266,7 +266,8 @@ public final class ReportUtils {
         if (startStop.getAttributes().containsKey(Position.KEY_HOURS)
                 && endStop.getAttributes().containsKey(Position.KEY_HOURS)) {
             engineHours = endStop.getLong(Position.KEY_HOURS) - startStop.getLong(Position.KEY_HOURS);
-        } else if (Context.getConfig().getBoolean("engineHours.enable")) {
+        } else if (Context.getConfig().getBoolean("processing.engineHours.enable")) {
+            // Temporary fallback for old data, to be removed in May 2019
             for (int i = startIndex + 1; i <= endIndex; i++) {
                 if (positions.get(i).getBoolean(Position.KEY_IGNITION)
                         && positions.get(i - 1).getBoolean(Position.KEY_IGNITION)) {

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -263,10 +263,16 @@ public final class ReportUtils {
         stop.setSpentFuel(calculateFuel(startStop, endStop));
 
         long engineHours = 0;
-        for (int i = startIndex + 1; i <= endIndex; i++) {
-            if (positions.get(i).getBoolean(Position.KEY_IGNITION)
-                    && positions.get(i - 1).getBoolean(Position.KEY_IGNITION)) {
-                engineHours += positions.get(i).getFixTime().getTime() - positions.get(i - 1).getFixTime().getTime();
+        if (startStop.getAttributes().containsKey(Position.KEY_HOURS)
+                && endStop.getAttributes().containsKey(Position.KEY_HOURS)) {
+            engineHours = endStop.getLong(Position.KEY_HOURS) - startStop.getLong(Position.KEY_HOURS);
+        } else if (Context.getConfig().getBoolean("engineHours.enable")) {
+            for (int i = startIndex + 1; i <= endIndex; i++) {
+                if (positions.get(i).getBoolean(Position.KEY_IGNITION)
+                        && positions.get(i - 1).getBoolean(Position.KEY_IGNITION)) {
+                    engineHours += positions.get(i).getFixTime().getTime()
+                            - positions.get(i - 1).getFixTime().getTime();
+                }
             }
         }
         stop.setEngineHours(engineHours);

--- a/src/org/traccar/reports/Summary.java
+++ b/src/org/traccar/reports/Summary.java
@@ -44,11 +44,13 @@ public final class Summary {
             Position firstPosition = null;
             Position previousPosition = null;
             double speedSum = 0;
+            boolean needCalculateEngineHours = Context.getConfig().getBoolean("engineHours.enable");
             for (Position position : positions) {
                 if (firstPosition == null) {
                     firstPosition = position;
                 }
-                if (previousPosition != null && position.getBoolean(Position.KEY_IGNITION)
+                if (needCalculateEngineHours && previousPosition != null
+                        && position.getBoolean(Position.KEY_IGNITION)
                         && previousPosition.getBoolean(Position.KEY_IGNITION)) {
                     result.addEngineHours(position.getFixTime().getTime()
                             - previousPosition.getFixTime().getTime());
@@ -62,6 +64,13 @@ public final class Summary {
             result.setDistance(ReportUtils.calculateDistance(firstPosition, previousPosition, !ignoreOdometer));
             result.setAverageSpeed(speedSum / positions.size());
             result.setSpentFuel(ReportUtils.calculateFuel(firstPosition, previousPosition));
+
+            if (needCalculateEngineHours
+                    && firstPosition.getAttributes().containsKey(Position.KEY_HOURS)
+                    && previousPosition.getAttributes().containsKey(Position.KEY_HOURS)) {
+                result.setEngineHours(
+                        previousPosition.getLong(Position.KEY_HOURS) - firstPosition.getLong(Position.KEY_HOURS));
+            }
 
             if (!ignoreOdometer
                     && firstPosition.getDouble(Position.KEY_ODOMETER) != 0

--- a/src/org/traccar/reports/Summary.java
+++ b/src/org/traccar/reports/Summary.java
@@ -44,14 +44,15 @@ public final class Summary {
             Position firstPosition = null;
             Position previousPosition = null;
             double speedSum = 0;
-            boolean needCalculateEngineHours = Context.getConfig().getBoolean("engineHours.enable");
+            boolean engineHoursEnabled = Context.getConfig().getBoolean("processing.engineHours.enable");
             for (Position position : positions) {
                 if (firstPosition == null) {
                     firstPosition = position;
                 }
-                if (needCalculateEngineHours && previousPosition != null
+                if (engineHoursEnabled && previousPosition != null
                         && position.getBoolean(Position.KEY_IGNITION)
                         && previousPosition.getBoolean(Position.KEY_IGNITION)) {
+                    // Temporary fallback for old data, to be removed in May 2019
                     result.addEngineHours(position.getFixTime().getTime()
                             - previousPosition.getFixTime().getTime());
                 }
@@ -65,7 +66,7 @@ public final class Summary {
             result.setAverageSpeed(speedSum / positions.size());
             result.setSpentFuel(ReportUtils.calculateFuel(firstPosition, previousPosition));
 
-            if (needCalculateEngineHours
+            if (engineHoursEnabled
                     && firstPosition.getAttributes().containsKey(Position.KEY_HOURS)
                     && previousPosition.getAttributes().containsKey(Position.KEY_HOURS)) {
                 result.setEngineHours(


### PR DESCRIPTION
I believe it is final server side step for #3532 

Main switch is `engineHours.enable` it controls two features:
- Enable `EngineHoursHandler` itself
- Enable engine hours calculation in reports (I think if switch is disabled user do not interested in engine hours at all, we just will not waste time on calculating it)

Handler designed as if device have never reported `hours` or `ignition` attribute will never appear.
Also it works as `copyAttributes` if device reports `hours` not in every position.

One side effect, if device reports `hours` periodically, traccar will still accumulate `hours` in between.

Some comments in code...