### PR TITLE
Fix coordinates.maxError key and coordinates.filter description

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -197,8 +197,9 @@ public final class Keys {
             "time.protocols", String.class);
 
     /**
-     * Replaces coordinates with last known if change is less than a 'coordinates.error' meters. Helps to avoid
-     * coordinates jumps during parking period.
+     * Replaces coordinates with last known if change is less than a 'coordinates.minError' meters
+     * or more than a 'coordinates.maxError' meters. Helps to avoid coordinates jumps during parking period
+     * or jumps to zero coordinates.
      */
     public static final ConfigKey COORDINATES_FILTER = new ConfigKey(
             "coordinates.filter", Boolean.class);
@@ -214,7 +215,7 @@ public final class Keys {
      * Position is also marked as 'invalid'.
      */
     public static final ConfigKey COORDINATES_MAX_ERROR = new ConfigKey(
-            "filter.maxError", Integer.class);
+            "coordinates.maxError", Integer.class);
 
     /**
      * Enable to save device IP addresses information. Disabled by default.


### PR DESCRIPTION
Hello
- Fixed `coordinates.maxError` key string
- Improved `coordinates.filter` description