### PR TITLE
Adds JC100 camera alarms

### DIFF
--- a/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
@@ -300,6 +300,17 @@ public class Gt06ProtocolDecoderTest extends ProtocolTest {
         verifyNull(decoder, binary(
                 "7878058A000688290D0A"));
 
+        verifyAttribute(decoder, binary(
+                "78780c95130a0209321c90000112800d0a"),
+                Position.KEY_ALARM, Position.ALARM_ACCELERATION);
+
+        verifyAttribute(decoder, binary(
+                "78780c95130a0209321c90000112800d0a"),
+                "alarmValue", 1);
+
+        verifyAttribute(decoder, binary(
+                "78780c95130a0209321c91000112800d0a"),
+                Position.KEY_ALARM, Position.ALARM_BRAKING);
     }
 
 }


### PR DESCRIPTION
Adds JC100 camera alarms as described in [document](https://www.dropbox.com/s/gysbq0mgugri01u/20170830%20Communication%20Protocol%20of%20JC100.pdf?dl=0), linked from a [traccar support forum topic](https://www.traccar.org/forums/topic/jc100-image-and-video-protocol/).

The camera communicates using *gt06* protocol but the alerts differ from what has been already implemented in `Gt06ProtocolDecoder` in traccar server.