### PR TITLE
Make optional server attributes lookup

### DIFF
--- a/src/main/java/org/traccar/BaseProtocolDecoder.java
+++ b/src/main/java/org/traccar/BaseProtocolDecoder.java
@@ -86,7 +86,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
 
     protected TimeZone getTimeZone(long deviceId, String defaultTimeZone) {
         TimeZone result = TimeZone.getTimeZone(defaultTimeZone);
-        String timeZoneName = identityManager.lookupAttributeString(deviceId, "decoder.timezone", null, true);
+        String timeZoneName = identityManager.lookupAttributeString(deviceId, "decoder.timezone", null, false, true);
         if (timeZoneName != null) {
             result = TimeZone.getTimeZone(timeZoneName);
         } else {

--- a/src/main/java/org/traccar/database/ConnectionManager.java
+++ b/src/main/java/org/traccar/database/ConnectionManager.java
@@ -157,7 +157,7 @@ public class ConnectionManager {
 
         event = Main.getInjector().getInstance(OverspeedEventHandler.class)
                 .updateOverspeedState(deviceState, Context.getDeviceManager().
-                        lookupAttributeDouble(deviceId, OverspeedEventHandler.ATTRIBUTE_SPEED_LIMIT, 0, false));
+                        lookupAttributeDouble(deviceId, OverspeedEventHandler.ATTRIBUTE_SPEED_LIMIT, 0, true, false));
         if (event != null) {
             result.putAll(event);
         }

--- a/src/main/java/org/traccar/database/DeviceManager.java
+++ b/src/main/java/org/traccar/database/DeviceManager.java
@@ -387,13 +387,12 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
                     }
                 }
             }
-            if (result == null) {
-                if (lookupConfig) {
-                    result = Context.getConfig().getString(attributeName);
-                } else if (lookupServer) {
-                    Server server = Context.getPermissionsManager().getServer();
-                    result = server.getAttributes().get(attributeName);
-                }
+            if (result == null && lookupConfig) {
+                result = Context.getConfig().getString(attributeName);
+            }
+            if (result == null && lookupServer) {
+                Server server = Context.getPermissionsManager().getServer();
+                result = server.getAttributes().get(attributeName);
             }
         }
         return result;

