### PR TITLE
Fix MSSQL triggers after renaming columns

### DIFF
--- a/schema/changelog-4.0-clean.xml
+++ b/schema/changelog-4.0-clean.xml
@@ -652,11 +652,15 @@
   <changeSet author="author" id="changelog-4.0-clean-mssql">
 
     <preConditions onFail="MARK_RAN">
-      <not>
-        <changeSetExecuted changeLogFile="changelog-3.3" id="changelog-3.3" author="author" />
-      </not>
       <dbms type="mssql" />
     </preConditions>
+
+    <sql>
+      IF EXISTS (SELECT * FROM sysobjects WHERE type = 'TR' AND name = 'tg_groups_delete')
+      BEGIN
+      DROP TRIGGER tg_groups_delete
+      END;
+    </sql>
 
     <sql>
       CREATE TRIGGER tg_groups_delete
@@ -664,6 +668,13 @@
       AS BEGIN
       UPDATE tc_groups SET groupid = NULL WHERE groupid IN (SELECT deleted.id FROM deleted)
       END
+    </sql>
+
+    <sql>
+      IF EXISTS (SELECT * FROM sysobjects WHERE type = 'TR' AND name = 'tg_users_delete')
+      BEGIN
+      DROP TRIGGER tg_users_delete
+      END;
     </sql>
 
     <sql>


### PR DESCRIPTION
Fixed triggers in MSSQL after renaming columns.
Tested migrations 4.0 to current and clean current.
They should be done as separate SQLs because "CREATE TRIGGER needs to be the first in a batch"