### PR TITLE
Allow the URL of an OpenCellId like service to be set via configuration.

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -192,6 +192,8 @@ public class MainModule extends AbstractModule {
                     return new GoogleGeolocationProvider(key);
                 case "opencellid":
                     return new OpenCellIdGeolocationProvider(key);
+                case "opencellid-standalone":
+                    return new OpenCellIdGeolocationProvider(url, key);
                 case "unwired":
                     return new UnwiredGeolocationProvider(url, key);
                 default:


### PR DESCRIPTION
Added a new type of geolocation named "opencellid-standalone" which allows a user to pass in an OpenCellId like URL via the configuration in order to dictate the end point to use. This flexibility enables users to have an alternative host for this service.