### PR TITLE
Fix and improve watch voice msg handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.traccar</groupId>
     <artifactId>traccar</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT-WatchFrameDecoderModified_TK906</version>
 
     <name>traccar</name>
     <url>https://www.traccar.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.traccar</groupId>
     <artifactId>traccar</artifactId>
-    <version>4.0-SNAPSHOT-WatchFrameDecoderModified_TK906</version>
+    <version>4.0-SNAPSHOT-WatchFrameDecoderModified_FrameLogging</version>
 
     <name>traccar</name>
     <url>https://www.traccar.org</url>

--- a/src/org/traccar/StringProtocolEncoder.java
+++ b/src/org/traccar/StringProtocolEncoder.java
@@ -18,6 +18,7 @@ package org.traccar;
 import org.traccar.model.Command;
 
 import java.util.Map;
+import java.util.regex.Matcher;
 
 public abstract class StringProtocolEncoder extends BaseProtocolEncoder {
 
@@ -38,7 +39,7 @@ public abstract class StringProtocolEncoder extends BaseProtocolEncoder {
             if (value == null) {
                 value = entry.getValue().toString();
             }
-            result = result.replaceAll("\\{" + entry.getKey() + "}", value);
+            result = result.replaceAll("\\{" + entry.getKey() + "}", Matcher.quoteReplacement(value));
         }
 
         return result;

--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -72,6 +72,7 @@ public class Command extends Message implements Cloneable {
     public static final String KEY_MESSAGE = "message";
     public static final String KEY_ENABLE = "enable";
     public static final String KEY_DATA = "data";
+    public static final String KEY_BLOB = "blob";
     public static final String KEY_INDEX = "index";
     public static final String KEY_PHONE = "phone";
     public static final String KEY_SERVER = "server";

--- a/src/org/traccar/protocol/WatchFrameDecoder.java
+++ b/src/org/traccar/protocol/WatchFrameDecoder.java
@@ -22,9 +22,17 @@ import io.netty.channel.ChannelHandlerContext;
 
 import java.nio.charset.StandardCharsets;
 
+import org.traccar.helper.Log;
 import org.traccar.BaseFrameDecoder;
+import org.traccar.Context;
 
 public class WatchFrameDecoder extends BaseFrameDecoder {
+
+    private final boolean enableFramelogging;
+
+    public WatchFrameDecoder(WatchProtocol protocol) {
+        enableFramelogging = Context.getConfig().getBoolean(protocol.getName() + ".enableFramelogging");
+    }
 
     @Override
     protected Object decode(
@@ -91,6 +99,12 @@ public class WatchFrameDecoder extends BaseFrameDecoder {
         if (endmarkerIndex < payloadIndex + 1 + length || payloadIndex + 1 + length < endmarkerIndex) {
             int framelength = length;
             length = endmarkerIndex - payloadIndex - 1;
+
+            if (enableFramelogging) {
+                Log.debug(String.format("watch protocol error fixed: lenght indicator "
+                        + "reported %d but supposed to be %d based on frame end marker",
+                        framelength, length));
+            }
         }
 
         if (buf.readableBytes() >= payloadIndex + 1 + length + 1 - buf.readerIndex()) {

--- a/src/org/traccar/protocol/WatchProtocol.java
+++ b/src/org/traccar/protocol/WatchProtocol.java
@@ -50,9 +50,9 @@ public class WatchProtocol extends BaseProtocol {
         serverList.add(new TrackerServer(false, getName()) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline) {
-                pipeline.addLast("frameDecoder", new WatchFrameDecoder());
+                pipeline.addLast("frameDecoder", new WatchFrameDecoder(WatchProtocol.this));
                 pipeline.addLast("stringEncoder", new StringEncoder());
-                pipeline.addLast("objectEncoder", new WatchProtocolEncoder());
+                pipeline.addLast("objectEncoder", new WatchProtocolEncoder(WatchProtocol.this));
                 pipeline.addLast("objectDecoder", new WatchProtocolDecoder(WatchProtocol.this));
             }
         });

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -34,11 +34,15 @@ import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.regex.Pattern;
+import org.traccar.helper.Log;
 
 public class WatchProtocolDecoder extends BaseProtocolDecoder {
 
+    private final boolean enableFramelogging;
+
     public WatchProtocolDecoder(WatchProtocol protocol) {
         super(protocol);
+        enableFramelogging = Context.getConfig().getBoolean(getProtocolName() + ".enableFramelogging");
     }
 
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
@@ -178,6 +182,9 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
             Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
 
         ByteBuf buf = (ByteBuf) msg;
+        if (enableFramelogging) {
+            logFrame(msg);
+        }
 
         buf.skipBytes(1); // header
         manufacturer = buf.readSlice(2).toString(StandardCharsets.US_ASCII);
@@ -309,4 +316,10 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
         return null;
     }
 
+    private void logFrame(Object msg) {
+        StringBuilder logmsg = new StringBuilder();
+        logmsg.append("received frame: ");
+        logmsg.append(((ByteBuf) msg).toString(StandardCharsets.US_ASCII));
+        Log.debug(logmsg.toString());
+    }
 }

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -42,23 +42,23 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
-            .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time (hhmmss)
-            .expression("([AV]),")               // validity
-            .number(" *(-?d+.d+),")              // latitude
+            .number("(dd)(dd)(dd),") // date (ddmmyy)
+            .number("(dd)(dd)(dd),") // time (hhmmss)
+            .expression("([AV]),") // validity
+            .number(" *(-?d+.d+),") // latitude
             .expression("([NS]),")
-            .number(" *(-?d+.d+),")              // longitude
+            .number(" *(-?d+.d+),") // longitude
             .expression("([EW])?,")
-            .number("(d+.?d*),")                 // speed
-            .number("(d+.?d*),")                 // course
-            .number("(d+.?d*),")                 // altitude
-            .number("(d+),")                     // satellites
-            .number("(d+),")                     // rssi
-            .number("(d+),")                     // battery
-            .number("(d+),")                     // steps
-            .number("d+,")                       // tumbles
-            .number("(x+),")                     // status
-            .expression("(.*)")                  // cell and wifi
+            .number("(d+.?d*),") // speed
+            .number("(d+.?d*),") // course
+            .number("(d+.?d*),") // altitude
+            .number("(d+),") // satellites
+            .number("(d+),") // rssi
+            .number("(d+),") // battery
+            .number("(d+),") // steps
+            .number("d+,") // tumbles
+            .number("(x+),") // status
+            .expression("(.*)") // cell and wifi
             .compile();
 
     private void sendResponse(Channel channel, String id, String index, String content) {

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -295,4 +295,7 @@ public class ProtocolTest extends BaseTest {
         assertEquals(ByteBufUtil.hexDump(expected), ByteBufUtil.hexDump((ByteBuf) object));
     }
 
+    protected void verifyFrameNull(Object object) {                
+        assertNull(object);
+    }
 }

--- a/test/org/traccar/protocol/WatchFrameDecoderTest.java
+++ b/test/org/traccar/protocol/WatchFrameDecoderTest.java
@@ -7,9 +7,26 @@ public class WatchFrameDecoderTest extends ProtocolTest {
 
     @Test
     public void testDecode() throws Exception {
-
+        
         WatchFrameDecoder decoder = new WatchFrameDecoder();
 
+        verifyFrame(
+                binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d"),
+                decoder.decode(null, null, binary("0D5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d")));
+
+        verifyFrameNull(                
+                decoder.decode(null, null, binary("0D53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d")));
+
+        verifyFrameNull(                
+                decoder.decode(null, null, binary("2a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d")));
+
+        verifyFrameNull(                
+                decoder.decode(null, null, binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c313030")));        
+        
+        verifyFrame(
+                binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d"),
+                decoder.decode(null, null, binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305D")));        
+        
         verifyFrame(
                 binary("5b33472a3335323636313039303134333135302a303030412a4c4b2c302c302c3130305d"),
                 decoder.decode(null, null, binary("5b33472a3335323636313039303134333135302a303030412a4c4b2c302c302c3130305d")));

--- a/test/org/traccar/protocol/WatchFrameDecoderTest.java
+++ b/test/org/traccar/protocol/WatchFrameDecoderTest.java
@@ -7,8 +7,9 @@ public class WatchFrameDecoderTest extends ProtocolTest {
 
     @Test
     public void testDecode() throws Exception {
-        
-        WatchFrameDecoder decoder = new WatchFrameDecoder();
+
+        WatchProtocol protocol = new WatchProtocol();
+        WatchFrameDecoder decoder = new WatchFrameDecoder(protocol);
 
         verifyFrame(
                 binary("5b53472a3335323636313039303134333135302a303030312a4c4b2c302c302c3130305d"),

--- a/test/org/traccar/protocol/WatchProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/WatchProtocolDecoderTest.java
@@ -15,7 +15,7 @@ public class WatchProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, buffer(
                 "[SG*352661090143150*006C*UD,150817,132115,V,28.435142,N,81.354333,W,2.2038,000,99,00,70,100,0,50,00000000,1,1,310,260,1091,30082,139,,00]"));
-
+  
         verifyAttributes(decoder, buffer(
                 "[3G*4700609403*0013*bphrt,120,79,73,,,,]"));
 
@@ -52,7 +52,13 @@ public class WatchProtocolDecoderTest extends ProtocolTest {
 
         verifyNull(decoder, buffer(
                 "[SG*9081000548*0009*LK,0,100]"));
+        
+        verifyNull(decoder, buffer(
+                "[SG*9081000548*0001*LK,0,100]"));
 
+        verifyNull(decoder, buffer(
+                "[SG*9081000548*0020*LK,0,100]"));
+        
         verifyPosition(decoder, buffer(
                 "[SG*9081000548*00A9*UD,110116,113639,V,16.479064,S,68.119072,,0.7593,000,99,00,80,80,0,50,00000000,5,1,736,2,10103,10732,153,10103,11061,152,10103,11012,152,10103,10151,150,10103,10731,143,,00]"));
 

--- a/test/org/traccar/protocol/WatchProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/WatchProtocolEncoderTest.java
@@ -11,7 +11,8 @@ public class WatchProtocolEncoderTest extends ProtocolTest {
     @Test
     public void testEncode() throws Exception {
 
-        WatchProtocolEncoder encoder = new WatchProtocolEncoder();
+        WatchProtocol protocol = new WatchProtocol();
+        WatchProtocolEncoder encoder = new WatchProtocolEncoder(protocol);
         
         Command command;
 

--- a/test/org/traccar/protocol/WatchProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/WatchProtocolEncoderTest.java
@@ -19,41 +19,50 @@ public class WatchProtocolEncoderTest extends ProtocolTest {
         command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_REBOOT_DEVICE);
-        assertEquals("[CS*123456789012345*0005*RESET]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*0005*RESET]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303030352A52455345545D"), encoder.encodeCommand(null, command));
 
         command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_SOS_NUMBER);
         command.set(Command.KEY_INDEX, 1);
         command.set(Command.KEY_PHONE, "123456789");
-        assertEquals("[CS*123456789012345*000e*SOS1,123456789]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*000e*SOS1,123456789]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303030652A534F53312C3132333435363738395D"), encoder.encodeCommand(null, command));
 
+        //expected encoded cmd "[CS*123456789012345*001e*TK,#!AMR"+[some binary blob]+"]"
+        //binary blob contains some testing char (e.g. some have to be escaped + some non ASCII char)
         command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_VOICE_MESSAGE);
-        command.set(Command.KEY_DATA, "3333");
-        assertEquals("[CS*123456789012345*0005*TK,33]", encoder.encodeCommand(null, command));
-
+        command.set(Command.KEY_DATA, "2321414D520A7D5B5D2C2A41424344454655FFEF");                                       
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303031632A544B2C2321414D520A7D017D027D037D047D0541424344454655FFEF5D"), encoder.encodeCommand(null, command));
+                             
         command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_CUSTOM);
         command.set(Command.KEY_DATA, "WORK,6-9,11-13,13-15,17-19");
-        assertEquals("[CS*123456789012345*001a*WORK,6-9,11-13,13-15,17-19]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*001a*WORK,6-9,11-13,13-15,17-19]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303031612A574F524B2C362D392C31312D31332C31332D31352C31372D31395D"), encoder.encodeCommand(null, command));
 
         command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_SET_TIMEZONE);
         command.set(Command.KEY_TIMEZONE, "Europe/Amsterdam");
-        assertEquals("[CS*123456789012345*0006*LZ,,+1]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*0006*LZ,,+1]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303030362A4C5A2C2C2B315D"), encoder.encodeCommand(null, command));
 
         command.set(Command.KEY_TIMEZONE, "GMT+01:30");
-        assertEquals("[CS*123456789012345*0008*LZ,,+1.5]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*0008*LZ,,+1.5]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303030382A4C5A2C2C2B312E355D"), encoder.encodeCommand(null, command));
 
         command.set(Command.KEY_TIMEZONE, "Atlantic/Azores");
-        assertEquals("[CS*123456789012345*0006*LZ,,-1]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*0006*LZ,,-1]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303030362A4C5A2C2C2D315D"), encoder.encodeCommand(null, command));
 
         command.set(Command.KEY_TIMEZONE, "GMT-11:30");
-        assertEquals("[CS*123456789012345*0009*LZ,,-11.5]", encoder.encodeCommand(null, command));
+        //expected encoded cmd "[CS*123456789012345*0009*LZ,,-11.5]"
+        assertEquals(binary("5B43532A3132333435363738393031323334352A303030392A4C5A2C2C2D31312E355D"), encoder.encodeCommand(null, command));
 
     }
 


### PR DESCRIPTION

**fix:** 


The cmd was not sent before when triggered from the web frontend if
"real" amr data (taken from a file generated from a smartwatch) was
entered to the "Key_Data" field within the webform, for some reasons:

the call (WatchProtocolEnecoder.java::191): 
cmdtoSend = formatCommand(channel, command, "TK," +
getBinaryData(command));

directly concats the binay data to the cmd content, which causes (with
real data) a handling problem within the class
StringProtocolEncoder::formatCommand
The binary blob also can contain "\" and "$" which cause problems 
when a string replacement methode is called.

According to java doc 'quoteReplacement' should be used in that cases...

Also changed the direct content concating to using the "key -
replacment conecept" all other cmds use.

Also changed the return type of the encode methode to "bytebuf" because
strings cause problems on all non-ASCII data - e.g. as the binary blob
of an amr file.

For the same reason, also the unit test of the watchencoder has been
changed from string to binary assert values and the voice msg test now
covers non-ascii char + char which need to be escaped.


This changes don't affact usual text cmds (which don't contain binary
data) - according to my tests but make the VOICE MSG cmd usable.

**Improvement:** 

Introduced a new cmd type (binary blob) for e.g. voice data.

Also added a way to specify a filename instead of forcing the user to
copy & paste unhandy audio data as hex encoded stream to the web form,
because it should be easier to reference to a file (and read the binary
blob from this file) than to extract this data manually.

To reference an amr - audio file, one needs to enter
"file://[rel.path]/[filename.amr]" within the "KEY_DATA" field in the
webform.
The path of the file is relative to the one which is configured as 
"media.path" 

e.g. if media.path is set to "/mypath" and the audio file is
stored in /mypath/foo/bar.amr then "file://foo/bar.amr" entered
as KEY_DATA will trigger a file read.
