### PR TITLE
Log device id on SqlException and log invalid websocket sessions

### DIFF
--- a/src/main/java/org/traccar/MainEventHandler.java
+++ b/src/main/java/org/traccar/MainEventHandler.java
@@ -59,7 +59,7 @@ public class MainEventHandler extends ChannelInboundHandlerAdapter {
             try {
                 Context.getDeviceManager().updateLatestPosition(position);
             } catch (SQLException error) {
-                LOGGER.warn("Failed to update device", error);
+                LOGGER.warn("Failed to update device id " + position.getDeviceId(), error);
             }
 
             String uniqueId = Context.getIdentityManager().getById(position.getDeviceId()).getUniqueId();

--- a/src/main/java/org/traccar/api/AsyncSocketServlet.java
+++ b/src/main/java/org/traccar/api/AsyncSocketServlet.java
@@ -15,7 +15,11 @@
  */
 package org.traccar.api;
 
-import org.eclipse.jetty.websocket.servlet.*;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traccar.Context;
@@ -34,8 +38,9 @@ public class AsyncSocketServlet extends WebSocketServlet {
             public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp) {
                 if (req.getSession() != null) {
                     Object userId = req.getSession().getAttribute(SessionResource.USER_ID_KEY);
-                    if (userId != null)
+                    if (userId != null) {
                         return new AsyncSocket((Long) userId);
+                    }
                 }
                 LOGGER.warn("Invalid session: {}", req.getHeaders());
                 return null;

--- a/src/main/java/org/traccar/api/AsyncSocketServlet.java
+++ b/src/main/java/org/traccar/api/AsyncSocketServlet.java
@@ -15,17 +15,16 @@
  */
 package org.traccar.api;
 
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.servlet.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traccar.Context;
 import org.traccar.api.resource.SessionResource;
 
 public class AsyncSocketServlet extends WebSocketServlet {
 
     private static final long ASYNC_TIMEOUT = 10 * 60 * 1000;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncSocketServlet.class);
 
     @Override
     public void configure(WebSocketServletFactory factory) {
@@ -34,11 +33,12 @@ public class AsyncSocketServlet extends WebSocketServlet {
             @Override
             public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp) {
                 if (req.getSession() != null) {
-                    long userId = (Long) req.getSession().getAttribute(SessionResource.USER_ID_KEY);
-                    return new AsyncSocket(userId);
-                } else {
-                    return null;
+                    Object userId = req.getSession().getAttribute(SessionResource.USER_ID_KEY);
+                    if (userId != null)
+                        return new AsyncSocket((Long) userId);
                 }
+                LOGGER.warn("Invalid session: {}", req.getHeaders());
+                return null;
             }
         });
     }

--- a/src/main/java/org/traccar/database/ConnectionManager.java
+++ b/src/main/java/org/traccar/database/ConnectionManager.java
@@ -135,7 +135,7 @@ public class ConnectionManager {
         try {
             Context.getDeviceManager().updateDeviceStatus(device);
         } catch (SQLException error) {
-            LOGGER.warn("Update device status error", error);
+            LOGGER.warn("Update device status error, device id: " + deviceId, error);
         }
 
         updateDevice(device);

--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -19,8 +19,9 @@ import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.proxy.AsyncProxyServlet;
-import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.RequestLogWriter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
@@ -103,11 +104,10 @@ public class WebServer {
         server.setHandler(handlers);
 
         if (config.getBoolean(Keys.WEB_REQUEST_LOG_ENABLE)) {
-            NCSARequestLog requestLog = new NCSARequestLog(config.getString(Keys.WEB_REQUEST_LOG_PATH));
-            requestLog.setAppend(true);
-            requestLog.setExtended(true);
-            requestLog.setLogLatency(true);
-            requestLog.setRetainDays(config.getInteger(Keys.WEB_REQUEST_LOG_RETAIN_DAYS));
+            RequestLogWriter logWriter = new RequestLogWriter(config.getString(Keys.WEB_REQUEST_LOG_PATH));
+            logWriter.setAppend(true);
+            logWriter.setRetainDays(config.getInteger(Keys.WEB_REQUEST_LOG_RETAIN_DAYS));
+            CustomRequestLog requestLog = new CustomRequestLog(logWriter, CustomRequestLog.NCSA_FORMAT);
             server.setRequestLog(requestLog);
         }
     }


### PR DESCRIPTION
This helped me debug these two issues:

I'm getting sql deadlock exceptions with some units when the device status is updated at the same time as the last position.

Because of a bug on my front end I was having clients trying to make a websocket connection with an invalid session.

![log](https://user-images.githubusercontent.com/31902485/94382300-13614100-0134-11eb-881e-d95677d35a22.png)
