### PR TITLE
Update Freematics API

### DIFF
--- a/src/main/java/org/traccar/protocol/FreematicsProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/FreematicsProtocolDecoder.java
@@ -134,6 +134,9 @@ public class FreematicsProtocolDecoder extends BaseProtocolDecoder {
                 case 0xF:
                     position.set(Position.KEY_SATELLITES, Integer.parseInt(value));
                     break;
+                case 0x12:
+                    position.set(Position.KEY_HDOP, Integer.parseInt(value));
+                    break;
                 case 0x20:
                     position.set(Position.KEY_ACCELERATION, value);
                     break;
@@ -146,8 +149,23 @@ public class FreematicsProtocolDecoder extends BaseProtocolDecoder {
                 case 0x82:
                     position.set(Position.KEY_DEVICE_TEMP, Integer.parseInt(value) * 0.1);
                     break;
+                case 0x104:
+                    position.set(Position.KEY_ENGINE_LOAD, Integer.parseInt(value));
+                    break;
+                case 0x105:
+                    position.set(Position.KEY_COOLANT_TEMP, Integer.parseInt(value));
+                    break;
+                case 0x10c:
+                    position.set(Position.KEY_RPM, Integer.parseInt(value));
+                    break;
+                case 0x10d:
+                    position.set(Position.KEY_OBD_SPEED, UnitsConverter.knotsFromKph(Integer.parseInt(value)));
+                    break;
+                case 0x111:
+                    position.set(Position.KEY_THROTTLE, Integer.parseInt(value));
+                    break;
                 default:
-                    position.set(data[0], value);
+                    position.set(Position.PREFIX_IO + data[0], value);
                     break;
             }
         }


### PR DESCRIPTION
Added support for standard PIDs returned by Freematics firmware. Prefixed all other PID attributes to maintain compatibility with JEXL.