### PR TITLE
SMS client: Changes to support msg91

### DIFF
--- a/src/org/traccar/sms/HttpSmsClient.java
+++ b/src/org/traccar/sms/HttpSmsClient.java
@@ -38,6 +38,7 @@ public class HttpSmsClient implements SmsManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpSmsClient.class);
 
     private String url;
+    private String authorizationHeader;
     private String authorization;
     private String template;
     private boolean encode;
@@ -45,6 +46,8 @@ public class HttpSmsClient implements SmsManager {
 
     public HttpSmsClient() {
         url = Context.getConfig().getString("sms.http.url");
+        authorizationHeader = Context.getConfig().getString("sms.http.authorizationHeader",
+                SecurityRequestFilter.AUTHORIZATION_HEADER);
         authorization = Context.getConfig().getString("sms.http.authorization");
         if (authorization == null) {
             String user = Context.getConfig().getString("sms.http.user");
@@ -70,7 +73,7 @@ public class HttpSmsClient implements SmsManager {
         try {
             return template
                     .replace("{phone}", prepareValue(destAddress))
-                    .replace("{message}", prepareValue(message));
+                    .replace("{message}", prepareValue(message.trim()));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -78,7 +81,7 @@ public class HttpSmsClient implements SmsManager {
 
     private Invocation.Builder getRequestBuilder() {
         return Context.getClient().target(url).request()
-                .header(SecurityRequestFilter.AUTHORIZATION_HEADER, authorization);
+                .header(authorizationHeader, authorization);
     }
 
     @Override


### PR DESCRIPTION
Hi @tananaev ,
The authorization header may require different name:value pair for
specifying token by the service provider. Add a config parameter
"sms.http.authorizationName" to support this. In case of msg91, the
name required is "authkey".

The newline at the end of short templates are causing invalid json in
request. Get rid of the newline using trim().

The required config to enable msg91 sms notifications are

    <entry key='notificator.types'>web,mail,sms</entry>
    <entry key='notificator.sms.manager.class'>org.traccar.sms.HttpSmsClient</entry>
    <entry key='sms.http.url'>http://api.msg91.com/api/v2/sendsms</entry>
    <entry key="sms.http.authorizationName">authkey</entry>
    <entry key='sms.http.authorization'>[YOUR TOKEN]</entry>
    <entry key='sms.http.template'>
        {
            "sender": "SOCKET",
            "route": "4",
            "country": "91",
            "sms": [
                {
                    "message": "{message}",
                    "to": ["{phone}"]
                }
            ]
        }
    </entry>

Signed-off-by: Syed Mujeer Hashmi <mujeerhashmi@gmail.com>