### PR TITLE
Allow per-device forward url override.

### DIFF
--- a/src/main/java/org/traccar/Context.java
+++ b/src/main/java/org/traccar/Context.java
@@ -324,7 +324,7 @@ public final class Context {
         serverManager = new ServerManager();
         scheduleManager = new ScheduleManager();
 
-        if (config.hasKey(Keys.EVENT_FORWARD_URL)) {
+        if (config.getBoolean(Keys.EVENT_FORWARD_ENABLE)) {
             eventForwarder = new EventForwarder();
         }
 

--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -264,7 +264,7 @@ public class MainModule extends AbstractModule {
     @Provides
     public static WebDataHandler provideWebDataHandler(
             Config config, IdentityManager identityManager, ObjectMapper objectMapper, Client client) {
-        if (config.hasKey(Keys.FORWARD_URL)) {
+        if (config.getBoolean(Keys.FORWARD_ENABLE)) {
             return new WebDataHandler(config, identityManager, objectMapper, client);
         }
         return null;

--- a/src/main/java/org/traccar/WebDataHandler.java
+++ b/src/main/java/org/traccar/WebDataHandler.java
@@ -132,11 +132,12 @@ public class WebDataHandler extends BaseDataHandler {
         }
     }
 
-    public String formatRequest(Position position) throws UnsupportedEncodingException, JsonProcessingException {
+    public String formatRequest(
+            String baseUrl, Position position) throws UnsupportedEncodingException, JsonProcessingException {
 
         Device device = identityManager.getById(position.getDeviceId());
 
-        String request = url
+        String request = baseUrl
                 .replace("{name}", URLEncoder.encode(device.getName(), StandardCharsets.UTF_8.name()))
                 .replace("{uniqueId}", device.getUniqueId())
                 .replace("{status}", device.getStatus())
@@ -192,9 +193,12 @@ public class WebDataHandler extends BaseDataHandler {
 
         AsyncRequestAndCallback(Position position) {
 
+            String baseUrl = Context.getIdentityManager().lookupAttributeString(
+                    position.getDeviceId(), Keys.FORWARD_URL.getKey(), url, false, false);
+
             String formattedUrl;
             try {
-                formattedUrl = json && !urlVariables ? url : formatRequest(position);
+                formattedUrl = json && !urlVariables ? baseUrl : formatRequest(baseUrl, position);
             } catch (UnsupportedEncodingException | JsonProcessingException e) {
                 throw new RuntimeException("Forwarding formatting error", e);
             }

--- a/src/main/java/org/traccar/config/ConfigKey.java
+++ b/src/main/java/org/traccar/config/ConfigKey.java
@@ -33,7 +33,7 @@ public class ConfigKey<T> {
         this.defaultValue = defaultValue;
     }
 
-    String getKey() {
+    public String getKey() {
         return key;
     }
 

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -555,6 +555,16 @@ public final class Keys {
             "max-age=3600,public");
 
     /**
+     * Enables/disables position forwarding. If 'forward.url' is set, it will be used for all position forwarding.
+     * Otherwise, device attribute 'forward.url' of the device (or its group) is used instead. If neither one
+     * is set, position forwarding is skipped.
+     */
+    public static final ConfigKey<Boolean> FORWARD_ENABLE = new ConfigKey<>(
+            "forward.enable",
+            Collections.singletonList(KeyType.GLOBAL),
+            true);
+
+    /**
      * URL to forward positions. Data is passed through URL parameters. For example, {uniqueId} for device identifier,
      * {latitude} and {longitude} for coordinates.
      */
@@ -618,6 +628,17 @@ public final class Keys {
     public static final ConfigKey<Integer> FORWARD_RETRY_LIMIT = new ConfigKey<>(
             "forward.retry.limit",
             Collections.singletonList(KeyType.GLOBAL));
+
+
+    /**
+     * Enables/disables event forwarding. If 'event.forward.url' is set, it will be used for all event forwarding.
+     * Otherwise, device attribute 'event.forward.url' of the device (or its group) is used instead. If neither one
+     * is set, event forwarding is skipped.
+     */
+    public static final ConfigKey<Boolean> EVENT_FORWARD_ENABLE = new ConfigKey<>(
+            "event.forward.enable",
+            Collections.singletonList(KeyType.GLOBAL),
+            true);
 
     /**
      * Events forwarding URL.

--- a/src/main/java/org/traccar/notification/EventForwarder.java
+++ b/src/main/java/org/traccar/notification/EventForwarder.java
@@ -52,8 +52,10 @@ public class EventForwarder {
     private static final String KEY_USERS = "users";
 
     public final void forwardEvent(Event event, Position position, Set<Long> users) {
-        String baseUrl = Context.getIdentityManager().lookupAttributeString(
-                position.getDeviceId(), Keys.EVENT_FORWARD_URL.getKey(), url, false, false);
+        String baseUrl = getEventForwardUrl(position.getDeviceId());
+        if (baseUrl == null) {
+            return;
+        }
 
         Invocation.Builder requestBuilder = Context.getClient().target(baseUrl).request();
 
@@ -77,6 +79,15 @@ public class EventForwarder {
                         LOGGER.warn("Event forwarding failed", throwable);
                     }
                 });
+    }
+
+    private String getEventForwardUrl(long deviceId) {
+        if (url != null) {
+            // Global 'event.forward.url' has precedence over per-device overrides.
+            return url;
+        }
+        return Context.getIdentityManager().lookupAttributeString(
+                deviceId, Keys.EVENT_FORWARD_URL.getKey(), null, false, false);
     }
 
     protected Map<String, Object> preparePayload(Event event, Position position, Set<Long> users) {

--- a/src/main/java/org/traccar/notification/EventForwarder.java
+++ b/src/main/java/org/traccar/notification/EventForwarder.java
@@ -52,8 +52,10 @@ public class EventForwarder {
     private static final String KEY_USERS = "users";
 
     public final void forwardEvent(Event event, Position position, Set<Long> users) {
+        String baseUrl = Context.getIdentityManager().lookupAttributeString(
+                position.getDeviceId(), Keys.EVENT_FORWARD_URL.getKey(), url, false, false);
 
-        Invocation.Builder requestBuilder = Context.getClient().target(url).request();
+        Invocation.Builder requestBuilder = Context.getClient().target(baseUrl).request();
 
         if (header != null && !header.isEmpty()) {
             for (String line: header.split("\\r?\\n")) {

--- a/src/test/java/org/traccar/WebDataHandlerTest.java
+++ b/src/test/java/org/traccar/WebDataHandlerTest.java
@@ -12,8 +12,8 @@ public class WebDataHandlerTest extends ProtocolTest {
     @Test
     public void testFormatRequest() throws Exception {
 
+        String url = "http://localhost/?fixTime={fixTime}&gprmc={gprmc}&name={name}";
         Config config = new Config();
-        config.setString(Keys.FORWARD_URL, "http://localhost/?fixTime={fixTime}&gprmc={gprmc}&name={name}");
 
         Position position = position("2016-01-01 01:02:03.000", true, 20, 30);
 
@@ -21,7 +21,7 @@ public class WebDataHandlerTest extends ProtocolTest {
 
         assertEquals(
                 "http://localhost/?fixTime=1451610123000&gprmc=$GPRMC,010203.000,A,2000.0000,N,03000.0000,E,0.00,0.00,010116,,*05&name=test",
-                handler.formatRequest(position));
+                handler.formatRequest(url, position));
 
     }
 


### PR DESCRIPTION
This is to allow overriding target urls for forwarding position information and events per device or per device group.

Our use case is 1 Traccar server that needs to forward events to one of N target servers depending on a device group.

@tananaev, please let me know if this is something useful for the core Traccar and any changes needed to get it in :v:.