### PR TITLE
Added integer checking for valid in osmand

### DIFF
--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -70,13 +70,7 @@ public class OsmAndProtocolDecoder extends BaseHttpProtocolDecoder {
                         position.setDeviceId(deviceSession.getDeviceId());
                         break;
                     case "valid":
-                        if (value == "1") {
-                            position.setValid(true);
-                        } else if (value == "0") {
-                            position.setValid(false);
-                        } else {
-                            position.setValid(Boolean.parseBoolean(value));
-                        }
+                        position.setValid(Boolean.parseBoolean(value) || "1".equals(value));
                         break;
                     case "timestamp":
                         try {

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -70,7 +70,13 @@ public class OsmAndProtocolDecoder extends BaseHttpProtocolDecoder {
                         position.setDeviceId(deviceSession.getDeviceId());
                         break;
                     case "valid":
-                        position.setValid(Boolean.parseBoolean(value));
+                        if (value == "1") {
+                            position.setValid(true);
+                        } else if (value == "0") {
+                            position.setValid(false);
+                        } else {
+                            position.setValid(Boolean.parseBoolean(value));
+                        }
                         break;
                     case "timestamp":
                         try {


### PR DESCRIPTION
I added a check for 0 or 1, because the `&valid=1`.
Now it will set the valid correct in this case also...