### PR TITLE
Integrated FCM Notifications

### DIFF
--- a/schema/changelog-4.0.xml
+++ b/schema/changelog-4.0.xml
@@ -173,4 +173,11 @@
 
   </changeSet>
 
+    <changeSet id="addFcm" author="atiq">
+        <addColumn tableName="tc_users">
+            <column name="fcmtoken" type="VARCHAR(255)">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -28,11 +28,13 @@
 
     <entry key='media.path'>./media</entry>
 
-    <entry key='notificator.types'>web,mail</entry>
+    <entry key='notificator.types'>web,mail,fcm</entry>
 
     <entry key='server.statistics'>https://www.traccar.org/analytics/</entry>
 
     <entry key='commands.queueing'>true</entry>
+
+    <entry key="notificator.fcm.serverkey"></entry>
 
     <!-- DATABASE CONFIG -->
 

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -17,6 +17,7 @@ package org.traccar.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import org.traccar.Context;
 import org.traccar.database.QueryExtended;
 import org.traccar.database.QueryIgnore;
 import org.traccar.helper.Hashing;
@@ -273,4 +274,29 @@ public class User extends ExtendedModel {
         return Hashing.validatePassword(password, hashedPassword, salt);
     }
 
+    private String fcmToken;
+
+    @JsonIgnore
+    public String getFcmToken() {
+        return fcmToken;
+    }
+
+    public void setFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+
+    @QueryIgnore
+    public String getFcm() {
+        return fcmToken;
+    }
+
+    public void setFcm(String fcmToken) {
+        if(fcmToken != null && !fcmToken.isEmpty())
+            this.fcmToken = fcmToken;
+        else{
+            User user = Context.getPermissionsManager().getUser(getId());
+            this.fcmToken = user.getFcmToken();
+
+        }
+    }
 }

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -99,6 +99,14 @@ public final class NotificationFormatter {
         return formatMessage(null, userId, event, position, "short");
     }
 
+    public static FullMessage formatFCMMessage(long userId,Event event, Position position){
+        VelocityContext velocityContext = prepareContext(userId, event, position);
+        String formattedMessage = formatMessage(velocityContext, userId, event, position, "short");
+
+        Device device = (Device) velocityContext.get("device");
+        return new FullMessage(device.getName(), formattedMessage);
+    }
+
     private static String formatMessage(VelocityContext vc, Long userId, Event event, Position position,
             String templatePath) {
 

--- a/src/org/traccar/notification/NotificatorManager.java
+++ b/src/org/traccar/notification/NotificatorManager.java
@@ -32,6 +32,7 @@ public final class NotificatorManager {
     private static final String DEFAULT_WEB_NOTIFICATOR = "org.traccar.notificators.NotificatorWeb";
     private static final String DEFAULT_MAIL_NOTIFICATOR = "org.traccar.notificators.NotificatorMail";
     private static final String DEFAULT_SMS_NOTIFICATOR = "org.traccar.notificators.NotificatorSms";
+    private static final String DEFAULT_FCM_NOTIFICATOR = "org.traccar.notificators.NotificatorFcm";
 
     private final Map<String, Notificator> notificators = new HashMap<>();
     private static final Notificator NULL_NOTIFICATOR = new NotificatorNull();
@@ -49,6 +50,9 @@ public final class NotificatorManager {
                     break;
                 case "sms":
                     defaultNotificator = DEFAULT_SMS_NOTIFICATOR;
+                    break;
+                case "fcm":
+                    defaultNotificator = DEFAULT_FCM_NOTIFICATOR;
                     break;
                 default:
                     break;

--- a/src/org/traccar/notificators/NotificatorFcm.java
+++ b/src/org/traccar/notificators/NotificatorFcm.java
@@ -1,0 +1,92 @@
+package org.traccar.notificators;
+
+import org.traccar.Context;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+import org.traccar.model.User;
+import org.traccar.notification.FullMessage;
+import org.traccar.notification.MessageException;
+import org.traccar.notification.NotificationFormatter;
+
+import javax.ws.rs.client.AsyncInvoker;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+
+public class NotificatorFcm extends Notificator {
+    @Override
+    public void sendSync(long userId, Event event, Position position) throws MessageException, InterruptedException {
+        User user = Context.getPermissionsManager().getUser(userId);
+
+        String serverKey = Context.getConfig().getString("notificator.fcm.serverkey", "");
+
+        String url = "https://fcm.googleapis.com/fcm/send";
+
+        Invocation.Builder requestBuilder = Context.getClient().target(url).request();
+        requestBuilder = requestBuilder.header("Authorization", "key=" + serverKey);
+        requestBuilder = requestBuilder.header("Content-Type", "application/json");
+
+        AsyncInvoker invoker = requestBuilder.async();
+
+        FullMessage fullMessage = NotificationFormatter.formatFCMMessage(userId, event, position);
+
+        invoker.post(Entity.json(new FCM(user.getFcm(), new FCM.Notification(fullMessage.getBody(), fullMessage.getSubject() + " Alert"))));
+
+    }
+
+    public static class FCM {
+        private String to;
+        private Notification notification;
+
+        public FCM() {
+        }
+
+        public FCM(String to, Notification notification) {
+            this.to = to;
+            this.notification = notification;
+        }
+
+        public String getTo() {
+            return to;
+        }
+
+        public void setTo(String to) {
+            this.to = to;
+        }
+
+        public Notification getNotification() {
+            return notification;
+        }
+
+        public void setNotification(Notification notification) {
+            this.notification = notification;
+        }
+
+        public static class Notification {
+            private String body, title;
+
+            public Notification() {
+            }
+
+            public Notification(String body, String title) {
+                this.body = body;
+                this.title = title;
+            }
+
+            public String getBody() {
+                return body;
+            }
+
+            public void setBody(String body) {
+                this.body = body;
+            }
+
+            public String getTitle() {
+                return title;
+            }
+
+            public void setTitle(String title) {
+                this.title = title;
+            }
+        }
+    }
+}


### PR DESCRIPTION
A much-requested feature to implement **Firebase Cloud Messaging** Notifications

Requested here #3707 , here #3814 

I have implemented the Feature without using FCM library so no extra burden, simple HTTP request just like event forwarding.

**How to use**
o enable, simply put "fcm" in "notificator.types"  and Your Server Key in "notificator.fcm.serverkey" in your configuration file.

debug.xml will look like

```
<entry key='notificator.types'>web,mail,fcm</entry>
<entry key="notificator.fcm.serverkey">YOUR_SERVER_KEY</entry>
```

You can get your Server key from here : [https://stackoverflow.com/a/37427911](https://stackoverflow.com/a/37427911)

A new field is added in user object named  "fcm" This is the Every user token to deliver the notifications to. This can be updated from Rest API just like you update the user.