### PR TITLE
Simplistic get user by id method with permission checks and strip null devices from response

### DIFF
--- a/src/main/java/org/traccar/api/resource/UserResource.java
+++ b/src/main/java/org/traccar/api/resource/UserResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.sql.SQLException;
@@ -43,6 +44,28 @@ public class UserResource extends BaseObjectResource<User> {
 
     public UserResource() {
         super(User.class);
+    }
+
+    @GET
+    @Path("{id}")
+    public User getById(@PathParam("id") long id) {
+        UsersManager usersManager = Context.getUsersManager();
+        User user = null;
+
+        if (Context.getPermissionsManager().getUserAdmin(getUserId())) {
+            user = usersManager.getById(id);
+        }
+
+        if (Context.getPermissionsManager().getUserManager(getUserId())) {
+            Context.getPermissionsManager().checkManager(getUserId(), id);
+            user = usersManager.getById(id);
+        }
+
+        if(id == getUserId()) {
+            user = usersManager.getById(id);
+        }
+
+        return user;
     }
 
     @GET

--- a/src/main/java/org/traccar/database/BaseObjectManager.java
+++ b/src/main/java/org/traccar/database/BaseObjectManager.java
@@ -158,7 +158,10 @@ public class BaseObjectManager<T extends BaseModel> {
     public final Collection<T> getItems(Set<Long> itemIds) {
         Collection<T> result = new LinkedList<>();
         for (long itemId : itemIds) {
-            result.add(getById(itemId));
+            T item = getById(itemId);
+            if (item != null) {
+                result.add(item);
+            }
         }
         return result;
     }
@@ -171,5 +174,4 @@ public class BaseObjectManager<T extends BaseModel> {
             readUnlock();
         }
     }
-
 }


### PR DESCRIPTION
This should solve what i mean about user filtering and being able to load data on a one to one basis from other back ends with the admin tokens

I also noticed when passing &id=1&id=2 to /api/devices it would return 2 as null as it does not exist, this may as well be removed from the response