### PR TITLE
Send queued commands on status online

### DIFF
--- a/src/org/traccar/database/ConnectionManager.java
+++ b/src/org/traccar/database/ConnectionManager.java
@@ -57,9 +57,7 @@ public class ConnectionManager {
     }
 
     public void addActiveDevice(long deviceId, Protocol protocol, Channel channel, SocketAddress remoteAddress) {
-        ActiveDevice activeDevice = new ActiveDevice(deviceId, protocol, channel, remoteAddress);
-        activeDevices.put(deviceId, activeDevice);
-        Context.getCommandsManager().sendQueuedCommands(activeDevice);
+        activeDevices.put(deviceId, new ActiveDevice(deviceId, protocol, channel, remoteAddress));
     }
 
     public void removeActiveDevice(Channel channel) {
@@ -136,6 +134,10 @@ public class ConnectionManager {
         }
 
         updateDevice(device);
+
+        if (status.equals(Device.STATUS_ONLINE) && !oldStatus.equals(Device.STATUS_ONLINE)) {
+            Context.getCommandsManager().sendQueuedCommands(getActiveDevice(deviceId));
+        }
     }
 
     public Map<Event, Position> updateDeviceState(long deviceId) {


### PR DESCRIPTION
You are right, we should not lock to active device adding/removing.
It is fine if we send queued commands when device become online.

There is no good way to determine if udp device on other side, just try to send command to "unknown" device.

I think we can add switch with logic like "queue commands if device status unknown" in future if there will be requests from users.