### PR TITLE
Ensure item is not null before adding to the collection  in getItems

### DIFF
--- a/src/main/java/org/traccar/database/BaseObjectManager.java
+++ b/src/main/java/org/traccar/database/BaseObjectManager.java
@@ -158,7 +158,10 @@ public class BaseObjectManager<T extends BaseModel> {
     public final Collection<T> getItems(Set<Long> itemIds) {
         Collection<T> result = new LinkedList<>();
         for (long itemId : itemIds) {
-            result.add(getById(itemId));
+            T item = getById(itemId);
+            if (item != null) {
+                result.add(item);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Noticed that if you use the id parameter and pass an item  that does not exist null items are also returned in the response array when enriching devices. This PR ensures an item is not null before adding into the collection 

