### PR TITLE
Add support for Nominatim-based per-road speed limits.

### DIFF
--- a/src/org/traccar/geocoder/Address.java
+++ b/src/org/traccar/geocoder/Address.java
@@ -107,4 +107,14 @@ public class Address {
         this.formattedAddress = formattedAddress;
     }
 
+    private String speedLimit;
+
+    public String getSpeedLimit() {
+        return speedLimit;
+    }
+
+    public void setSpeedLimit(String speedLimit) {
+        this.speedLimit = speedLimit;
+    }
+
 }

--- a/src/org/traccar/geocoder/AddressFormat.java
+++ b/src/org/traccar/geocoder/AddressFormat.java
@@ -68,6 +68,7 @@ public class AddressFormat extends Format {
         result = replace(result, "%r", address.getStreet());
         result = replace(result, "%h", address.getHouse());
         result = replace(result, "%f", address.getFormattedAddress());
+        result = replace(result, "%z", address.getSpeedLimit());
 
         result = result.replaceAll("^[, ]*", "");
 

--- a/src/org/traccar/geocoder/Geocoder.java
+++ b/src/org/traccar/geocoder/Geocoder.java
@@ -20,11 +20,13 @@ public interface Geocoder {
     interface ReverseGeocoderCallback {
 
         void onSuccess(String address);
+        void onSuccess(double speed);
 
         void onFailure(Throwable e);
 
     }
 
     String getAddress(double latitude, double longitude, ReverseGeocoderCallback callback);
+    double getSpeedLimit(double latitude, double longitude, ReverseGeocoderCallback callback);
 
 }

--- a/src/org/traccar/geocoder/NominatimGeocoder.java
+++ b/src/org/traccar/geocoder/NominatimGeocoder.java
@@ -16,14 +16,18 @@
 package org.traccar.geocoder;
 
 import javax.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NominatimGeocoder extends JsonGeocoder {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NominatimGeocoder.class);
+
     private static String formatUrl(String url, String key, String language) {
         if (url == null) {
-            url = "https://nominatim.openstreetmap.org/reverse";
+            url = "https://nominatim.openstreetmap.org/";
         }
-        url += "?format=json&lat=%f&lon=%f&zoom=18&addressdetails=1";
+        url += "reverse?format=json&lat=%f&lon=%f&zoom=16&addressdetails=1&extratags=1";
         if (key != null) {
             url += "&key=" + key;
         }
@@ -40,7 +44,7 @@ public class NominatimGeocoder extends JsonGeocoder {
     @Override
     public Address parseAddress(JsonObject json) {
         JsonObject result = json.getJsonObject("address");
-
+        JsonObject extrasresult = json.getJsonObject("extratags");
         if (result != null) {
             Address address = new Address();
 
@@ -81,7 +85,11 @@ public class NominatimGeocoder extends JsonGeocoder {
             if (result.containsKey("postcode")) {
                 address.setPostcode(result.getString("postcode"));
             }
-
+            if (extrasresult != null) {
+                if (extrasresult.containsKey("maxspeed")) {
+                    address.setSpeedLimit(extrasresult.getString("maxspeed"));
+                }
+            }
             return address;
         }
 

--- a/src/org/traccar/handler/GeocoderHandler.java
+++ b/src/org/traccar/handler/GeocoderHandler.java
@@ -82,6 +82,11 @@ public class GeocoderHandler extends ChannelInboundHandlerAdapter {
                         LOGGER.warn("Geocoding failed", e);
                         ctx.fireChannelRead(position);
                     }
+
+                    @Override
+                    public void onSuccess(double speed) {
+                        throw new UnsupportedOperationException("Not supported yet.");
+                    }
                 });
             } else {
                 ctx.fireChannelRead(position);

--- a/src/org/traccar/handler/events/OverspeedEventHandler.java
+++ b/src/org/traccar/handler/events/OverspeedEventHandler.java
@@ -19,6 +19,9 @@ package org.traccar.handler.events;
 import java.util.Collections;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.netty.channel.ChannelHandler;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
@@ -29,6 +32,7 @@ import org.traccar.model.DeviceState;
 import org.traccar.model.Event;
 import org.traccar.model.Geofence;
 import org.traccar.model.Position;
+import org.traccar.Context;
 
 @ChannelHandler.Sharable
 public class OverspeedEventHandler extends BaseEventHandler {
@@ -141,6 +145,14 @@ public class OverspeedEventHandler extends BaseEventHandler {
         }
         if (geofenceSpeedLimit > 0) {
             speedLimit = geofenceSpeedLimit;
+        }
+
+        if (Context.getGeocoder() != null) {
+            double geoLimit = Context.getGeocoder().getSpeedLimit(
+                    position.getLatitude(), position.getLongitude(), null);
+            if (geoLimit > 0) {
+                speedLimit = geoLimit;
+            }
         }
 
         if (speedLimit == 0) {


### PR DESCRIPTION
These changes implement the reading of the extratags object in nominatim, which includes maxspeed (Speed limit).
We automatically detect kph or mph and convert to knots, which is checked in the overspeed event.