### PR TITLE
H02FrameDecoder  for tracker protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/H02FrameDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02FrameDecoder.java
@@ -70,25 +70,19 @@ public class H02FrameDecoder extends BaseFrameDecoder {
                     } else {
                         messageLength = MESSAGE_SHORT;
                     }
-                }
-                else
-                {
+                } else {
                     // messagelength = 37 in config (for GPS data)
-                    if(buf.capacity() > messageLength)
-                	{
+                    if (buf.capacity() > messageLength) {
                 		byte dataFormat = buf.getByte(messageLength - 7);
                         
-                		if(dataFormat > 0x00)
-                		{
+                		if (dataFormat > 0x00) {
                             byte count = buf.getByte(messageLength - 6);
                 			// LBS Data
-                			if(dataFormat == 0x01)
-                			{
+                			if (dataFormat == 0x01) {
                 				messageLength = MESSAGE_SHORT + count * LBS_DATASET_LENGTH + 1;
                 			}
                 			// Wifi Data
-                			else if(dataFormat == 0x02)
-                			{
+                			else if (dataFormat == 0x02) {
                 				messageLength = MESSAGE_SHORT + count * WIFI_DATASET_LENGTH + 1;
                 			}
                 		}

--- a/src/main/java/org/traccar/protocol/H02FrameDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02FrameDecoder.java
@@ -24,6 +24,8 @@ public class H02FrameDecoder extends BaseFrameDecoder {
 
     private static final int MESSAGE_SHORT = 32;
     private static final int MESSAGE_LONG = 45;
+    private static final int LBS_DATASET_LENGTH = 8;
+    private static final int WIFI_DATASET_LENGTH = 7;
 
     private int messageLength;
 
@@ -68,6 +70,29 @@ public class H02FrameDecoder extends BaseFrameDecoder {
                     } else {
                         messageLength = MESSAGE_SHORT;
                     }
+                }
+                else
+                {
+                    // messagelength = 37 in config (for GPS data)
+                    if(buf.capacity() > messageLength)
+                	{
+                		byte dataFormat = buf.getByte(messageLength - 7);
+                        
+                		if(dataFormat > 0x00)
+                		{
+                            byte count = buf.getByte(messageLength - 6);
+                			// LBS Data
+                			if(dataFormat == 0x01)
+                			{
+                				messageLength = MESSAGE_SHORT + count * LBS_DATASET_LENGTH + 1;
+                			}
+                			// Wifi Data
+                			else if(dataFormat == 0x02)
+                			{
+                				messageLength = MESSAGE_SHORT + count * WIFI_DATASET_LENGTH + 1;
+                			}
+                		}
+                	}
                 }
 
                 if (buf.readableBytes() >= messageLength) {


### PR DESCRIPTION
Adjust frame length according to new protocol version. Distinguish between LBS, Wifi and GPS data in binary messages.
[GPRS PROTOCOL-20201021 PET02.pdf](https://github.com/traccar/traccar/files/5458160/GPRS.PROTOCOL-20201021.PET02.pdf)

Not sure if generally applicable for other H02 devices. I set messagelength to 37 in config file, because this is the shortest message I received. It only contains GPS data. Other message lengths are calculated according to the content.
