### PR TITLE
Fixed geofences processing order

### DIFF
--- a/src/org/traccar/events/GeofenceEventHandler.java
+++ b/src/org/traccar/events/GeofenceEventHandler.java
@@ -60,20 +60,20 @@ public class GeofenceEventHandler extends BaseEventHandler {
         device.setGeofenceIds(currentGeofences);
 
         Map<Event, Position> events = new HashMap<>();
-        for (long geofenceId : newGeofences) {
-            long calendarId = geofenceManager.getById(geofenceId).getCalendarId();
-            Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
-            if (calendar == null || calendar.checkMoment(position.getFixTime())) {
-                Event event = new Event(Event.TYPE_GEOFENCE_ENTER, position.getDeviceId(), position.getId());
-                event.setGeofenceId(geofenceId);
-                events.put(event, position);
-            }
-        }
         for (long geofenceId : oldGeofences) {
             long calendarId = geofenceManager.getById(geofenceId).getCalendarId();
             Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
             if (calendar == null || calendar.checkMoment(position.getFixTime())) {
                 Event event = new Event(Event.TYPE_GEOFENCE_EXIT, position.getDeviceId(), position.getId());
+                event.setGeofenceId(geofenceId);
+                events.put(event, position);
+            }
+        }
+        for (long geofenceId : newGeofences) {
+            long calendarId = geofenceManager.getById(geofenceId).getCalendarId();
+            Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
+            if (calendar == null || calendar.checkMoment(position.getFixTime())) {
+                Event event = new Event(Event.TYPE_GEOFENCE_ENTER, position.getDeviceId(), position.getId());
                 event.setGeofenceId(geofenceId);
                 events.put(event, position);
             }


### PR DESCRIPTION
If the position simultaneously generates an exit from the previous geofence and an entrance to the next one, then we will get an incorrect sequence of events. I think that in this case the geofenceExit event should be before the geofenceEnter event.
Example: [report.xlsx](https://github.com/traccar/traccar/files/2866664/report.xlsx)
