### PR TITLE
Add geofenceCrossed event

### DIFF
--- a/gradle/checkstyle.xml
+++ b/gradle/checkstyle.xml
@@ -70,7 +70,10 @@
         <module name="MethodLength">
             <property name="max" value="200"/>
         </module>
-        <module name="ParameterNumber"/>
+        <module name="ParameterNumber">
+            <property name="max" value="8"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
 
         <!-- Checks for whitespace                               -->
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -56,6 +56,12 @@
         SELECT tc_positions.* FROM tc_positions INNER JOIN tc_devices ON tc_positions.id = tc_devices.positionid;
     </entry>
 
+    <entry key='database.selectPreviousPosition'>
+        SELECT * FROM tc_positions WHERE deviceID = :deviceId AND id &lt; :positionId
+        ORDER BY id DESC
+        LIMIT 1
+    </entry>
+
     <entry key='database.updateLatestPosition'>
         UPDATE tc_devices SET positionId = :id WHERE id = :deviceId
     </entry>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -57,7 +57,7 @@
     </entry>
 
     <entry key='database.selectPreviousPosition'>
-        SELECT * FROM tc_positions WHERE deviceID = :deviceId AND id &lt; :positionId
+        SELECT * FROM tc_positions WHERE id &lt; :positionId AND deviceid = (SELECT deviceid FROM tc_positions WHERE id = :positionId)
         ORDER BY id DESC
         LIMIT 1
     </entry>

--- a/src/main/java/org/traccar/database/DataManager.java
+++ b/src/main/java/org/traccar/database/DataManager.java
@@ -359,6 +359,15 @@ public class DataManager {
                 .executeQuery(Position.class);
     }
 
