### PR TITLE
Added logger.rotate configuration parameter for compatibility with logrotate

### DIFF
--- a/setup/default.xml
+++ b/setup/default.xml
@@ -21,6 +21,7 @@
     <entry key='logger.enable'>true</entry>
     <entry key='logger.level'>info</entry>
     <entry key='logger.file'>./logs/tracker-server.log</entry>
+    <entry key='logger.rotate'>true</entry>
 
     <entry key='filter.enable'>true</entry>
     <entry key='filter.future'>86400</entry>


### PR DESCRIPTION
A new option allows to disable native rotation of the log file. This feature allows compatibility with logrotate in unix-based systems.
Logrotate config example /etc/logrotate.d/traccar:
`/var/log/traccar/tracker-server.log {`
`    copytruncate`
`    daily`
`    rotate 7`
`    compress`
`    delaycompress`
`    missingok`
`    notifempty`
`    create 0644 traccar traccar`
`}`