### PR TITLE
Add AutoNavi  Geocoder

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -43,6 +43,7 @@ import org.traccar.geocoder.MapQuestGeocoder;
 import org.traccar.geocoder.MapmyIndiaGeocoder;
 import org.traccar.geocoder.NominatimGeocoder;
 import org.traccar.geocoder.OpenCageGeocoder;
+import org.traccar.geocoder.AutoNaviGeocoder;
 import org.traccar.geolocation.GeolocationProvider;
 import org.traccar.geolocation.GoogleGeolocationProvider;
 import org.traccar.geolocation.MozillaGeolocationProvider;
@@ -160,6 +161,8 @@ public class MainModule extends AbstractModule {
                     return new MapQuestGeocoder(url, key, cacheSize, addressFormat);
                 case "opencage":
                     return new OpenCageGeocoder(url, key, cacheSize, addressFormat);
+                case "autonavi":
+                    return new AutoNaviGeocoder(url, key, cacheSize, addressFormat);
                 case "bingmaps":
                     return new BingMapsGeocoder(url, key, cacheSize, addressFormat);
                 case "factual":

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -353,6 +353,13 @@ public final class Keys {
      */
     public static final ConfigKey GEOCODER_REUSE_DISTANCE = new ConfigKey(
             "geocoder.reuseDistance", Integer.class);
+    /**
+     * Boolean flag to apply reverse location. 
+     * Traccar's default locatin is "latitude,longitude", but some Geolocation Provider is "longitude, latitude".
+     * Such as AutoNavi. Default value is false.
+     */
+    public static final ConfigKey GEOCODER_REQUEST_LOCATION_REVERSE= new ConfigKey(
+            "geocoder.requestLocationReverse", Boolean.class);
 
     /**
      * Boolean flag to enable LBS location resolution. Some devices send cell towers information and WiFi point when GPS

--- a/src/main/java/org/traccar/geocoder/AutoNaviGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/AutoNaviGeocoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Mac Zhou (mac_zhou@live.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.geocoder;
+
+import javax.json.JsonObject;
+
+public class AutoNaviGeocoder extends JsonGeocoder {
+
+    private static String formatUrl(String url, String key) {
+        if (url == null) {
+            url = "https://restapi.amap.com/v3/geocode/regeo";
+        }
+        url += "?output=json&location=%f,%f&key=" + key;
+        return url;
+    }
+
+    public AutoNaviGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
+        super(formatUrl(url, key), cacheSize, addressFormat);
+    }
+
+    @Override
+    public Address parseAddress(JsonObject json) {
+        JsonObject regeocode = json.getJsonObject("regeocode");
+        if (regeocode != null) {
+            JsonObject addressComponent = regeocode.getJsonObject("addressComponent");
+            if (addressComponent != null) {
+                Address address = new Address();
+
+                if (regeocode.containsKey("formatted_address")) {
+                    address.setFormattedAddress(regeocode.getString("formatted_address"));
+                }
+                if (addressComponent.containsKey("district")) {
+                    address.setDistrict(addressComponent.getString("district"));
+                }
+                if (addressComponent.containsKey("city")) {
+                    address.setSettlement(addressComponent.getString("city"));
+                }
+                if (addressComponent.containsKey("province")) {
+                    address.setState(addressComponent.getString("province"));
+                }
+                if (addressComponent.containsKey("country")) {
+                    address.setCountry(addressComponent.getString("country"));
+                }
+
+                return address;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/traccar/geocoder/JsonGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/JsonGeocoder.java
@@ -27,6 +27,7 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.traccar.config.Keys;
 
 public abstract class JsonGeocoder implements Geocoder {
 
@@ -34,12 +35,14 @@ public abstract class JsonGeocoder implements Geocoder {
 
     private final String url;
     private final AddressFormat addressFormat;
+    private final boolean requestLocationReverse;
 
     private Map<Map.Entry<Double, Double>, String> cache;
 
     public JsonGeocoder(String url, final int cacheSize, AddressFormat addressFormat) {
         this.url = url;
         this.addressFormat = addressFormat;
+        requestLocationReverse = Context.getConfig().getBoolean(Keys.GEOCODER_REQUEST_LOCATION_REVERSE);
         if (cacheSize > 0) {
             this.cache = Collections.synchronizedMap(new LinkedHashMap<Map.Entry<Double, Double>, String>() {
                 @Override
@@ -89,12 +92,9 @@ public abstract class JsonGeocoder implements Geocoder {
         }
 
         String urlFormat = String.format(url, latitude, longitude);
-        // The AutoNavi web API(V4.2.0)'s location Must Format "longitude,latitude".
-        boolean isAutoNavi = url.contains("restapi.amap.com/v3/geocode/regeo");
-        if (isAutoNavi){
+        if (requestLocationReverse){
             urlFormat = String.format(url, longitude, latitude);
-        }
-
+        } 
         Invocation.Builder request = Context.getClient().target(urlFormat).request();
 
         if (callback != null) {

--- a/src/main/java/org/traccar/geocoder/JsonGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/JsonGeocoder.java
@@ -88,7 +88,14 @@ public abstract class JsonGeocoder implements Geocoder {
             }
         }
 
-        Invocation.Builder request = Context.getClient().target(String.format(url, latitude, longitude)).request();
+        String urlFormat = String.format(url, latitude, longitude);
+        // The AutoNavi web API(V4.2.0)'s location Must Format "longitude,latitude".
+        boolean isAutoNavi = url.contains("restapi.amap.com/v3/geocode/regeo");
+        if (isAutoNavi){
+            urlFormat = String.format(url, longitude, latitude);
+        }
+
+        Invocation.Builder request = Context.getClient().target(urlFormat).request();
 
         if (callback != null) {
             request.async().get(new InvocationCallback<JsonObject>() {

--- a/src/test/java/org/traccar/geocoder/GeocoderTest.java
+++ b/src/test/java/org/traccar/geocoder/GeocoderTest.java
@@ -85,4 +85,12 @@ public class GeocoderTest {
         String address = geocoder.getAddress(28.6129602407977, 77.2294557094574, null);
         assertEquals("New Delhi, Delhi. 1 m from India Gate pin-110001 (India)", address);
     }
+
+    @Ignore
+    @Test
+    public void testAutoNavi() {
+        Geocoder geocoder = new AutoNaviGeocoder(null, "", 0, new AddressFormat("%f, %c"));
+        String address = geocoder.getAddress(39.991957, 116.310003, null);
+        assertEquals("北京市海淀区燕园街道北京大学, 中国", address);
+    }
 }


### PR DESCRIPTION
AutoNavi is popular in China.
It reverse geocoding is very helpful for the chinese user.
The "formatted_address" contains "state", "city", "street", "building" and more.
So, the Confirgurations required to be added in the config file
"traccar.xml" are
```
    <entry key='geocoder.enable'>true</entry>
    <entry key='geocoder.type'>autonavi</entry>
    <entry key='geocoder.requestLocationReverse'>true</entry>
    <entry key="geocoder.format">%f, %c</entry>
    <entry key='geocoder.url'>http://restapi.amap.com/v3/geocode/regeo</entry>
    <entry key='geocoder.key'>YOUR API KEY</entry>
```