### PR TITLE
CI: Only pass if there are no Gradle warnings

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --warning-mode=fail


### PR DESCRIPTION
Adds the CLI option `--warning-mode=fail` to the Gradle build job. This ensures the build only passes if no warnings are cast.

See: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_warnings