### PR TITLE
CI: Validate Gradle Wrapper

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
       run: ./gradlew build
+  


### PR DESCRIPTION
Validates the gradle-wrapper.jar file on each builds, which is a binary blob of executable code. This action ensures it's legit and doesn't execute malicious code.

See https://github.com/gradle/wrapper-validation-action