+    public Position getPreviousPosition(Position position) throws SQLException {
+        return QueryBuilder.create(dataSource,  getQuery("database.selectPreviousPosition"))
+                .setLong("deviceId", position.getDeviceId())
+                .setLong("positionId", position.getId())
+                .executeQuery(Position.class)
+                .iterator()
+                .next();
+    }
+
     public void clearHistory() throws SQLException {
         long historyDays = config.getInteger("database.historyDays");
         if (historyDays != 0) {

--- a/src/main/java/org/traccar/database/DataManager.java
+++ b/src/main/java/org/traccar/database/DataManager.java
@@ -361,7 +361,6 @@ public class DataManager {
 
     public Position getPreviousPosition(Position position) throws SQLException {
         return QueryBuilder.create(dataSource,  getQuery("database.selectPreviousPosition"))
-                .setLong("deviceId", position.getDeviceId())
                 .setLong("positionId", position.getId())
                 .executeQuery(Position.class)
                 .iterator()

--- a/src/main/java/org/traccar/database/DeviceManager.java
+++ b/src/main/java/org/traccar/database/DeviceManager.java
@@ -270,6 +270,15 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
         return lastPosition == null || position.getFixTime().compareTo(lastPosition.getFixTime()) >= 0;
     }
 
+    public Position getPreviousPosition(Position position) {
+        try {
+            return getDataManager().getPreviousPosition(position);
+        } catch (SQLException error) {
+            LOGGER.warn("Load previous position error", error);
+            return null;
+        }
+    }
+
     public void updateLatestPosition(Position position) throws SQLException {
 
         if (isLatestPosition(position)) {

--- a/src/main/java/org/traccar/database/GeofenceManager.java
+++ b/src/main/java/org/traccar/database/GeofenceManager.java
@@ -47,6 +47,21 @@ public class GeofenceManager extends ExtendedObjectManager<Geofence> {
         return result;
     }
 
+    public List<Long> getCurrentDeviceCrossedGeofences(Position position) {
+        Position prevPosition = Context.getDeviceManager().getPreviousPosition(position);
+
+        List<Long> result = new ArrayList<>();
+        for (long geofenceId : getAllDeviceItems(position.getDeviceId())) {
+            Geofence geofence = getById(geofenceId);
+            if (geofence != null && prevPosition != null && geofence.getGeometry()
+                    .crossesGeofence(position.getLatitude(), position.getLongitude(),
+                    prevPosition.getLatitude(), prevPosition.getLongitude())) {
+                result.add(geofenceId);
+            }
+        }
+        return result;
+    }
+
     public void recalculateDevicesGeofences() {
         for (Device device : Context.getDeviceManager().getAllDevices()) {
             List<Long> deviceGeofenceIds = device.getGeofenceIds();

--- a/src/main/java/org/traccar/geofence/GeofenceCircle.java
+++ b/src/main/java/org/traccar/geofence/GeofenceCircle.java
@@ -49,6 +49,12 @@ public class GeofenceCircle extends GeofenceGeometry {
     }
 
     @Override
+    public boolean crossesGeofence(double latitude1, double longitude1, double latitude2, double longitude2) {
+        return DistanceCalculator.lineCrossesCircle(
+                latitude1, longitude1, latitude2, longitude2, centerLatitude, centerLongitude, radius);
+    }
+
+    @Override
     public String toWkt() {
         String wkt = "";
         wkt = "CIRCLE (";

--- a/src/main/java/org/traccar/geofence/GeofenceCircle.java
+++ b/src/main/java/org/traccar/geofence/GeofenceCircle.java
@@ -50,8 +50,10 @@ public class GeofenceCircle extends GeofenceGeometry {
 
     @Override
     public boolean crossesGeofence(double latitude1, double longitude1, double latitude2, double longitude2) {
-        return DistanceCalculator.lineCrossesCircle(
-                latitude1, longitude1, latitude2, longitude2, centerLatitude, centerLongitude, radius);
+        return DistanceCalculator.distanceToLine(
+                centerLatitude, centerLongitude, latitude1, longitude1, latitude2, longitude2) <= radius
+                && DistanceCalculator.distance(centerLatitude, centerLongitude, latitude1, longitude1) > radius
+                && DistanceCalculator.distance(centerLatitude, centerLongitude, latitude2, longitude2) > radius;
     }
 
     @Override

--- a/src/main/java/org/traccar/geofence/GeofenceGeometry.java
+++ b/src/main/java/org/traccar/geofence/GeofenceGeometry.java
@@ -21,6 +21,8 @@ public abstract class GeofenceGeometry {
 
     public abstract boolean containsPoint(double latitude, double longitude);
 
+    public abstract boolean crossesGeofence(double latitude1, double longitude1, double latitude2, double longitude2);
+
     public abstract String toWkt();
 
     public abstract void fromWkt(String wkt) throws ParseException;

--- a/src/main/java/org/traccar/geofence/GeofencePolygon.java
+++ b/src/main/java/org/traccar/geofence/GeofencePolygon.java
@@ -112,19 +112,13 @@ public class GeofencePolygon extends GeofenceGeometry {
     @Override
     public boolean crossesGeofence(double latitude1, double longitude1, double latitude2, double longitude2) {
         int crosses = 0;
+        int polyCorners = coordinates.size();
 
-        for (int i = 1; i <= coordinates.size(); i++) {
-            if (i == coordinates.size()) {
-                if (DistanceCalculator.lineCrossesLine(
-                        latitude1, longitude1, latitude2, longitude2,
-                        coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon(),
-                        coordinates.get(0).getLat(), coordinates.get(0).getLon())) {
-                    crosses++;
-                }
-            } else if (DistanceCalculator.lineCrossesLine(
+        for (int i = 1; i <= polyCorners; i++) {
+            if (DistanceCalculator.lineCrossesLine(
                     latitude1, longitude1, latitude2, longitude2,
                     coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon(),
-                    coordinates.get(i).getLat(), coordinates.get(i).getLon())) {
+                    coordinates.get(i % polyCorners).getLat(), coordinates.get(i % polyCorners).getLon())) {
                 crosses++;
             }
         }

--- a/src/main/java/org/traccar/geofence/GeofencePolygon.java
+++ b/src/main/java/org/traccar/geofence/GeofencePolygon.java
@@ -18,6 +18,8 @@ package org.traccar.geofence;
 import java.text.ParseException;
 import java.util.ArrayList;
 
+import org.traccar.helper.DistanceCalculator;
+
 public class GeofencePolygon extends GeofenceGeometry {
 
     public GeofencePolygon() {
@@ -105,6 +107,29 @@ public class GeofencePolygon extends GeofenceGeometry {
             }
         }
         return oddNodes;
+    }
+
+    @Override
+    public boolean crossesGeofence(double latitude1, double longitude1, double latitude2, double longitude2) {
+        int crosses = 0;
+
+        for (int i = 1; i <= coordinates.size(); i++) {
+            if (i == coordinates.size()) {
+                if (DistanceCalculator.lineCrossesLine(
+                        latitude1, longitude1, latitude2, longitude2,
+                        coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon(),
+                        coordinates.get(0).getLat(), coordinates.get(0).getLon())) {
+                    crosses++;
+                }
+            } else if (DistanceCalculator.lineCrossesLine(
+                    latitude1, longitude1, latitude2, longitude2,
+                    coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon(),
+                    coordinates.get(i).getLat(), coordinates.get(i).getLon())) {
+                crosses++;
+            }
+        }
+
+        return crosses > 0 && crosses % 2 == 0;
     }
 
     @Override

--- a/src/main/java/org/traccar/geofence/GeofencePolyline.java
+++ b/src/main/java/org/traccar/geofence/GeofencePolyline.java
@@ -47,6 +47,19 @@ public class GeofencePolyline extends GeofenceGeometry {
     }
 
     @Override
+    public boolean crossesGeofence(double latitude1, double longitude1, double latitude2, double longitude2) {
+        for (int i = 1; i < coordinates.size(); i++) {
+            if (DistanceCalculator.lineCrossesLine(
+                    latitude1, longitude1, latitude2, longitude2,
+                    coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon(),
+                    coordinates.get(i).getLat(), coordinates.get(i).getLon())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public String toWkt() {
         StringBuilder buf = new StringBuilder();
         buf.append("LINESTRING (");

--- a/src/main/java/org/traccar/helper/DistanceCalculator.java
+++ b/src/main/java/org/traccar/helper/DistanceCalculator.java
@@ -50,4 +50,28 @@ public final class DistanceCalculator {
         return 2 * area / d1;
     }
 
+    public static boolean lineCrossesLine(
+            double aLat1, double aLon1, double aLat2, double aLon2,
+            double bLat1, double bLon1, double bLat2, double bLon2) {
+
+        double det, gamma, lambda;
+        det = (aLat2 - aLat1) * (bLon2 - bLon1) - (bLat2 - bLat1) * (aLon2 - aLon1);
+
+        if (det == 0) {
+            return false;
+        } else {
+            lambda = ((bLon2 - bLon1) * (bLat2 - aLat1) + (bLat1 - bLat2) * (bLon2 - aLon1)) / det;
+            gamma = ((aLon1 - aLon2) * (bLat2 - aLat1) + (aLat2 - aLat1) * (bLon2 - aLon1)) / det;
+            return (0 < lambda && lambda < 1) && (0 < gamma && gamma < 1);
+        }
+    }
+
+    public static boolean lineCrossesCircle(
+            double lat1, double lon1, double lat2, double lon2, double circleLat, double circleLon, double circleRad) {
+        return (Math.abs((lat2 - lat1) * circleLon + circleLat * (lon1 - lon2)
+                + (lat1 - lat2) * lon1
+                + (lon1 - lon2) * lat1) / Math.sqrt(Math.pow((lat2 - lat1), 2)
+                + Math.pow((lon1 - lon2), 2)) <= circleRad);
+    }
+
 }

--- a/src/main/java/org/traccar/helper/DistanceCalculator.java
+++ b/src/main/java/org/traccar/helper/DistanceCalculator.java
@@ -65,13 +65,4 @@ public final class DistanceCalculator {
             return (0 < lambda && lambda < 1) && (0 < gamma && gamma < 1);
         }
     }
-
-    public static boolean lineCrossesCircle(
-            double lat1, double lon1, double lat2, double lon2, double circleLat, double circleLon, double circleRad) {
-        return (Math.abs((lat2 - lat1) * circleLon + circleLat * (lon1 - lon2)
-                + (lat1 - lat2) * lon1
-                + (lon1 - lon2) * lat1) / Math.sqrt(Math.pow((lat2 - lat1), 2)
-                + Math.pow((lon1 - lon2), 2)) <= circleRad);
-    }
-
 }

--- a/src/main/java/org/traccar/model/Event.java
+++ b/src/main/java/org/traccar/model/Event.java
@@ -49,6 +49,7 @@ public class Event extends Message {
 
     public static final String TYPE_GEOFENCE_ENTER = "geofenceEnter";
     public static final String TYPE_GEOFENCE_EXIT = "geofenceExit";
+    public static final String TYPE_GEOFENCE_CROSSED = "geofenceCrossed";
 
     public static final String TYPE_ALARM = "alarm";
 

--- a/templates/full/geofenceCrossed.vm
+++ b/templates/full/geofenceCrossed.vm
@@ -1,0 +1,10 @@
+#set($subject = "$device.name: has crossed geofence")
+<!DOCTYPE html>
+<html>
+<body>
+Device: $device.name<br>
+Has crossed geofence: $geofence.name<br>
+Time: $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)<br>
+Point: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+</body>
+</html>  

--- a/templates/short/geofenceCrossed.vm
+++ b/templates/short/geofenceCrossed.vm
@@ -1,0 +1,1 @@
+$device.name has crossed geofence $geofence.name at $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)


### PR DESCRIPTION
In repsonse to #4277 , I've added a new Event called _geofenceCrossed_.

It works separately to _geofenceEnter_ and _geofenceExit_ and simply detects if the path from the previous position to the current position crosses over a geofence, without a position being recorded in it.

This could then be used for the finish line situation, or maybe if a road cuts over the corner of a geofence, and the device only records positions either side of it for example.

![geofenceCrossed](https://user-images.githubusercontent.com/4670502/57552927-549d5900-7365-11e9-8a23-c175ee9c7943.gif)

(You can see it triggers on the circle and the line (twice), but doesn't on the polygon (which registers a position inside)

It also would need a string adding to the traccar-web locale