### PR TITLE
Handle Freematics client sending double

### DIFF
--- a/src/main/java/org/traccar/protocol/FreematicsProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/FreematicsProtocolDecoder.java
@@ -132,37 +132,37 @@ public class FreematicsProtocolDecoder extends BaseProtocolDecoder {
                     position.setCourse(Integer.parseInt(value));
                     break;
                 case 0xF:
-                    position.set(Position.KEY_SATELLITES, Integer.parseInt(value));
+                    position.set(Position.KEY_SATELLITES, Double.parseDouble(value));
                     break;
                 case 0x12:
-                    position.set(Position.KEY_HDOP, Integer.parseInt(value));
+                    position.set(Position.KEY_HDOP, Double.parseDouble(value));
                     break;
                 case 0x20:
                     position.set(Position.KEY_ACCELERATION, value);
                     break;
                 case 0x24:
-                    position.set(Position.KEY_BATTERY, Integer.parseInt(value) * 0.01);
+                    position.set(Position.KEY_BATTERY, Double.parseDouble(value));
                     break;
                 case 0x81:
-                    position.set(Position.KEY_RSSI, Integer.parseInt(value));
+                    position.set(Position.KEY_RSSI, Double.parseDouble(value));
                     break;
                 case 0x82:
-                    position.set(Position.KEY_DEVICE_TEMP, Integer.parseInt(value) * 0.1);
+                    position.set(Position.KEY_DEVICE_TEMP, Double.parseDouble(value));
                     break;
                 case 0x104:
-                    position.set(Position.KEY_ENGINE_LOAD, Integer.parseInt(value));
+                    position.set(Position.KEY_ENGINE_LOAD, Double.parseDouble(value));
                     break;
                 case 0x105:
-                    position.set(Position.KEY_COOLANT_TEMP, Integer.parseInt(value));
+                    position.set(Position.KEY_COOLANT_TEMP, Double.parseDouble(value));
                     break;
                 case 0x10c:
-                    position.set(Position.KEY_RPM, Integer.parseInt(value));
+                    position.set(Position.KEY_RPM, Double.parseDouble(value));
                     break;
                 case 0x10d:
                     position.set(Position.KEY_OBD_SPEED, UnitsConverter.knotsFromKph(Integer.parseInt(value)));
                     break;
                 case 0x111:
-                    position.set(Position.KEY_THROTTLE, Integer.parseInt(value));
+                    position.set(Position.KEY_THROTTLE, Double.parseDouble(value));
                     break;
                 default:
                     position.set(Position.PREFIX_IO + key, value);

--- a/src/test/java/org/traccar/protocol/FreematicsProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/FreematicsProtocolDecoderTest.java
@@ -2,6 +2,7 @@ package org.traccar.protocol;
 
 import org.junit.Test;
 import org.traccar.ProtocolTest;
+import org.traccar.model.Position;
 
 public class FreematicsProtocolDecoderTest extends ProtocolTest {
 
@@ -30,6 +31,9 @@ public class FreematicsProtocolDecoderTest extends ProtocolTest {
 
         verifyPositions(decoder, text(
                 "1#0=68338,10D=79,30=1010,105=199,10C=4375,104=56,111=62,20=0;-1;95,10=6454200,A=-32.727482,B=150.150301,C=159,D=0,F=5,24=1250*7A"));
+
+        verifyAttribute(decoder, text(
+                "1#0=68338,82:55.000000*7A"), Position.KEY_DEVICE_TEMP, 55.0);
 
     }
 


### PR DESCRIPTION
Found some cases using latest v5 firmware telelogger from Freematics where it was sending `55.00000` as a device temp causing `parseInt` to fail. Since it appears that Traccar supports doubles, switching to parsing in these cases.