### PR TITLE
Preserve existing traccar.xml on update

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
 
+PRESERVECONFIG=0
+if [ -f /opt/traccar/conf/traccar.xml ]
+then
+    cp /opt/traccar/conf/traccar.xml /opt/traccar/conf/traccar.xml.saved
+    PRESERVECONFIG=1
+fi
+
 mkdir -p /opt/traccar
 cp -r * /opt/traccar
 chmod -R go+rX /opt/traccar
+
+if [ ${PRESERVECONFIG} -eq 1 ] && [ -f /opt/traccar/conf/traccar.xml.saved ]
+then
+    mv -f /opt/traccar/conf/traccar.xml.saved /opt/traccar/conf/traccar.xml
+fi
 
 mv /opt/traccar/traccar.service /etc/systemd/system
 chmod 664 /etc/systemd/system/traccar.service


### PR DESCRIPTION
When you update an existing traccar installation with the standard installer it will overwrite an existing "traccar.xml" config file. 
As this file is used for local changes to your installation you currently have to manually copy it aside before running the update. And restore it after the update.

This change will preserve the existing "traccar.xml" when it finds one and stores the new "traccar.xml" template from the installer as "traccar.xml.new".