### PR TITLE
Add no_annotations=1 parameter in the call to OpenCage API

### DIFF
--- a/src/org/traccar/geocoder/OpenCageGeocoder.java
+++ b/src/org/traccar/geocoder/OpenCageGeocoder.java
@@ -22,7 +22,7 @@ import javax.json.JsonObject;
 public class OpenCageGeocoder extends JsonGeocoder {
 
     public OpenCageGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
-        super(url + "/json?q=%f,%f&key=" + key, cacheSize, addressFormat);
+        super(url + "/json?q=%f,%f&no_annotations=1&key=" + key, cacheSize, addressFormat);
     }
 
     @Override


### PR DESCRIPTION
This makes the response slightly faster by not requesting information traccar never uses.

See:
https://opencagedata.com/api#bestpractices
https://opencagedata.com/api#forward-opt