### PR TITLE
Add watch framelogging for Debugging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.traccar</groupId>
     <artifactId>traccar</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT-WatchFrameDecoderModified_TK906</version>
 
     <name>traccar</name>
     <url>https://www.traccar.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.traccar</groupId>
     <artifactId>traccar</artifactId>
-    <version>4.0-SNAPSHOT-WatchFrameDecoderModified_TK906</version>
+    <version>4.0-SNAPSHOT-WatchFrameDecoderModified_FrameLogging</version>
 
     <name>traccar</name>
     <url>https://www.traccar.org</url>

--- a/src/org/traccar/protocol/WatchFrameDecoder.java
+++ b/src/org/traccar/protocol/WatchFrameDecoder.java
@@ -22,9 +22,17 @@ import io.netty.channel.ChannelHandlerContext;
 
 import java.nio.charset.StandardCharsets;
 
+import org.traccar.helper.Log;
 import org.traccar.BaseFrameDecoder;
+import org.traccar.Context;
 
 public class WatchFrameDecoder extends BaseFrameDecoder {
+
+    private final boolean enableFramelogging;
+
+    public WatchFrameDecoder(WatchProtocol protocol) {
+        enableFramelogging = Context.getConfig().getBoolean(protocol.getName() + ".enableFramelogging");
+    }
 
     @Override
     protected Object decode(
@@ -91,6 +99,12 @@ public class WatchFrameDecoder extends BaseFrameDecoder {
         if (endmarkerIndex < payloadIndex + 1 + length || payloadIndex + 1 + length < endmarkerIndex) {
             int framelength = length;
             length = endmarkerIndex - payloadIndex - 1;
+
+            if (enableFramelogging) {
+                Log.debug(String.format("watch protocol error fixed: lenght indicator "
+                        + "reported %d but supposed to be %d based on frame end marker",
+                        framelength, length));
+            }
         }
 
         if (buf.readableBytes() >= payloadIndex + 1 + length + 1 - buf.readerIndex()) {

--- a/src/org/traccar/protocol/WatchProtocol.java
+++ b/src/org/traccar/protocol/WatchProtocol.java
@@ -50,9 +50,9 @@ public class WatchProtocol extends BaseProtocol {
         serverList.add(new TrackerServer(false, getName()) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline) {
-                pipeline.addLast("frameDecoder", new WatchFrameDecoder());
+                pipeline.addLast("frameDecoder", new WatchFrameDecoder(WatchProtocol.this));
                 pipeline.addLast("stringEncoder", new StringEncoder());
-                pipeline.addLast("objectEncoder", new WatchProtocolEncoder());
+                pipeline.addLast("objectEncoder", new WatchProtocolEncoder(WatchProtocol.this));
                 pipeline.addLast("objectDecoder", new WatchProtocolDecoder(WatchProtocol.this));
             }
         });

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -34,11 +34,15 @@ import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.regex.Pattern;
+import org.traccar.helper.Log;
 
 public class WatchProtocolDecoder extends BaseProtocolDecoder {
 
+    private final boolean enableFramelogging;
+
     public WatchProtocolDecoder(WatchProtocol protocol) {
         super(protocol);
+        enableFramelogging = Context.getConfig().getBoolean(getProtocolName() + ".enableFramelogging");
     }
 
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
@@ -178,6 +182,9 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
             Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
 
         ByteBuf buf = (ByteBuf) msg;
+        if (enableFramelogging) {
+            logFrame(msg);
+        }
 
         buf.skipBytes(1); // header
         manufacturer = buf.readSlice(2).toString(StandardCharsets.US_ASCII);
@@ -309,4 +316,10 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
         return null;
     }
 
+    private void logFrame(Object msg) {
+        StringBuilder logmsg = new StringBuilder();
+        logmsg.append("received frame: ");
+        logmsg.append(((ByteBuf) msg).toString(StandardCharsets.US_ASCII));
+        Log.debug(logmsg.toString());
+    }
 }

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -42,23 +42,23 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
-            .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time (hhmmss)
-            .expression("([AV]),")               // validity
-            .number(" *(-?d+.d+),")              // latitude
+            .number("(dd)(dd)(dd),") // date (ddmmyy)
+            .number("(dd)(dd)(dd),") // time (hhmmss)
+            .expression("([AV]),") // validity
+            .number(" *(-?d+.d+),") // latitude
             .expression("([NS]),")
-            .number(" *(-?d+.d+),")              // longitude
+            .number(" *(-?d+.d+),") // longitude
             .expression("([EW])?,")
-            .number("(d+.?d*),")                 // speed
-            .number("(d+.?d*),")                 // course
-            .number("(d+.?d*),")                 // altitude
-            .number("(d+),")                     // satellites
-            .number("(d+),")                     // rssi
-            .number("(d+),")                     // battery
-            .number("(d+),")                     // steps
-            .number("d+,")                       // tumbles
-            .number("(x+),")                     // status
-            .expression("(.*)")                  // cell and wifi
+            .number("(d+.?d*),") // speed
+            .number("(d+.?d*),") // course
+            .number("(d+.?d*),") // altitude
+            .number("(d+),") // satellites
+            .number("(d+),") // rssi
+            .number("(d+),") // battery
+            .number("(d+),") // steps
+            .number("d+,") // tumbles
+            .number("(x+),") // status
+            .expression("(.*)") // cell and wifi
             .compile();
 
     private void sendResponse(Channel channel, String id, String index, String content) {

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -295,4 +295,7 @@ public class ProtocolTest extends BaseTest {
         assertEquals(ByteBufUtil.hexDump(expected), ByteBufUtil.hexDump((ByteBuf) object));
     }
 
+    protected void verifyFrameNull(Object object) {                
+        assertNull(object);
+    }
 }

--- a/test/org/traccar/protocol/WatchFrameDecoderTest.java
+++ b/test/org/traccar/protocol/WatchFrameDecoderTest.java
@@ -7,9 +7,26 @@ public class WatchFrameDecoderTest extends ProtocolTest {
 
     @Test
     public void testDecode() throws Exception {
-
+        
         WatchFrameDecoder decoder = new WatchFrameDecoder();
 
+        verifyFrame(
+                binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d"),
+                decoder.decode(null, null, binary("0D5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d")));
+
+        verifyFrameNull(                
+                decoder.decode(null, null, binary("0D53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d")));
+
+        verifyFrameNull(                
+                decoder.decode(null, null, binary("2a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d")));
+
+        verifyFrameNull(                
+                decoder.decode(null, null, binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c313030")));        
+        
+        verifyFrame(
+                binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d"),
+                decoder.decode(null, null, binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305D")));        
+        
         verifyFrame(
                 binary("5b33472a3335323636313039303134333135302a303030412a4c4b2c302c302c3130305d"),
                 decoder.decode(null, null, binary("5b33472a3335323636313039303134333135302a303030412a4c4b2c302c302c3130305d")));

--- a/test/org/traccar/protocol/WatchFrameDecoderTest.java
+++ b/test/org/traccar/protocol/WatchFrameDecoderTest.java
@@ -7,8 +7,9 @@ public class WatchFrameDecoderTest extends ProtocolTest {
 
     @Test
     public void testDecode() throws Exception {
-        
-        WatchFrameDecoder decoder = new WatchFrameDecoder();
+
+        WatchProtocol protocol = new WatchProtocol();
+        WatchFrameDecoder decoder = new WatchFrameDecoder(protocol);
 
         verifyFrame(
                 binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d"),

--- a/test/org/traccar/protocol/WatchProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/WatchProtocolDecoderTest.java
@@ -15,7 +15,7 @@ public class WatchProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, buffer(
                 "[SG*352661090143150*006C*UD,150817,132115,V,28.435142,N,81.354333,W,2.2038,000,99,00,70,100,0,50,00000000,1,1,310,260,1091,30082,139,,00]"));
-
+  
         verifyAttributes(decoder, buffer(
                 "[3G*4700609403*0013*bphrt,120,79,73,,,,]"));
 
@@ -52,7 +52,13 @@ public class WatchProtocolDecoderTest extends ProtocolTest {
 
         verifyNull(decoder, buffer(
                 "[SG*9081000548*0009*LK,0,100]"));
+        
+        verifyNull(decoder, buffer(
+                "[SG*9081000548*0001*LK,0,100]"));
 
+        verifyNull(decoder, buffer(
+                "[SG*9081000548*0020*LK,0,100]"));
+        
         verifyPosition(decoder, buffer(
                 "[SG*9081000548*00A9*UD,110116,113639,V,16.479064,S,68.119072,,0.7593,000,99,00,80,80,0,50,00000000,5,1,736,2,10103,10732,153,10103,11061,152,10103,11012,152,10103,10151,150,10103,10731,143,,00]"));
 

--- a/test/org/traccar/protocol/WatchProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/WatchProtocolEncoderTest.java
@@ -11,7 +11,8 @@ public class WatchProtocolEncoderTest extends ProtocolTest {
     @Test
     public void testEncode() throws Exception {
 
-        WatchProtocolEncoder encoder = new WatchProtocolEncoder();
+        WatchProtocol protocol = new WatchProtocol();
+        WatchProtocolEncoder encoder = new WatchProtocolEncoder(protocol);
         
         Command command;
 


### PR DESCRIPTION
This fixes device issues found with TK906 bike trackers, which tend to
transmit wrong a frame length for some frames very often. 

The fixed Watch protocol frame decoder now not only evaluates the frame
length transmitted from the device itself but also checks the no of
frame bytes till the next "frame end marker" (']') and uses whatever is
correct.

Additionally the frame start detection has been improved to better sync
to valid frames according to the watch protocol spec.

usecase 1) ignore chars which don't belong to a frame (not between '['
and ']'):
```
12345[SG*12345678*0004*LK,,]abcde\n..[SG*12345678*0004*LK,,]222
```
in this example '12345', 'abcde\n..' and '222' stream bytes will be
ignored

usecase 2) partial transmitted frames
```
[SG*12345678[SG*12345678*0002*LK]
```
in this example, the leading bytes '[SG*12345678' will be ignored


The fix does not affact devices which work according to the protocol
spec, but improves handling of devices like the TK906 which fail to
fulfill the protcol spec and otherwise could not be used with traccar.