### PR TITLE
Rename all tables to avoid using reserved words

### DIFF
--- a/schema/changelog-4.0.xml
+++ b/schema/changelog-4.0.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+  logicalFilePath="changelog-4.0">
+
+  <changeSet author="author" id="changelog-4.0-renaming">
+
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="tc_servers" />
+      </not>
+    </preConditions>
+
+    <renameTable oldTableName="attributes" newTableName="tc_attributes" />
+    <renameTable oldTableName="calendars" newTableName="tc_calendars" />
+    <renameTable oldTableName="commands" newTableName="tc_commands" />
+    <renameTable oldTableName="device_attribute" newTableName="tc_device_attribute" />
+    <renameTable oldTableName="device_command" newTableName="tc_device_command" />
+    <renameTable oldTableName="device_driver" newTableName="tc_device_driver" />
+    <renameTable oldTableName="device_geofence" newTableName="tc_device_geofence" />
+    <renameTable oldTableName="device_maintenance" newTableName="tc_device_maintenance" />
+    <renameTable oldTableName="device_notification" newTableName="tc_device_notification" />
+    <renameTable oldTableName="devices" newTableName="tc_devices" />
+    <renameTable oldTableName="drivers" newTableName="tc_drivers" />
+    <renameTable oldTableName="events" newTableName="tc_events" />
+    <renameTable oldTableName="geofences" newTableName="tc_geofences" />
+    <renameTable oldTableName="group_attribute" newTableName="tc_group_attribute" />
+    <renameTable oldTableName="group_command" newTableName="tc_group_command" />
+    <renameTable oldTableName="group_driver" newTableName="tc_group_driver" />
+    <renameTable oldTableName="group_geofence" newTableName="tc_group_geofence" />
+    <renameTable oldTableName="group_maintenance" newTableName="tc_group_maintenance" />
+    <renameTable oldTableName="group_notification" newTableName="tc_group_notification" />
+    <renameTable oldTableName="groups" newTableName="tc_groups" />
+    <renameTable oldTableName="maintenances" newTableName="tc_maintenances" />
+    <renameTable oldTableName="notifications" newTableName="tc_notifications" />
+    <renameTable oldTableName="positions" newTableName="tc_positions" />
+    <renameTable oldTableName="servers" newTableName="tc_servers" />
+    <renameTable oldTableName="statistics" newTableName="tc_statistics" />
+    <renameTable oldTableName="user_attribute" newTableName="tc_user_attribute" />
+    <renameTable oldTableName="user_calendar" newTableName="tc_user_calendar" />
+    <renameTable oldTableName="user_command" newTableName="tc_user_command" />
+    <renameTable oldTableName="user_device" newTableName="tc_user_device" />
+    <renameTable oldTableName="user_driver" newTableName="tc_user_driver" />
+    <renameTable oldTableName="user_geofence" newTableName="tc_user_geofence" />
+    <renameTable oldTableName="user_group" newTableName="tc_user_group" />
+    <renameTable oldTableName="user_maintenance" newTableName="tc_user_maintenance" />
+    <renameTable oldTableName="user_notification" newTableName="tc_user_notification" />
+    <renameTable oldTableName="user_user" newTableName="tc_user_user" />
+    <renameTable oldTableName="users" newTableName="tc_users" />
+
+  </changeSet>
+
+</databaseChangeLog>

--- a/schema/changelog-master.xml
+++ b/schema/changelog-master.xml
@@ -18,4 +18,5 @@
   <include file="changelog-3.15.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.16.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.17.xml" relativeToChangelogFile="true" />
+  <include file="changelog-4.0.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -41,36 +41,36 @@
     <entry key='database.changelog'>./schema/changelog-master.xml</entry>
  
     <entry key='database.loginUser'>
-        SELECT * FROM users
+        SELECT * FROM tc_users
         WHERE email = :email OR login = :email
     </entry>
 
     <entry key='database.selectPositions'>
-        SELECT * FROM positions WHERE deviceId = :deviceId AND fixTime BETWEEN :from AND :to ORDER BY fixTime
+        SELECT * FROM tc_positions WHERE deviceId = :deviceId AND fixTime BETWEEN :from AND :to ORDER BY fixTime
     </entry>
 
     <entry key='database.selectLatestPositions'>
-        SELECT positions.* FROM positions INNER JOIN devices ON positions.id = devices.positionid;
+        SELECT tc_positions.* FROM tc_positions INNER JOIN tc_devices ON tc_positions.id = tc_devices.positionid;
     </entry>
 
     <entry key='database.updateLatestPosition'>
-        UPDATE devices SET positionId = :id WHERE id = :deviceId
+        UPDATE tc_devices SET positionId = :id WHERE id = :deviceId
     </entry>
 
     <entry key='database.selectEvents'>
-        SELECT * FROM events WHERE deviceId = :deviceId AND serverTime BETWEEN :from AND :to ORDER BY serverTime
+        SELECT * FROM tc_events WHERE deviceId = :deviceId AND serverTime BETWEEN :from AND :to ORDER BY serverTime
     </entry>
 
     <entry key='database.deletePositions'>
