### PR TITLE
[Gpsmta] Fix battery level decoding

### DIFF
--- a/src/org/traccar/protocol/GpsmtaProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsmtaProtocolDecoder.java
@@ -43,7 +43,7 @@ public class GpsmtaProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+) ")                     // accuracy
             .number("(d+) ")                     // altitude
             .number("(d+) ")                     // flags
-            .number("(d+) ")                     // battery
+            .number("(d+) ")                     // battery level
             .number("(d+) ")                     // temperature
             .number("(d)")                       // charging status
             .any()
@@ -77,7 +77,7 @@ public class GpsmtaProtocolDecoder extends BaseProtocolDecoder {
         position.setAltitude(parser.nextInt(0));
 
         position.set(Position.KEY_STATUS, parser.nextInt(0));
-        position.set(Position.KEY_BATTERY, parser.nextInt(0));
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
         position.set(Position.PREFIX_TEMP + 1, parser.nextInt(0));
         position.set(Position.KEY_CHARGE, parser.nextInt(0) == 1);
 

--- a/test/org/traccar/protocol/GpsmtaProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/GpsmtaProtocolDecoderTest.java
@@ -16,7 +16,7 @@ public class GpsmtaProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, text(
                 "864528021249771 1446116686 49.85073 24.004438 0 217 6 338 00 59 27 0 0"));
 
-        verifyPosition(decoder, text(
+        verifyNotNull(decoder, text(
                 "359144048138856 1442932957 -49.85064 -24.003979 1 0 40 0 10 110 26 0 0"));
 
     }


### PR DESCRIPTION
Protocol analysis reveals Gpsmta client sends battery _level_, not _voltage_.