### PR TITLE
Fix for notifications migration on postgresql and mssql

### DIFF
--- a/schema/changelog-4.0.xml
+++ b/schema/changelog-4.0.xml
@@ -53,11 +53,29 @@
 
   </changeSet>
 
-  <changeSet author="author" id="changelog-4.0">
+  <changeSet author="author" id="changelog-4.0-pre">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="tc_notifications" columnName="notificators" />
+      </not>
+    </preConditions>
 
     <addColumn tableName="tc_notifications">
       <column name="notificators" type="VARCHAR(128)" />
     </addColumn>
+
+  </changeSet>
+
+  <changeSet author="author" id="changelog-4.0-common">
+
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <dbms type="postgresql" />
+      </not>
+      <columnExists tableName="tc_notifications" columnName="web" />
+      <columnExists tableName="tc_notifications" columnName="mail" />
+      <columnExists tableName="tc_notifications" columnName="sms" />
+    </preConditions>
 
     <update tableName="tc_notifications">
         <column name="notificators" value="web,mail,sms" />
@@ -94,8 +112,69 @@
         <where>web = 0 AND mail = 0 AND sms = 1</where>
     </update>
 
+  </changeSet>
+
+  <changeSet author="author" id="changelog-4.0-pg">
+
+    <preConditions onFail="MARK_RAN">
+      <dbms type="postgresql" />
+      <columnExists tableName="tc_notifications" columnName="web" />
+      <columnExists tableName="tc_notifications" columnName="mail" />
+      <columnExists tableName="tc_notifications" columnName="sms" />
+    </preConditions>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="web,mail,sms" />
+        <where>web = TRUE AND mail = TRUE AND sms = TRUE</where>
+    </update>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="web,mail" />
+        <where>web = TRUE AND mail = TRUE AND sms = FALSE</where>
+    </update>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="web" />
+        <where>web = TRUE AND mail = FALSE AND sms = FALSE</where>
+    </update>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="web,sms" />
+        <where>web = TRUE AND mail = FALSE AND sms = TRUE</where>
+    </update>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="mail,sms" />
+        <where>web = FALSE AND mail = TRUE AND sms = TRUE</where>
+    </update>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="mail" />
+        <where>web = FALSE AND mail = TRUE AND sms = FALSE</where>
+    </update>
+
+    <update tableName="tc_notifications">
+        <column name="notificators" value="sms" />
+        <where>web = FALSE AND mail = FALSE AND sms = TRUE</where>
+    </update>
+
+  </changeSet>
+
+  <changeSet author="author" id="changelog-4.0-post">
+
+    <preConditions onFail="MARK_RAN">
+      <columnExists tableName="tc_notifications" columnName="web" />
+      <columnExists tableName="tc_notifications" columnName="mail" />
+      <columnExists tableName="tc_notifications" columnName="sms" />
+    </preConditions>
+
+    <dropDefaultValue tableName="tc_notifications" columnName="web" />
     <dropColumn tableName="tc_notifications" columnName="web" />
+
+    <dropDefaultValue tableName="tc_notifications" columnName="mail" />
     <dropColumn tableName="tc_notifications" columnName="mail" />
+
+    <dropDefaultValue tableName="tc_notifications" columnName="sms" />
     <dropColumn tableName="tc_notifications" columnName="sms" />
 
   </changeSet>

--- a/schema/changelog-4.0.xml
+++ b/schema/changelog-4.0.xml
@@ -160,13 +160,7 @@
 
   </changeSet>
 
-  <changeSet author="author" id="changelog-4.0-post">
-
-    <preConditions onFail="MARK_RAN">
-      <columnExists tableName="tc_notifications" columnName="web" />
-      <columnExists tableName="tc_notifications" columnName="mail" />
-      <columnExists tableName="tc_notifications" columnName="sms" />
-    </preConditions>
+  <changeSet author="author" id="changelog-4.0">
 
     <dropDefaultValue tableName="tc_notifications" columnName="web" />
     <dropColumn tableName="tc_notifications" columnName="web" />


### PR DESCRIPTION
Made separate migrations for h2, mysql, mssql(`common`) and postgresql (`pg`).
Split on `pre`, "main" and `post`.
Added preconditions in case somebody already successfully migrated to 4.0 for future.

It might looks a bit complicated but I hope be universal.

fix #3993 