-        DELETE FROM positions WHERE serverTime &lt; :serverTime AND id NOT IN (SELECT positionId FROM devices WHERE positionId IS NOT NULL)
+        DELETE FROM tc_positions WHERE serverTime &lt; :serverTime AND id NOT IN (SELECT positionId FROM tc_devices WHERE positionId IS NOT NULL)
     </entry>
 
     <entry key='database.deleteEvents'>
-        DELETE FROM events WHERE serverTime &lt; :serverTime
+        DELETE FROM tc_events WHERE serverTime &lt; :serverTime
     </entry>
 
     <entry key='database.selectStatistics'>
-        SELECT * FROM statistics WHERE captureTime BETWEEN :from AND :to ORDER BY captureTime
+        SELECT * FROM tc_statistics WHERE captureTime BETWEEN :from AND :to ORDER BY captureTime
     </entry>
 
     <!-- PROTOCOL CONFIG -->

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -273,11 +273,12 @@ public class DataManager {
         if (propertyName.equals("ManagedUser")) {
             propertyName = "User";
         }
-        return Introspector.decapitalize(owner.getSimpleName()) + "_" + Introspector.decapitalize(propertyName);
+        return "tc_" + Introspector.decapitalize(owner.getSimpleName())
+                + "_" + Introspector.decapitalize(propertyName);
     }
 
     private static String getObjectsTableName(Class<?> clazz) {
-        String result = Introspector.decapitalize(clazz.getSimpleName());
+        String result = "tc_" + Introspector.decapitalize(clazz.getSimpleName());
         // Add "s" ending if object name is not plural already
         if (!result.endsWith("s")) {
             result += "s";

--- a/test/org/traccar/database/DataManagerTest.java
+++ b/test/org/traccar/database/DataManagerTest.java
@@ -18,11 +18,11 @@ public class DataManagerTest {
 
     @Test
     public void constructObjectQuery() {
-        assertEquals("SELECT * FROM users",
+        assertEquals("SELECT * FROM tc_users",
                 DataManager.constructObjectQuery(DataManager.ACTION_SELECT_ALL, User.class, false));
-        assertEquals("DELETE FROM groups WHERE id = :id",
+        assertEquals("DELETE FROM tc_groups WHERE id = :id",
                 DataManager.constructObjectQuery(DataManager.ACTION_DELETE, Group.class, false));
-        assertEquals("SELECT * FROM positions WHERE id = :id",
+        assertEquals("SELECT * FROM tc_positions WHERE id = :id",
                 DataManager.constructObjectQuery(DataManager.ACTION_SELECT, Position.class, false));
 
         String insertDevice = DataManager.constructObjectQuery(DataManager.ACTION_INSERT, Device.class, false);
@@ -52,28 +52,28 @@ public class DataManagerTest {
 
     @Test
     public void constructPermissionsQuery() {
-        assertEquals("SELECT userId, deviceId FROM user_device",
+        assertEquals("SELECT userId, deviceId FROM tc_user_device",
                 DataManager.constructPermissionQuery(DataManager.ACTION_SELECT_ALL, User.class, Device.class));
 
-        assertEquals("SELECT userId, managedUserId FROM user_user",
+        assertEquals("SELECT userId, managedUserId FROM tc_user_user",
                 DataManager.constructPermissionQuery(DataManager.ACTION_SELECT_ALL, User.class, ManagedUser.class));
 
-        assertEquals("SELECT deviceId, driverId FROM device_driver",
+        assertEquals("SELECT deviceId, driverId FROM tc_device_driver",
                 DataManager.constructPermissionQuery(DataManager.ACTION_SELECT_ALL, Device.class, Driver.class));
 
-        assertEquals("SELECT groupId, geofenceId FROM group_geofence",
+        assertEquals("SELECT groupId, geofenceId FROM tc_group_geofence",
                 DataManager.constructPermissionQuery(DataManager.ACTION_SELECT_ALL, Group.class, Geofence.class));
 
-        assertEquals("INSERT INTO user_device (userId, deviceId) VALUES (:userId, :deviceId)",
+        assertEquals("INSERT INTO tc_user_device (userId, deviceId) VALUES (:userId, :deviceId)",
                 DataManager.constructPermissionQuery(DataManager.ACTION_INSERT, User.class, Device.class));
 
-        assertEquals("DELETE FROM user_user WHERE userId = :userId AND managedUserId = :managedUserId",
+        assertEquals("DELETE FROM tc_user_user WHERE userId = :userId AND managedUserId = :managedUserId",
                 DataManager.constructPermissionQuery(DataManager.ACTION_DELETE, User.class, ManagedUser.class));
 
-        assertEquals("INSERT INTO device_geofence (deviceId, geofenceId) VALUES (:deviceId, :geofenceId)",
+        assertEquals("INSERT INTO tc_device_geofence (deviceId, geofenceId) VALUES (:deviceId, :geofenceId)",
                 DataManager.constructPermissionQuery(DataManager.ACTION_INSERT, Device.class, Geofence.class));
 
-        assertEquals("DELETE FROM group_attribute WHERE groupId = :groupId AND attributeId = :attributeId",
+        assertEquals("DELETE FROM tc_group_attribute WHERE groupId = :groupId AND attributeId = :attributeId",
                 DataManager.constructPermissionQuery(DataManager.ACTION_DELETE, Group.class, Attribute.class));
 
     }


### PR DESCRIPTION
I think it is right to detach renaming to separate changeset with precondition, can't say why but feel it is better.