### PR TITLE
Fix, rssi info is deleting when locations get from geolocation services

### DIFF
--- a/src/main/java/org/traccar/handler/GeolocationHandler.java
+++ b/src/main/java/org/traccar/handler/GeolocationHandler.java
@@ -65,7 +65,6 @@ public class GeolocationHandler extends ChannelInboundHandlerAdapter {
                         position.setAltitude(0);
                         position.setSpeed(0);
                         position.setCourse(0);
-                        position.set(Position.KEY_RSSI, 0);
                         ctx.fireChannelRead(position);
                     }
 


### PR DESCRIPTION
We losing data from device when location captured via geoservices.