### PR TITLE
Decode ignition states for meitrack

### DIFF
--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -142,18 +142,20 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
         switch (event) {
             case 2:
             case 3:
-            case 4:  position.set(Position.KEY_IGNITION, true);
+            case 4:
+                position.set(Position.KEY_IGNITION, true);
                 break;
 
             case 10:
             case 11:
-            case 12:  position.set(Position.KEY_IGNITION, false);
+            case 12:
+                position.set(Position.KEY_IGNITION, false);
                 break;
 
             default:
                 break;
         }
-        
+
         position.setLatitude(parser.nextDouble(0));
         position.setLongitude(parser.nextDouble(0));
 

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -139,6 +139,21 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_EVENT, event);
         position.set(Position.KEY_ALARM, decodeAlarm(event));
 
+        switch (event) {
+            case 2:
+            case 3:
+            case 4:  position.set(Position.KEY_IGNITION, true);
+                break;
+
+            case 10:
+            case 11:
+            case 12:  position.set(Position.KEY_IGNITION, false);
+                break;
+
+            default:
+                break;
+        }
+        
         position.setLatitude(parser.nextDouble(0));
         position.setLongitude(parser.nextDouble(0));
 


### PR DESCRIPTION
Hi Anton,
this pull request sets the ignition attribute for meitrack trackers.
It's related to https://github.com/traccar/traccar/issues/3666 and https://www.traccar.org/forums/topic/using-event-number-as-trigger-for-ignition-on-and-off/ 
I'm using it with the latest traccar version and it works great when combined with the attribute copying in the conf file.
Could you please review it?