### PR TITLE
starting user email validation

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -375,6 +375,13 @@ public final class Keys {
             Collections.singletonList(KeyType.GLOBAL));
 
     /**
+     * Send email validation emails before user creation and email change.
+     */
+    public static final ConfigKey<Boolean> USERS_EMAIL_VALIDATION_ENABLE = new ConfigKey<>(
+            "users.emailValidation.enable",
+            Collections.singletonList(KeyType.GLOBAL));
+
+    /**
      * LDAP server URL.
      */
     public static final ConfigKey<String> LDAP_URL = new ConfigKey<>(

--- a/src/main/java/org/traccar/database/MailManager.java
+++ b/src/main/java/org/traccar/database/MailManager.java
@@ -97,11 +97,14 @@ public final class MailManager {
     }
 
     public void sendMessage(
-            long userId, String subject, String body, MimeBodyPart attachment) throws MessagingException {
-        User user = Context.getPermissionsManager().getUser(userId);
+            User user, String subject, String body) throws MessagingException {
+        sendMessage(user, subject, body, null);
+    }
 
+    public void sendMessage(
+            User user, String subject, String body, MimeBodyPart attachment) throws MessagingException {
         Properties properties = null;
-        if (!Context.getConfig().getBoolean("mail.smtp.ignoreUserConfig")) {
+        if (!Context.getConfig().getBoolean("mail.smtp.ignoreUserConfig") && !Context.getConfig().getBoolean("users.emailValidation.enable")) {
             properties = getProperties(new PropertiesProvider(user));
         }
         if (properties == null || !properties.containsKey("mail.smtp.host")) {
@@ -146,6 +149,12 @@ public final class MailManager {
                     properties.getProperty("mail.smtp.password"));
             transport.sendMessage(message, message.getAllRecipients());
         }
+    }
+
+    public void sendMessage(
+            long userId, String subject, String body, MimeBodyPart attachment) throws MessagingException {
+        User user = Context.getPermissionsManager().getUser(userId);
+        sendMessage(user, subject, body, attachment);
     }
 
 }

--- a/src/main/java/org/traccar/database/MailManager.java
+++ b/src/main/java/org/traccar/database/MailManager.java
@@ -104,7 +104,8 @@ public final class MailManager {
     public void sendMessage(
             User user, String subject, String body, MimeBodyPart attachment) throws MessagingException {
         Properties properties = null;
-        if (!Context.getConfig().getBoolean("mail.smtp.ignoreUserConfig") && !Context.getConfig().getBoolean("users.emailValidation.enable")) {
+        if (!Context.getConfig().getBoolean("mail.smtp.ignoreUserConfig")
+                && !Context.getConfig().getBoolean("users.emailValidation.enable")) {
             properties = getProperties(new PropertiesProvider(user));
         }
         if (properties == null || !properties.containsKey("mail.smtp.host")) {

--- a/templates/full/validateEmail.vm
+++ b/templates/full/validateEmail.vm
@@ -1,0 +1,8 @@
+#set($subject = "Validate email")
+<!DOCTYPE html>
+<html>
+<body>
+To validate your email please click on the following link:<br>
+<a href="$webUrl/api/users/validate?user=$user&signature=$signature&salt=$salt&">Confirm email</a><br>
+</body>
+</html>


### PR DESCRIPTION
Checking if starting in the right direction. 

Maybe makes more sense to serialise the whole user model as json and then hash it. Not sure if the velocity template will handle the url encoding if I put a big string on the query string.

I see Response.serverError is not used anywhere else but I didn't want to add a new exception to the add method signature on BaseObjectResource.

Where does it make sense to put the new api method?