### PR TITLE
The Central Repository no longer supports plain http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,32 @@
         <jackson.version>2.9.9</jackson.version> <!-- same version as jersey-media-json-jackson dependency -->
         <protobuf.version>3.11.1</protobuf.version>
     </properties>
+    
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
… insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS