### PR TITLE
package.sh revisited

### DIFF
--- a/setup/package.sh
+++ b/setup/package.sh
@@ -1,41 +1,93 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
-# Script to create installers
+# Script to create installers for various platforms.
 #
 
 cd $(dirname $0)
 
-if [[ $# -lt 1 ]]
-then
-  echo "USAGE: $0 <version>"
+usage () {
+  echo "Usage: $0 VERSION [PLATFORM]"
+  echo "Build Traccar installers."
+  echo
+  echo "Without PLATFORM provided, builds installers for all platforms."
+  echo
+  echo "Available platforms:"
+  echo " * linux-64"
+  echo " * linux-arm"
+  echo " * windows-64"
+  echo " * other"
   exit 1
-fi
-
-VERSION=$1
-
-check_requirement () {
-  if ! eval $1 &>/dev/null
-  then
-    echo $2
-    exit 1
-  fi 
 }
 
-check_requirement "ls ../../ext-6.2.0" "Missing ExtJS (https://www.sencha.com/legal/GPL/)"
-check_requirement "ls innosetup-*.exe" "Missing Inno Setup (http://www.jrsoftware.org/isdl.php)"
-check_requirement "ls java-*.windows.x86_64.zip" "Missing Windows 64 Java (https://github.com/ojdkbuild/ojdkbuild)"
-check_requirement "ls jdk-*-linux-x64.zip" "Missing Linux 64 Java (https://github.com/ojdkbuild/contrib_jdk10u-ci/releases)"
-check_requirement "ls jdk-*-linux-armhf.zip" "Missing Linux ARM Java (https://github.com/ojdkbuild/contrib_jdk10u-aarch32-ci/releases)"
-check_requirement "which sencha" "Missing sencha cmd package (https://www.sencha.com/products/extjs/cmd-download/)"
-check_requirement "which unzip" "Missing unzip"
-check_requirement "which wine" "Missing wine"
-check_requirement "which innoextract" "Missing innoextract"
-check_requirement "which makeself" "Missing makeself"
-check_requirement "which jlink" "Missing jlink"
+if [[ $# -lt 1 ]]
+then
+  usage
+fi
+
+info () {
+  echo -e "[\033[1;34mINFO\033[0m] "$1
+}
+
+ok () {
+  echo -e "[\033[1;32m OK \033[0m] "$1
+}
+
+warn () {
+  echo -e "[\033[1;31mWARN\033[0m] "$1
+}
+
+VERSION=$1
+PLATFORM=${2:-all}
+export EXTJS_PATH=$(cd ../..; pwd)/ext-6.2.0
+PREREQ=true
+
+check_requirement () {
+  if ! eval $2 &>/dev/null
+  then
+	warn "$3"
+	PREREQ=false
+  else
+	ok "$@"
+  fi
+}
+
+info "Checking build requirements for platform: "$PLATFORM
+check_requirement "Traccar server archive" "ls ../target/tracker-server.jar" "Missing traccar archive"
+check_requirement "Traccar web interface" "ls ../traccar-web/tools/minify.sh" "Missing traccar-web sources"
+check_requirement "Zip" "which zip" "Missing zip binary"
+check_requirement "Unzip" "which unzip" "Missing unzip binary"
+check_requirement "Ext JS" "ls $EXTJS_PATH" "ExtJS not found in $EXTJS_PATH (https://www.sencha.com/legal/GPL/)"
+check_requirement "Sencha Cmd" "which sencha" "Missing Sencha Cmd package (https://www.sencha.com/products/extjs/cmd-download/)"
+if [ $PLATFORM != "other" ]; then
+  check_requirement "Jlink" "which jlink" "Missing jlink binary (openjdk-10-jdk-headless)"
+fi
+if [ $PLATFORM = "all" -o $PLATFORM = "windows-64" ]; then
+  check_requirement "Inno Extractor" "which innoextract" "Missing innoextract binary"
+  check_requirement "Inno Setup" "ls innosetup-*.exe" "Missing Inno Setup (http://www.jrsoftware.org/isdl.php)"
+  check_requirement "Windows 64 Java" "ls java-*.windows.x86_64.zip" "Missing Windows 64 Java (https://github.com/ojdkbuild/ojdkbuild)"
+  check_requirement "Wine" "which wine" "Missing wine binary"
+fi
+if [ $PLATFORM = "all" -o $PLATFORM = "linux-64" -o $PLATFORM = "linux-arm" ]; then
+  check_requirement "Makeself" "which makeself" "Missing makeself binary"
+fi
+if [ $PLATFORM = "all" -o $PLATFORM = "linux-64" ]; then
+  check_requirement "Linux 64 Java" "ls jdk-*-linux-x64.zip" "Missing Linux 64 Java (https://github.com/ojdkbuild/contrib_jdk10u-ci/releases)"
+fi
+if [ $PLATFORM = "all" -o $PLATFORM = "linux-arm" ]; then
+  check_requirement "Linux ARM Java" "ls jdk-*-linux-armhf.zip" "Missing Linux ARM Java (https://github.com/ojdkbuild/contrib_jdk10u-aarch32-ci/releases)"
+fi
+if [ $PREREQ = false ]; then
+  info "Missing build requirements, aborting..."
+  exit 1
+else
+  info "Building..."
+fi
 
 prepare () {
-  ../traccar-web/tools/minify.sh
+  info "Generating app.min.js"
+  ../traccar-web/tools/minify.sh >/dev/null
+  ok "Created app.min.js"
 
   mkdir -p out/{conf,data,lib,logs,web,schema,templates}
 
@@ -47,64 +99,101 @@ prepare () {
   cp default.xml out/conf
   cp traccar.xml out/conf
 
-  innoextract innosetup-*.exe
-  echo "If you got any errors here try isetup version 5.5.5 (or check supported versions using 'innoextract -v')"
+  if [ $PLATFORM = "all" -o $PLATFORM = "windows-64" ]; then
+	innoextract innosetup-*.exe >/dev/null
+	info "If you got any errors here try Inno Setup version 5.5.5 (or check supported versions using 'innoextract -v')"
+  fi
 }
 
 cleanup () {
+  info "Cleanup"
   rm ../traccar-web/web/app.min.js
 
   rm -r out
-  rm -r tmp
-  rm -r app
+  if [ $PLATFORM = "all" -o $PLATFORM = "windows-64" ]; then
+	rm -r tmp
+	rm -r app
+  fi
 }
 
 package_other () {
+  info "Building Zip archive"
   cp README.txt out
   cd out
-  zip -r ../traccar-other-$VERSION.zip *
+  zip -q -r ../traccar-other-$VERSION.zip *
   cd ..
   rm out/README.txt
+  ok "Created Zip archive"
 }
 
 package_windows () {
-  unzip -o java-*.windows.x86_64.zip
+  info "Building Windows 64 installer"
+  unzip -q -o java-*.windows.x86_64.zip
   jlink --module-path java-*.windows.x86_64/jmods --add-modules java.se.ee --output out/jre
   rm -rf java-*.windows.x86_64
-  wine app/ISCC.exe traccar.iss
+  wine app/ISCC.exe traccar.iss >/dev/null
   rm -rf out/jre
-  zip -j traccar-windows-64-$VERSION.zip Output/traccar-setup.exe README.txt
+  zip -q -j traccar-windows-64-$VERSION.zip Output/traccar-setup.exe README.txt
   rm -r Output
+  ok "Created Windows 64 installer"
 }
 
-package_unix () {
+package_linux () {
   cp setup.sh out
   cp traccar.service out
 
-  unzip -o jdk-*-linux-x64.zip
-  jlink --module-path jdk-*-linux-x64/jmods --add-modules java.se.ee --output out/jre
-  rm -rf jdk-*-linux-x64
-  makeself --notemp out traccar.run "traccar" ./setup.sh
+  unzip -q -o jdk-*-linux-$1.zip
+  jlink --module-path jdk-*-linux-$1/jmods --add-modules java.se.ee --output out/jre
+  rm -rf jdk-*-linux-$1
+  makeself --quiet --notemp out traccar.run "traccar" ./setup.sh
   rm -rf out/jre
-  zip -j traccar-linux-64-$VERSION.zip traccar.run README.txt
-  rm traccar.run
 
-  unzip -o jdk-*-linux-armhf.zip
-  jlink --module-path jdk-*-linux-armhf/jmods --add-modules java.se.ee --output out/jre
-  rm -rf jdk-*-linux-armhf
-  makeself --notemp out traccar.run "traccar" ./setup.sh
-  rm -rf out/jre
-  zip -j traccar-linux-arm-$VERSION.zip traccar.run README.txt
-  rm traccar.run
+  zip -q -j traccar-linux-$2-$VERSION.zip traccar.run README.txt
 
+  rm traccar.run
   rm out/setup.sh
   rm out/traccar.service
 }
 
+package_linux_64 () {
+  info "Building Linux 64 installer"
+  package_linux x64 64
+  ok "Created Linux 64 installer"
+}
+
+package_linux_arm () {
+  info "Building Linux ARM installer"
+  package_linux armhf arm
+  ok "Created Linux ARM installer"
+}
+
 prepare
 
-package_other
-package_windows
-package_unix
+case $PLATFORM in
+  all)
+	package_linux_64
+	package_linux_arm
+	package_windows
+	package_other
+	;;
+
+  linux-64)
+	package_linux_64
+	;;
+
+  linux-arm)
+	package_linux_arm
+	;;
+
+  windows-64)
+	package_windows
+	;;
+
+  other)
+	package_other
+	;;
+esac
 
 cleanup
+
+ok "Done"


### PR DESCRIPTION
Rationale: Religion forbids me to build anything for a proprietary OS.

```
$ ./platform.sh
Usage: ./platform.sh VERSION [PLATFORM]
Build Traccar installers.

Without PLATFORM provided, builds installers for all platforms.

Available platforms:
 * linux-x64
 * linux-arm
 * windows-64
 * other
```

Should be fairly easy to understand. Fancy colors for clueless people.

Caveats:
 * Only tested twice.
 * Will not run on a PDP-11.

