### PR TITLE
Enhance Laipac protocol decoder (2)

### DIFF
--- a/src/main/java/org/traccar/BaseProtocolDecoder.java
+++ b/src/main/java/org/traccar/BaseProtocolDecoder.java
@@ -184,7 +184,9 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
         }
     }
 
-    public void getLastLocation(Position position, Date deviceTime) {
+    public boolean getLastLocation(Position position, Date deviceTime) {
+        boolean found = false;
+
         if (position.getDeviceId() != 0) {
             position.setOutdated(true);
 
@@ -198,6 +200,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
                 position.setSpeed(last.getSpeed());
                 position.setCourse(last.getCourse());
                 position.setAccuracy(last.getAccuracy());
+                found = true;
             } else {
                 position.setFixTime(new Date(0));
             }
@@ -208,6 +211,8 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
                 position.setDeviceTime(new Date());
             }
         }
+
+        return found;
     }
 
     @Override

--- a/src/main/java/org/traccar/BaseProtocolDecoder.java
+++ b/src/main/java/org/traccar/BaseProtocolDecoder.java
@@ -184,9 +184,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
         }
     }
 
-    public boolean getLastLocation(Position position, Date deviceTime) {
-        boolean found = false;
-
+    public void getLastLocation(Position position, Date deviceTime) {
         if (position.getDeviceId() != 0) {
             position.setOutdated(true);
 
@@ -200,7 +198,6 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
                 position.setSpeed(last.getSpeed());
                 position.setCourse(last.getCourse());
                 position.setAccuracy(last.getAccuracy());
-                found = true;
             } else {
                 position.setFixTime(new Date(0));
             }
@@ -211,8 +208,6 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
                 position.setDeviceTime(new Date());
             }
         }
-
-        return found;
     }
 
     @Override

--- a/src/main/java/org/traccar/model/Position.java
+++ b/src/main/java/org/traccar/model/Position.java
@@ -84,7 +84,7 @@ public class Position extends Message {
     public static final String KEY_AXLE_WEIGHT = "axleWeight";
     public static final String KEY_G_SENSOR = "gSensor";
     public static final String KEY_ICCID = "iccid";
-    public static final String KEY_PHONE_NUMBER = "phoneNumber";
+    public static final String KEY_PHONE = "phone";
 
     public static final String KEY_DTCS = "dtcs";
     public static final String KEY_OBD_SPEED = "obdSpeed"; // knots

--- a/src/main/java/org/traccar/model/Position.java
+++ b/src/main/java/org/traccar/model/Position.java
@@ -84,6 +84,7 @@ public class Position extends Message {
     public static final String KEY_AXLE_WEIGHT = "axleWeight";
     public static final String KEY_G_SENSOR = "gSensor";
     public static final String KEY_ICCID = "iccid";
+    public static final String KEY_PHONE_NUMBER = "phoneNumber";
 
     public static final String KEY_DTCS = "dtcs";
     public static final String KEY_OBD_SPEED = "obdSpeed"; // knots

--- a/src/main/java/org/traccar/protocol/LaipacProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/LaipacProtocolDecoder.java
@@ -44,9 +44,9 @@ public class LaipacProtocolDecoder extends BaseProtocolDecoder {
             .text("$EAVSYS,")
             .expression("([^,]+),")              // identifier
             .expression("([0-9]+),")             // iccid
-            .expression("(\\+?[0-9]*),")         // sim phone number
+            .expression("(\\+?[0-9]+)?,")        // sim phone number
             .expression("(?:[^,]*),")            // owner name
-            .expression("([^,]*)")               // firmware version
+            .expression("([^,]*)?")              // firmware version
             .text("*")
             .number("(xx)")                      // checksum
             .compile();
@@ -189,16 +189,8 @@ public class LaipacProtocolDecoder extends BaseProtocolDecoder {
         getLastLocation(position, null);
 
         position.set(Position.KEY_ICCID, parser.next());
-
-        String phoneNumber = parser.next();
-        if (!phoneNumber.isEmpty()) {
-            position.set(Position.KEY_PHONE_NUMBER, phoneNumber);
-        }
-
-        String firmware = parser.next();
-        if (!firmware.isEmpty()) {
-            position.set(Position.KEY_VERSION_FW, firmware);
-        }
+        position.set(Position.KEY_PHONE, parser.next());
+        position.set(Position.KEY_VERSION_FW, parser.next());
 
         return position;
     }

--- a/src/test/java/org/traccar/protocol/LaipacProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/LaipacProtocolDecoderTest.java
@@ -22,7 +22,7 @@ public class LaipacProtocolDecoderTest extends ProtocolTest {
         verifyNull(decoder, text(
                 "$AVSYS,MSG00002,14406,7046811160,64*1A"));
 
-        verifyNotNull(decoder, text(
+        verifyAttributes(decoder, text(
                 "$EAVSYS,MSG00002,8931086013104404999,,Owner,0x52014406*76"));
 
         verifyNull(decoder, text(

--- a/src/test/java/org/traccar/protocol/LaipacProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/LaipacProtocolDecoderTest.java
@@ -22,7 +22,7 @@ public class LaipacProtocolDecoderTest extends ProtocolTest {
         verifyNull(decoder, text(
                 "$AVSYS,MSG00002,14406,7046811160,64*1A"));
 
-        verifyNull(decoder, text(
+        verifyNotNull(decoder, text(
                 "$EAVSYS,MSG00002,8931086013104404999,,Owner,0x52014406*76"));
 
         verifyNull(decoder, text(


### PR DESCRIPTION
Extending Laipac protocol decoder to handle EAVSYS messages. These type of sentences can be used to get the hardware type, the firmware version and the SIM card ICCID. Tell me if you have a better idea for the first commit. Thanks.