### PR TITLE
Teltonika protocol - change fuel level from io89 to io84

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -260,11 +260,11 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
             case 83:
                 position.set(Position.KEY_FUEL_USED, readValue(buf, length, false) * 0.1);
                 break;
+            case 84:
+                position.set(Position.KEY_FUEL_LEVEL, readValue(buf, length, false) * 0.1);
+                break;
             case 85:
                 position.set(Position.KEY_RPM, readValue(buf, length, false));
-                break;
-            case 89:
-                position.set(Position.KEY_FUEL_LEVEL, readValue(buf, length, false));
                 break;
             case 90:
                 position.set(Position.KEY_DOOR, readValue(buf, length, false));


### PR DESCRIPTION
Teltonika protocol - change fuel level from io89 (in percents) to io84 (in litres). 
Io84 this is a fuel in litres * 0.1
https://wiki.teltonika-gps.com/view/FMB_AVL_ID