### PR TITLE
Stop running traccar service when performing update

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -7,8 +7,14 @@ then
     PRESERVECONFIG=1
 fi
 
+ISACTIVE=`systemctl is-active traccar.service`
+if [ "${ISACTIVE}" == "active" ]
+then
+    systemctl stop traccar
+fi
+
 mkdir -p /opt/traccar
-cp -r * /opt/traccar
+cp -r -f * /opt/traccar
 chmod -R go+rX /opt/traccar
 
 if [ ${PRESERVECONFIG} -eq 1 ] && [ -f /opt/traccar/conf/traccar.xml.saved ]
@@ -20,7 +26,7 @@ mv /opt/traccar/traccar.service /etc/systemd/system
 chmod 664 /etc/systemd/system/traccar.service
 
 systemctl daemon-reload
-systemctl enable traccar.service
+systemctl enable traccar
 
 rm /opt/traccar/setup.sh
 rm -r ../out


### PR DESCRIPTION
When you perform an install (update) op traccar on a linux system which already has traccar installed and the traccar service is running the installer produces the following error:

```
# ./traccar.run 
Creating directory out
Verifying archive integrity...  100%   All good.
Uncompressing traccar  100%  
cp: cannot create regular file '/opt/traccar/jre/bin/java': Text file busy
Created symlink /etc/systemd/system/multi-user.target.wants/traccar.service → /etc/systemd/system/traccar.service.
```

This update/patch fixes this issue by stopping the service when it is active before copying the new files into place.