### PR TITLE
Update WatchProtocolEncoder.java

### DIFF
--- a/src/main/java/org/traccar/protocol/WatchProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolEncoder.java
@@ -135,7 +135,7 @@ public class WatchProtocolEncoder extends StringProtocolEncoder implements Strin
             case Command.TYPE_CUSTOM:
                 return formatTextCommand(channel, command, command.getString(Command.KEY_DATA));
             case Command.TYPE_POSITION_SINGLE:
-                return formatTextCommand(channel, command, "RG");
+                return formatTextCommand(channel, command, "CR");
             case Command.TYPE_SOS_NUMBER:
                 return formatTextCommand(channel, command, "SOS%s,%s", Command.KEY_INDEX, Command.KEY_PHONE);
             case Command.TYPE_ALARM_SOS:


### PR DESCRIPTION
Based on protocol documentation, the implementation of Command.TYPE_POSITION_SINGLE is wrong.

"RG" message is supposed to be issued when requesting location data from BTS (no gps signal)

"CR" message instructs the terminal to wake up gps module immediately and send gps positions in 10 sec intervals during the timespan of 3 minutes.

https://www.traccar.org/protocols/
Communication Protocol.doc
比电协议V1.8（20160926）.doc

https://github.com/tananaev/traccar/files/213814/3g.elec.comm.protocol.docx