### PR TITLE
Add an optional queue to web data handler

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -378,7 +378,7 @@ public class MainModule extends AbstractModule {
 
     @Singleton
     @Provides
-    public static Timer provideGlobalTimer() {
+    public static Timer provideTimer() {
         return GlobalTimer.getTimer();
     }
 

--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -73,6 +73,7 @@ import org.traccar.reports.model.TripsConfig;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.client.Client;
+import io.netty.util.Timer;
 
 public class MainModule extends AbstractModule {
 
@@ -373,6 +374,12 @@ public class MainModule extends AbstractModule {
     @Provides
     public static DriverEventHandler provideDriverEventHandler(IdentityManager identityManager) {
         return new DriverEventHandler(identityManager);
+    }
+
+    @Singleton
+    @Provides
+    public static Timer provideGlobalTimer() {
+        return GlobalTimer.getTimer();
     }
 
     @Override

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -104,23 +104,22 @@ public final class Keys {
      * Position forwarding retrying enable. When enabled, additional attempts are made to deliver positions.
      * If initial delivery fails, because of an unreachable server or an HTTP response different from '200 OK',
      * the software waits for 'forward.retry.delay.min' seconds to retry delivery. On subsequent failures, this
-     * delay is incremented by 1 second up to 'forward.retry.delay.max'. On successful delivery, the delay is reset
-     * to 'forward.retry.delay.min'. Pending positions to be delivered are limited to 'forward.retry.pending.limit'.
-     * If this limit is reached, positions are discarded before next retry.
+     * delay is incremented by 1 second up to 'forward.retry.delay.max'. Positions pending to be delivered
+     * are limited to 'forward.retry.pending.limit'. If this limit is reached, positions get discarded.
      */
     public static final ConfigKey FORWARD_RETRY_ENABLE = new ConfigKey(
             "forward.retry.enable", Boolean.class);
 
     /**
      * Position forwarding retry minimum delay in seconds.
-     * Can be set to anything between 1 and 3600 seconds. Defaults to 1 second.
+     * Can be set to anything greater than 0. Defaults to 1 second.
      */
     public static final ConfigKey FORWARD_RETRY_DELAY_MIN = new ConfigKey(
             "forward.retry.delay.min", Integer.class);
 
     /**
      * Position forwarding retry maximum delay in seconds.
-     * Can be set to anything between 1 and 3600 seconds. Defaults to 10 seconds.
+     * Can be set to anything greater than 0. Defaults to 10 seconds.
      */
     public static final ConfigKey FORWARD_RETRY_DELAY_MAX = new ConfigKey(
             "forward.retry.delay.max", Integer.class);

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -101,6 +101,13 @@ public final class Keys {
             "forward.json", Boolean.class);
 
     /**
+     * Position forwarding queue size. A ring buffer of the specified size is used to queue positions.
+     * If negative, zero, or not specified, queueing is disabled. (Legacy behaviour)
+     */
+    public static final ConfigKey FORWARD_QUEUE_SIZE = new ConfigKey(
+            "forward.queue.size", Integer.class);
+
+    /**
      * Boolean flag to enable or disable position filtering.
      */
     public static final ConfigKey FILTER_ENABLE = new ConfigKey(

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -108,6 +108,13 @@ public final class Keys {
             "forward.queue.size", Integer.class);
 
     /**
+     * Position forwarding queue concurrency. Defines how many HTTP requests can be pending at any time.
+     * If queueing is enabled, and this value is less than one, it's ignored and forced to be one.
+     */
+    public static final ConfigKey FORWARD_QUEUE_CONCURRENCY = new ConfigKey(
+            "forward.queue.concurrency", Integer.class);
+
+    /**
      * Boolean flag to enable or disable position filtering.
      */
     public static final ConfigKey FILTER_ENABLE = new ConfigKey(

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -103,7 +103,7 @@ public final class Keys {
     /**
      * Position forwarding retrying enable. When enabled, additional attempts are made to deliver positions.
      * If initial delivery fails, because of an unreachable server or an HTTP response different from '200 OK',
-     * the software waits for 'forward.retry.delay.min' seconds to retry delivery. On subsecuent failures, this
+     * the software waits for 'forward.retry.delay.min' seconds to retry delivery. On subsequent failures, this
      * delay is incremented by 1 second up to 'forward.retry.delay.max'. On successful delivery, the delay is reset
      * to 'forward.retry.delay.min'. Pending positions to be delivered are limited to 'forward.retry.pending.limit'.
      * If this limit is reached, positions are discarded before next retry.

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -101,35 +101,35 @@ public final class Keys {
             "forward.json", Boolean.class);
 
     /**
-     * Position forwarding retrying enable. When enabled, additional attempts are made to deliver positions.
-     * If initial delivery fails, because of an unreachable server or an HTTP response different from '200 OK',
-     * the software waits for 'forward.retry.delay.min' seconds to retry delivery. On subsequent failures, this
-     * delay is incremented by 1 second up to 'forward.retry.delay.max'. Positions pending to be delivered
-     * are limited to 'forward.retry.pending.limit'. If this limit is reached, positions get discarded.
+     * Position forwarding retrying enable. When enabled, additional attempts are made to deliver positions. If initial
+     * delivery fails, because of an unreachable server or an HTTP response different from '2xx', the software waits
+     * for 'forward.retry.delay' milliseconds to retry delivery. On subsequent failures, this delay is duplicated.
+     * If forwarding is retried for 'forward.retry.count', retrying is canceled and the position is dropped. Positions
+     * pending to be delivered are limited to 'forward.retry.limit'. If this limit is reached, positions get discarded.
      */
     public static final ConfigKey FORWARD_RETRY_ENABLE = new ConfigKey(
             "forward.retry.enable", Boolean.class);
 
     /**
-     * Position forwarding retry minimum delay in seconds.
-     * Can be set to anything greater than 0. Defaults to 1 second.
+     * Position forwarding retry first delay in milliseconds.
+     * Can be set to anything greater than 0. Defaults to 100 milliseconds.
      */
-    public static final ConfigKey FORWARD_RETRY_DELAY_MIN = new ConfigKey(
-            "forward.retry.delay.min", Integer.class);
+    public static final ConfigKey FORWARD_RETRY_DELAY = new ConfigKey(
+            "forward.retry.delay", Integer.class);
 
     /**
-     * Position forwarding retry maximum delay in seconds.
-     * Can be set to anything greater than 0. Defaults to 10 seconds.
+     * Position forwarding retry maximum retries.
+     * Can be set to anything greater than 0. Defaults to 10 retries.
      */
-    public static final ConfigKey FORWARD_RETRY_DELAY_MAX = new ConfigKey(
-            "forward.retry.delay.max", Integer.class);
+    public static final ConfigKey FORWARD_RETRY_COUNT = new ConfigKey(
+            "forward.retry.count", Integer.class);
 
     /**
-     * Position forwarding retry pending limit.
+     * Position forwarding retry pending positions limit.
      * Can be set to anything greater than 0. Defaults to 100 positions.
      */
-    public static final ConfigKey FORWARD_RETRY_PENDING_LIMIT = new ConfigKey(
-            "forward.retry.pending.limit", Integer.class);
+    public static final ConfigKey FORWARD_RETRY_LIMIT = new ConfigKey(
+            "forward.retry.limit", Integer.class);
 
     /**
      * Boolean flag to enable or disable position filtering.

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -101,18 +101,36 @@ public final class Keys {
             "forward.json", Boolean.class);
 
     /**
-     * Position forwarding queue size. A ring buffer of the specified size is used to queue positions.
-     * If negative, zero, or not specified, queueing is disabled. (Legacy behaviour)
+     * Position forwarding retrying enable. When enabled, additional attempts are made to deliver positions.
+     * If initial delivery fails, because of an unreachable server or an HTTP response different from '200 OK',
+     * the software waits for 'forward.retry.delay.min' seconds to retry delivery. On subsecuent failures, this
+     * delay is incremented by 1 second up to 'forward.retry.delay.max'. On successful delivery, the delay is reset
+     * to 'forward.retry.delay.min'. Pending positions to be delivered are limited to 'forward.retry.pending.limit'.
+     * If this limit is reached, positions are discarded before next retry.
      */
-    public static final ConfigKey FORWARD_QUEUE_SIZE = new ConfigKey(
-            "forward.queue.size", Integer.class);
+    public static final ConfigKey FORWARD_RETRY_ENABLE = new ConfigKey(
+            "forward.retry.enable", Boolean.class);
 
     /**
-     * Position forwarding queue concurrency. Defines how many HTTP requests can be pending at any time.
-     * If queueing is enabled, and this value is less than one, it's ignored and forced to be one.
+     * Position forwarding retry minimum delay in seconds.
+     * Can be set to anything between 1 and 3600 seconds. Defaults to 1 second.
      */
-    public static final ConfigKey FORWARD_QUEUE_CONCURRENCY = new ConfigKey(
-            "forward.queue.concurrency", Integer.class);
+    public static final ConfigKey FORWARD_RETRY_DELAY_MIN = new ConfigKey(
+            "forward.retry.delay.min", Integer.class);
+
+    /**
+     * Position forwarding retry maximum delay in seconds.
+     * Can be set to anything between 1 and 3600 seconds. Defaults to 10 seconds.
+     */
+    public static final ConfigKey FORWARD_RETRY_DELAY_MAX = new ConfigKey(
+            "forward.retry.delay.max", Integer.class);
+
+    /**
+     * Position forwarding retry pending limit.
+     * Can be set to anything greater than 0. Defaults to 100 positions.
+     */
+    public static final ConfigKey FORWARD_RETRY_PENDING_LIMIT = new ConfigKey(
+            "forward.retry.pending.limit", Integer.class);
 
     /**
      * Boolean flag to enable or disable position filtering.


### PR DESCRIPTION
Added an optional (configurable) queue, actually a ring buffer, to forwarded positions in web data handler. The size of the queue can be specified in the configuration file. If the queue is enabled, HTTP responses needs to be 200 OK to get positions removed from the queue. I'm planning to do the same with event forwarding.
Waiting for comments...
Thanks. 