### PR TITLE
[Teltonika] Fix wrong ACK on codec 12 and 13

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -624,7 +624,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
             }
         }
 
-        if (channel != null && codec != CODEC_12 && codec != CODEC_13 ) {
+        if (channel != null && codec != CODEC_12 && codec != CODEC_13) {
             if (connectionless) {
                 ByteBuf response = Unpooled.buffer();
                 response.writeShort(5);

--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -624,7 +624,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
             }
         }
 
-        if (channel != null) {
+        if (channel != null && codec != CODEC_12 && codec != CODEC_13 ) {
             if (connectionless) {
                 ByteBuf response = Unpooled.buffer();
                 response.writeShort(5);


### PR DESCRIPTION
Codec12 and codec13 uses no ACK at all. I modified TeltonikaProtocolDecoder.java to avoid sending ACK on those specific codecs.  This issue raised an error "[D.P.TCP]-> CODEC12 ERROR in state 0, ZEROES MISSING" on the gps device log. Tested with FM6300 and FMU125. 

https://wiki.teltonika-gps.com/view/Codec#Codec_12