### PR TITLE
Feature/filter users by id

### DIFF
--- a/src/main/java/org/traccar/api/resource/UserResource.java
+++ b/src/main/java/org/traccar/api/resource/UserResource.java
@@ -46,13 +46,20 @@ public class UserResource extends BaseObjectResource<User> {
     }
 
     @GET
-    public Collection<User> get(@QueryParam("userId") long userId) throws SQLException {
+    public Collection<User> get(
+            @QueryParam("userId") long userId,
+            @QueryParam("id") Set<Long> ids
+    ) throws SQLException {
         UsersManager usersManager = Context.getUsersManager();
         Set<Long> result = null;
         if (Context.getPermissionsManager().getUserAdmin(getUserId())) {
             if (userId != 0) {
                 result = usersManager.getUserItems(userId);
             } else {
+                if(ids.size() > 0) {
+                    Set<Long> userIds = usersManager.getUserItemsByIds(ids);
+                    return usersManager.getItems(userIds);
+                }
                 result = usersManager.getAllItems();
             }
         } else if (Context.getPermissionsManager().getUserManager(getUserId())) {

--- a/src/main/java/org/traccar/database/UsersManager.java
+++ b/src/main/java/org/traccar/database/UsersManager.java
@@ -16,11 +16,12 @@
  */
 package org.traccar.database;
 
+import org.traccar.model.User;
+
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.traccar.model.User;
 
 public class UsersManager extends SimpleObjectManager<User> {
 
@@ -77,8 +78,18 @@ public class UsersManager extends SimpleObjectManager<User> {
         return result;
     }
 
+    public Set<Long> getUserItemsByIds(Set<Long> ids) {
+        Set<Long> result = new HashSet<>();
+        for (Long userId : ids) {
+            User cachedUser = getById(userId);
+            if (cachedUser != null) {
+                result.add(cachedUser.getId());
+            }
+        }
+        return result;
+    }
+
     public User getUserByToken(String token) {
         return usersTokens.get(token);
     }
-
 }


### PR DESCRIPTION
Creates a way for REST API's using admin tokens on /user endpoint to retrieve one or many users by id and also hooks into existing caching system.

This PR adds a new method to UserManager for validating a set of longs and then some extra logic within UserResource to return the expected result, i am making use of some available methods here too.

Usage for example `http://localhost:8082/api/users?id=1&id=33`