### PR TITLE
[TELTONIKA] Fix OBD_SPEED - change kmh to knots

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -256,7 +256,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
                 position.set("workMode", readValue(buf, length, false));
                 break;
             case 81:
-                position.set(Position.KEY_OBD_SPEED, readValue(buf, length, false));
+                position.set(Position.KEY_OBD_SPEED, readValue(buf, length, false) / 1.852);
                 break;
             case 82:
                 position.set(Position.KEY_THROTTLE, readValue(buf, length, false));


### PR DESCRIPTION
[TELTONIKA] Fix OBD_SPEED - change kmh to knots.
Teltonika gives OBD_SPEED in km/h, Traccar wants in knots.
https://wiki.teltonika-gps.com/view/FMB_AVL_ID