### PR TITLE
Move notificators to appropriate package and rename.

### DIFF
--- a/src/org/traccar/notification/NotificatorManager.java
+++ b/src/org/traccar/notification/NotificatorManager.java
@@ -24,15 +24,17 @@ import java.util.Set;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.Typed;
+import org.traccar.notificators.NotificatorNull;
+import org.traccar.notificators.Notificator;
 
 public final class NotificatorManager {
 
-    private static final String DEFAULT_WEB_NOTIFICATOR = "org.traccar.notification.NotificationWeb";
-    private static final String DEFAULT_MAIL_NOTIFICATOR = "org.traccar.notification.NotificationMail";
-    private static final String DEFAULT_SMS_NOTIFICATOR = "org.traccar.notification.NotificationSms";
+    private static final String DEFAULT_WEB_NOTIFICATOR = "org.traccar.notificators.NotificatorWeb";
+    private static final String DEFAULT_MAIL_NOTIFICATOR = "org.traccar.notificators.NotificatorMail";
+    private static final String DEFAULT_SMS_NOTIFICATOR = "org.traccar.notificators.NotificatorSms";
 
     private final Map<String, Notificator> notificators = new HashMap<>();
-    private static final Notificator NULL_NOTIFICATOR = new NotificationNull();
+    private static final Notificator NULL_NOTIFICATOR = new NotificatorNull();
 
     public NotificatorManager() {
         final String[] types = Context.getConfig().getString("notificator.types", "").split(",");

--- a/src/org/traccar/notificators/Notificator.java
+++ b/src/org/traccar/notificators/Notificator.java
@@ -14,11 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.traccar.notification;
+package org.traccar.notificators;
 
 import org.traccar.helper.Log;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
+import org.traccar.notification.MessageException;
 
 public abstract class Notificator {
 

--- a/src/org/traccar/notificators/NotificatorMail.java
+++ b/src/org/traccar/notificators/NotificatorMail.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.traccar.notification;
+package org.traccar.notificators;
 
 import java.util.Properties;
 
@@ -31,8 +31,12 @@ import org.traccar.helper.Log;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 import org.traccar.model.User;
+import org.traccar.notification.FullMessage;
+import org.traccar.notification.MessageException;
+import org.traccar.notification.NotificationFormatter;
+import org.traccar.notification.PropertiesProvider;
 
-public final class NotificationMail extends Notificator {
+public final class NotificatorMail extends Notificator {
 
     private static Properties getProperties(PropertiesProvider provider) {
         Properties properties = new Properties();

--- a/src/org/traccar/notificators/NotificatorNull.java
+++ b/src/org/traccar/notificators/NotificatorNull.java
@@ -14,17 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.traccar.notification;
+package org.traccar.notificators;
 
-import org.traccar.Context;
+import org.traccar.helper.Log;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 
-public final class NotificationWeb extends Notificator {
+public final class NotificatorNull extends Notificator {
+
+    @Override
+    public void sendAsync(long userId, Event event, Position position) {
+        Log.warning("You are using null notificatior, please check your configuration, notification not sent");
+    }
 
     @Override
     public void sendSync(long userId, Event event, Position position) {
-        Context.getConnectionManager().updateEvent(userId, event);
+        Log.warning("You are using null notificatior, please check your configuration, notification not sent");
     }
-
 }

--- a/src/org/traccar/notificators/NotificatorSms.java
+++ b/src/org/traccar/notificators/NotificatorSms.java
@@ -14,19 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.traccar.notification;
+package org.traccar.notificators;
 
 import org.traccar.Context;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 import org.traccar.model.User;
+import org.traccar.notification.MessageException;
+import org.traccar.notification.NotificationFormatter;
 import org.traccar.sms.SmsManager;
 
-public final class NotificationSms extends Notificator {
+public final class NotificatorSms extends Notificator {
 
     private final SmsManager smsManager;
 
-    public NotificationSms() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    public NotificatorSms() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
         final String smsClass = Context.getConfig().getString("notificator.sms.manager.class", "");
         if (smsClass.length() > 0) {
             smsManager = (SmsManager) Class.forName(smsClass).newInstance();

--- a/src/org/traccar/notificators/NotificatorWeb.java
+++ b/src/org/traccar/notificators/NotificatorWeb.java
@@ -14,21 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.traccar.notification;
+package org.traccar.notificators;
 
-import org.traccar.helper.Log;
+import org.traccar.Context;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 
-public final class NotificationNull extends Notificator {
-
-    @Override
-    public void sendAsync(long userId, Event event, Position position) {
-        Log.warning("You are using null notificatior, please check your configuration, notification not sent");
-    }
+public final class NotificatorWeb extends Notificator {
 
     @Override
     public void sendSync(long userId, Event event, Position position) {
-        Log.warning("You are using null notificatior, please check your configuration, notification not sent");
+        Context.getConnectionManager().updateEvent(userId, event);
     }
+
 }


### PR DESCRIPTION
Here is part of #3956 
Moved default notificators with base class to `org.traccar.notificators` and renamed to `NotificatorXxx`