### PR TITLE
As the installation needs root permissions beter check the user is root

### DIFF
--- a/setup/package.sh
+++ b/setup/package.sh
@@ -145,7 +145,7 @@ package_linux () {
   unzip -q -o jdk-*-linux-$1.zip
   jlink --module-path jdk-*-linux-$1/jmods --add-modules java.se,jdk.charsets,jdk.crypto.ec --output out/jre
   rm -rf jdk-*-linux-$1
-  makeself --quiet --notemp out traccar.run "traccar" ./setup.sh
+  makeself --needroot --quiet --notemp out traccar.run "traccar" ./setup.sh
   rm -rf out/jre
 
   zip -q -j traccar-linux-$2-$VERSION.zip traccar.run README.txt


### PR DESCRIPTION
Current versions of makeself on linux can check if the user running the final self extracting installer is root. When not it will show a warning.
This update adds this options to the makeself command.

This option was added to makeself in december 2016 ([commit on github](https://github.com/megastep/makeself/commit/436cf306fe05ab4d4805d3fda69660faac8eb4a5#diff-12513486c9b5ce3dea36337159a0fa4f62ca8044c68221ba206e163e630e25a6)) and is available on ubuntu 18.04.