--- a/src/main/java/org/traccar/database/DeviceManager.java
+++ b/src/main/java/org/traccar/database/DeviceManager.java
@@ -325,7 +325,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     @Override
     public boolean lookupAttributeBoolean(
             long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
         if (result != null) {
             return result instanceof String ? Boolean.parseBoolean((String) result) : (Boolean) result;
         }
@@ -335,13 +335,13 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     @Override
     public String lookupAttributeString(
             long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
         return result != null ? (String) result : defaultValue;
     }
 
     @Override
     public int lookupAttributeInteger(long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
         if (result != null) {
             return result instanceof String ? Integer.parseInt((String) result) : ((Number) result).intValue();
         }
@@ -351,7 +351,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     @Override
     public long lookupAttributeLong(
             long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
         if (result != null) {
             return result instanceof String ? Long.parseLong((String) result) : ((Number) result).longValue();
         }
@@ -360,14 +360,14 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
     public double lookupAttributeDouble(
             long deviceId, String attributeName, double defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
         if (result != null) {
             return result instanceof String ? Double.parseDouble((String) result) : ((Number) result).doubleValue();
         }
         return defaultValue;
     }
 
-    private Object lookupAttribute(long deviceId, String attributeName, boolean lookupConfig) {
+    private Object lookupAttribute(long deviceId, String attributeName, boolean lookupServer, boolean lookupConfig) {
         Object result = null;
         Device device = getById(deviceId);
         if (device != null) {
@@ -390,7 +390,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
             if (result == null) {
                 if (lookupConfig) {
                     result = Context.getConfig().getString(attributeName);
-                } else {
+                } else if (lookupServer) {
                     Server server = Context.getPermissionsManager().getServer();
                     result = server.getAttributes().get(attributeName);
                 }

--- a/src/main/java/org/traccar/database/DeviceManager.java
+++ b/src/main/java/org/traccar/database/DeviceManager.java
@@ -324,8 +324,8 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
     @Override
     public boolean lookupAttributeBoolean(
-            long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
+            long deviceId, String attributeName, boolean defaultValue, boolean lookupServer, boolean lookupConfig) {
+        Object result = lookupAttribute(deviceId, attributeName, lookupServer, lookupConfig);
         if (result != null) {
             return result instanceof String ? Boolean.parseBoolean((String) result) : (Boolean) result;
         }
@@ -334,14 +334,15 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
     @Override
     public String lookupAttributeString(
-            long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
+            long deviceId, String attributeName, String defaultValue, boolean lookupServer, boolean lookupConfig) {
+        Object result = lookupAttribute(deviceId, attributeName, lookupServer, lookupConfig);
         return result != null ? (String) result : defaultValue;
     }
 
     @Override
-    public int lookupAttributeInteger(long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
+    public int lookupAttributeInteger(
+            long deviceId, String attributeName, int defaultValue, boolean lookupServer, boolean lookupConfig) {
+        Object result = lookupAttribute(deviceId, attributeName, lookupServer, lookupConfig);
         if (result != null) {
             return result instanceof String ? Integer.parseInt((String) result) : ((Number) result).intValue();
         }
@@ -350,8 +351,8 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
     @Override
     public long lookupAttributeLong(
-            long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
+            long deviceId, String attributeName, long defaultValue, boolean lookupServer, boolean lookupConfig) {
+        Object result = lookupAttribute(deviceId, attributeName, lookupServer, lookupConfig);
         if (result != null) {
             return result instanceof String ? Long.parseLong((String) result) : ((Number) result).longValue();
         }
@@ -359,8 +360,8 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     }
 
     public double lookupAttributeDouble(
-            long deviceId, String attributeName, double defaultValue, boolean lookupConfig) {
-        Object result = lookupAttribute(deviceId, attributeName, true, lookupConfig);
+            long deviceId, String attributeName, double defaultValue, boolean lookupServer, boolean lookupConfig) {
+        Object result = lookupAttribute(deviceId, attributeName, lookupServer, lookupConfig);
         if (result != null) {
             return result instanceof String ? Double.parseDouble((String) result) : ((Number) result).doubleValue();
         }
@@ -387,12 +388,12 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
                     }
                 }
             }
-            if (result == null && lookupConfig) {
-                result = Context.getConfig().getString(attributeName);
-            }
             if (result == null && lookupServer) {
                 Server server = Context.getPermissionsManager().getServer();
                 result = server.getAttributes().get(attributeName);
+            }
+            if (result == null && lookupConfig) {
+                result = Context.getConfig().getString(attributeName);
             }
         }
         return result;

--- a/src/main/java/org/traccar/database/IdentityManager.java
+++ b/src/main/java/org/traccar/database/IdentityManager.java
@@ -32,14 +32,19 @@ public interface IdentityManager {
 
     boolean isLatestPosition(Position position);
 
-    boolean lookupAttributeBoolean(long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig);
+    boolean lookupAttributeBoolean(
+            long deviceId, String attributeName, boolean defaultValue, boolean lookupServer, boolean lookupConfig);
 
-    String lookupAttributeString(long deviceId, String attributeName, String defaultValue, boolean lookupConfig);
+    String lookupAttributeString(
+            long deviceId, String attributeName, String defaultValue, boolean lookupServer, boolean lookupConfig);
 
-    int lookupAttributeInteger(long deviceId, String attributeName, int defaultValue, boolean lookupConfig);
+    int lookupAttributeInteger(
+            long deviceId, String attributeName, int defaultValue, boolean lookupServer, boolean lookupConfig);
 
-    long lookupAttributeLong(long deviceId, String attributeName, long defaultValue, boolean lookupConfig);
+    long lookupAttributeLong(
+            long deviceId, String attributeName, long defaultValue, boolean lookupServer, boolean lookupConfig);
 
-    double lookupAttributeDouble(long deviceId, String attributeName, double defaultValue, boolean lookupConfig);
+    double lookupAttributeDouble(
+            long deviceId, String attributeName, double defaultValue, boolean lookupServer, boolean lookupConfig);
 
 }

--- a/src/main/java/org/traccar/handler/CopyAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/CopyAttributesHandler.java
@@ -33,7 +33,7 @@ public class CopyAttributesHandler extends BaseDataHandler {
     @Override
     protected Position handlePosition(Position position) {
         String attributesString = identityManager.lookupAttributeString(
-                position.getDeviceId(), "processing.copyAttributes", "", true);
+                position.getDeviceId(), "processing.copyAttributes", "", false, true);
         if (attributesString.isEmpty()) {
             attributesString = Position.KEY_DRIVER_UNIQUE_ID;
         } else {

--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -130,7 +130,7 @@ public class FilterHandler extends BaseDataHandler {
     private boolean skipAttributes(Position position) {
         if (skipAttributes) {
             String attributesString = Context.getIdentityManager().lookupAttributeString(
-                    position.getDeviceId(), "filter.skipAttributes", "", true);
+                    position.getDeviceId(), "filter.skipAttributes", "", false, true);
             for (String attribute : attributesString.split("[ ,]")) {
                 if (position.getAttributes().containsKey(attribute)) {
                     return true;

--- a/src/main/java/org/traccar/handler/events/FuelDropEventHandler.java
+++ b/src/main/java/org/traccar/handler/events/FuelDropEventHandler.java
@@ -47,7 +47,7 @@ public class FuelDropEventHandler extends BaseEventHandler {
         }
 
         double fuelDropThreshold = identityManager
-                .lookupAttributeDouble(device.getId(), ATTRIBUTE_FUEL_DROP_THRESHOLD, 0, false);
+                .lookupAttributeDouble(device.getId(), ATTRIBUTE_FUEL_DROP_THRESHOLD, 0, true, false);
 
         if (fuelDropThreshold > 0) {
             Position lastPosition = identityManager.getLastPosition(position.getDeviceId());

--- a/src/main/java/org/traccar/handler/events/OverspeedEventHandler.java
+++ b/src/main/java/org/traccar/handler/events/OverspeedEventHandler.java
@@ -120,7 +120,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
             return null;
         }
 
-        double speedLimit = deviceManager.lookupAttributeDouble(deviceId, ATTRIBUTE_SPEED_LIMIT, 0, false);
+        double speedLimit = deviceManager.lookupAttributeDouble(deviceId, ATTRIBUTE_SPEED_LIMIT, 0, true, false);
 
         double geofenceSpeedLimit = 0;
         long overspeedGeofenceId = 0;

--- a/src/main/java/org/traccar/protocol/Gt06ProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolEncoder.java
@@ -33,7 +33,8 @@ public class Gt06ProtocolEncoder extends BaseProtocolEncoder {
 
     private ByteBuf encodeContent(long deviceId, String content) {
 
-        boolean language = Context.getIdentityManager().lookupAttributeBoolean(deviceId, "gt06.language", false, true);
+        boolean language = Context.getIdentityManager()
+            .lookupAttributeBoolean(deviceId, "gt06.language", false, false, true);
 
         ByteBuf buf = Unpooled.buffer();
 
@@ -66,7 +67,7 @@ public class Gt06ProtocolEncoder extends BaseProtocolEncoder {
     protected Object encodeCommand(Command command) {
 
         boolean alternative = Context.getIdentityManager().lookupAttributeBoolean(
-                command.getDeviceId(), "gt06.alternative", false, true);
+                command.getDeviceId(), "gt06.alternative", false, false, true);
 
         switch (command.getType()) {
             case Command.TYPE_ENGINE_STOP:

--- a/src/main/java/org/traccar/protocol/H02ProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolEncoder.java
@@ -60,7 +60,7 @@ public class H02ProtocolEncoder extends StringProtocolEncoder {
             case Command.TYPE_POSITION_PERIODIC:
                 String frequency = command.getAttributes().get(Command.KEY_FREQUENCY).toString();
                 if (Context.getIdentityManager().lookupAttributeBoolean(
-                        command.getDeviceId(), "h02.alternative", false, true)) {
+                        command.getDeviceId(), "h02.alternative", false, false, true)) {
                     return formatCommand(time, uniqueId, "D1", frequency);
                 } else {
                     return formatCommand(time, uniqueId, "S71", "22", frequency);

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
@@ -36,7 +36,7 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
     protected Object encodeCommand(Command command) {
 
         boolean alternative = Context.getIdentityManager().lookupAttributeBoolean(
-                command.getDeviceId(), "huabao.alternative", false, true);
+                command.getDeviceId(), "huabao.alternative", false, false, true);
 
         ByteBuf id = Unpooled.wrappedBuffer(
                 DataConverter.parseHex(getUniqueId(command.getDeviceId())));

--- a/src/main/java/org/traccar/protocol/MeitrackProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/MeitrackProtocolEncoder.java
@@ -43,7 +43,7 @@ public class MeitrackProtocolEncoder extends StringProtocolEncoder {
         Map<String, Object> attributes = command.getAttributes();
 
         boolean alternative = Context.getIdentityManager().lookupAttributeBoolean(
-                command.getDeviceId(), "meitrack.alternative", false, true);
+                command.getDeviceId(), "meitrack.alternative", false, false, true);
 
         switch (command.getType()) {
             case Command.TYPE_POSITION_SINGLE:

--- a/src/main/java/org/traccar/protocol/SuntechProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/SuntechProtocolDecoder.java
@@ -50,7 +50,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
 
     public int getProtocolType(long deviceId) {
         return Context.getIdentityManager().lookupAttributeInteger(
-                deviceId, getProtocolName() + ".protocolType", protocolType, true);
+                deviceId, getProtocolName() + ".protocolType", protocolType, false, true);
     }
 
     public void setHbm(boolean hbm) {
@@ -59,7 +59,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
 
     public boolean isHbm(long deviceId) {
         return Context.getIdentityManager().lookupAttributeBoolean(
-                deviceId, getProtocolName() + ".hbm", hbm, true);
+                deviceId, getProtocolName() + ".hbm", hbm, false, true);
     }
 
     public void setIncludeAdc(boolean includeAdc) {
@@ -68,7 +68,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
 
     public boolean isIncludeAdc(long deviceId) {
         return Context.getIdentityManager().lookupAttributeBoolean(
-                deviceId, getProtocolName() + ".includeAdc", includeAdc, true);
+                deviceId, getProtocolName() + ".includeAdc", includeAdc, false, true);
     }
 
     public void setIncludeRpm(boolean includeRpm) {
@@ -77,7 +77,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
 
     public boolean isIncludeRpm(long deviceId) {
         return Context.getIdentityManager().lookupAttributeBoolean(
-                deviceId, getProtocolName() + ".includeRpm", includeRpm, true);
+                deviceId, getProtocolName() + ".includeRpm", includeRpm, false, true);
     }
 
     public void setIncludeTemp(boolean includeTemp) {
@@ -86,7 +86,7 @@ public class SuntechProtocolDecoder extends BaseProtocolDecoder {
 
     public boolean isIncludeTemp(long deviceId) {
         return Context.getIdentityManager().lookupAttributeBoolean(
-                deviceId, getProtocolName() + ".includeTemp", includeTemp, true);
+                deviceId, getProtocolName() + ".includeTemp", includeTemp, false, true);
     }
 
     private Position decode9(

--- a/src/main/java/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/T55ProtocolDecoder.java
@@ -103,7 +103,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
         if (deviceSession != null && channel != null && !(channel instanceof DatagramChannel)
                 && Context.getIdentityManager().lookupAttributeBoolean(
-                        deviceSession.getDeviceId(), getProtocolName() + ".ack", false, true)) {
+                        deviceSession.getDeviceId(), getProtocolName() + ".ack", false, false, true)) {
             channel.writeAndFlush(new NetworkMessage("OK1\r\n", remoteAddress));
         }
 

--- a/src/main/java/org/traccar/protocol/Tk103ProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/Tk103ProtocolEncoder.java
@@ -43,7 +43,7 @@ public class Tk103ProtocolEncoder extends StringProtocolEncoder {
     protected Object encodeCommand(Command command) {
 
         boolean alternative = forceAlternative || Context.getIdentityManager().lookupAttributeBoolean(
-                command.getDeviceId(), "tk103.alternative", false, true);
+                command.getDeviceId(), "tk103.alternative", false, false, true);
 
         initDevicePassword(command, "123456");
 

--- a/src/main/java/org/traccar/reports/Stops.java
+++ b/src/main/java/org/traccar/reports/Stops.java
@@ -43,7 +43,7 @@ public final class Stops {
 
     private static Collection<StopReport> detectStops(long deviceId, Date from, Date to) throws SQLException {
         boolean ignoreOdometer = Context.getDeviceManager()
-                .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, true);
+                .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, false, true);
 
         IdentityManager identityManager = Main.getInjector().getInstance(IdentityManager.class);
         DeviceManager deviceManager = Main.getInjector().getInstance(DeviceManager.class);

--- a/src/main/java/org/traccar/reports/Summary.java
+++ b/src/main/java/org/traccar/reports/Summary.java
@@ -61,7 +61,7 @@ public final class Summary {
                 result.setMaxSpeed(position.getSpeed());
             }
             boolean ignoreOdometer = Context.getDeviceManager()
-                    .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, true);
+                    .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, false, true);
             result.setDistance(ReportUtils.calculateDistance(firstPosition, previousPosition, !ignoreOdometer));
             result.setAverageSpeed(speedSum / positions.size());
             result.setSpentFuel(ReportUtils.calculateFuel(firstPosition, previousPosition));

--- a/src/main/java/org/traccar/reports/Trips.java
+++ b/src/main/java/org/traccar/reports/Trips.java
@@ -42,7 +42,7 @@ public final class Trips {
 
     private static Collection<TripReport> detectTrips(long deviceId, Date from, Date to) throws SQLException {
         boolean ignoreOdometer = Context.getDeviceManager()
-                .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, true);
+                .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, false, true);
 
         IdentityManager identityManager = Main.getInjector().getInstance(IdentityManager.class);
         DeviceManager deviceManager = Main.getInjector().getInstance(DeviceManager.class);

--- a/src/test/java/org/traccar/TestIdentityManager.java
+++ b/src/test/java/org/traccar/TestIdentityManager.java
@@ -46,31 +46,31 @@ public final class TestIdentityManager implements IdentityManager {
 
     @Override
     public boolean lookupAttributeBoolean(
-            long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
+            long deviceId, String attributeName, boolean defaultValue, boolean lookupServer, boolean lookupConfig) {
         return defaultValue;
     }
 
     @Override
     public String lookupAttributeString(
-            long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
+            long deviceId, String attributeName, String defaultValue, boolean lookupServer, boolean lookupConfig) {
         return "alarm,result";
     }
 
     @Override
     public int lookupAttributeInteger(
-            long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
+            long deviceId, String attributeName, int defaultValue, boolean lookupServer, boolean lookupConfig) {
         return defaultValue;
     }
 
     @Override
     public long lookupAttributeLong(
-            long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
+            long deviceId, String attributeName, long defaultValue, boolean lookupServer, boolean lookupConfig) {
         return defaultValue;
     }
 
     @Override
     public double lookupAttributeDouble(
-            long deviceId, String attributeName, double defaultValue, boolean lookupConfig) {
+            long deviceId, String attributeName, double defaultValue, boolean lookupServer, boolean lookupConfig) {
         return defaultValue;
     }
 


### PR DESCRIPTION
Make optional the server-wide attributes lookup. It's already avoided when a lookup up is performed on the configuration file, I'm keeping it that way...