### PR TITLE
geocoder: Implement MapmyIndia Reverse geocoder

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -60,6 +60,7 @@ import org.traccar.geocoder.HereGeocoder;
 import org.traccar.geocoder.MapQuestGeocoder;
 import org.traccar.geocoder.NominatimGeocoder;
 import org.traccar.geocoder.OpenCageGeocoder;
+import org.traccar.geocoder.MapmyIndiaGeocoder;
 import org.traccar.geocoder.Geocoder;
 import org.traccar.geolocation.UnwiredGeolocationProvider;
 import org.traccar.helper.Log;
@@ -351,6 +352,8 @@ public final class Context {
                 return new BanGeocoder(cacheSize, addressFormat);
             case "here":
                 return new HereGeocoder(id, key, language, cacheSize, addressFormat);
+            case "mapmyindia":
+                return new MapmyIndiaGeocoder(url, key, cacheSize, addressFormat);
             default:
                 return new GoogleGeocoder(key, language, cacheSize, addressFormat);
         }

--- a/src/org/traccar/geocoder/MapmyIndiaGeocoder.java
+++ b/src/org/traccar/geocoder/MapmyIndiaGeocoder.java
@@ -1,0 +1,67 @@
+package org.traccar.geocoder;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+public class MapmyIndiaGeocoder extends JsonGeocoder {
+
+    public MapmyIndiaGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
+        super(url + "/" + key + "/rev_geocode?lat=%f&lng=%f", cacheSize, addressFormat);
+    }
+
+    @Override
+    public Address parseAddress(JsonObject json) {
+        JsonArray results = json.getJsonArray("results");
+
+        if (!results.isEmpty()) {
+            Address address = new Address();
+
+            JsonObject result = (JsonObject) results.get(0);
+
+            if (result.containsKey("formatted_address")) {
+                address.setFormattedAddress(result.getString("formatted_address"));
+            }
+
+            if (result.containsKey("house_number") && (result.getString("house_number") != "")) {
+                address.setHouse(result.getString("house_number"));
+            } else if (result.containsKey("house_name") && (result.getString("house_name") != "")) {
+                address.setHouse(result.getString("house_name"));
+            }
+
+            if (result.containsKey("street")) {
+                address.setStreet(result.getString("street"));
+            }
+
+            if (result.containsKey("locality") && (result.getString("locality") != "")) {
+                address.setSuburb(result.getString("locality"));
+            } else if (result.containsKey("sublocality") && (result.getString("sublocality") != "")) {
+                address.setSuburb(result.getString("sublocality"));
+            } else if (result.containsKey("subsublocality") && (result.getString("subsublocality") != "")) {
+                address.setSuburb(result.getString("subsublocality"));
+            }
+
+            if (result.containsKey("city") && (result.getString("city") != "")) {
+                address.setSettlement(result.getString("city"));
+            } else if (result.containsKey("village") && (result.getString("village") != "")) {
+                address.setSettlement(result.getString("village"));
+            }
+
+            if (result.containsKey("district")) {
+                address.setDistrict(result.getString("district"));
+            } else if (result.containsKey("subDistrict")) {
+                address.setDistrict(result.getString("subDistrict"));
+            }
+
+            if (result.containsKey("state")) {
+                address.setState(result.getString("state"));
+            }
+
+            if (result.containsKey("pincode")) {
+                address.setPostcode(result.getString("pincode"));
+            }
+
+            return address;
+        }
+        return null;
+    }
+}

--- a/test/org/traccar/geocoder/GeocoderTest.java
+++ b/test/org/traccar/geocoder/GeocoderTest.java
@@ -78,4 +78,11 @@ public class GeocoderTest {
         assertEquals("6 Avenue Gustave Eiffel, Paris, Île-de-France, FRA", address);
     }
 
+    @Ignore
+    @Test
+    public void testMapmyIndia() {
+        Geocoder geocoder = new MapmyIndiaGeocoder("", "", 0, new AddressFormat("%f"));
+        String address = geocoder.getAddress(28.6129602407977, 77.2294557094574, null);
+        assertEquals("New Delhi, Delhi. 1 m from India Gate pin-110001 (India)", address);
+    }
 }


### PR DESCRIPTION
@tananaev request you to kindly review the changes and merge them if you find it OK.

MapmyIndia reverse geocoding is very helpful for the Indian
subcontinent, It's "distance from nearest POI" detail embedded in the
formatted_address field of the response is quite impressive for the
reports.
The Confirgurations required to be added in the config file
"traccar.xml" are

    <entry key='geocoder.enable'>true</entry>
    <entry key='geocoder.type'>mapmyindia</entry>
    <entry key="geocoder.url">https://apis.mapmyindia.com/advancedmaps/v1</entry>
    <entry key="geocoder.key">YOUR_KeY</entry>
    <entry key="geocoder.format">%f</entry>

Signed-off-by: Syed Mujeer Hashmi <mujeerhashmi@gmail.com>