### PR TITLE
Added missing protocol decodings for both teltonika and pretrace protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/PretraceProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/PretraceProtocolDecoder.java
@@ -16,8 +16,6 @@
 package org.traccar.protocol;
 
 import io.netty.channel.Channel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.Protocol;

--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -19,6 +19,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.Context;
 import org.traccar.DeviceSession;
@@ -538,7 +540,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
                 int length = buf.readUnsignedShort();
                 if (id == 256) {
                     position.set(Position.KEY_VIN, buf.readSlice(length).toString(StandardCharsets.US_ASCII));
-                } else if (id == 385) {
+                } else if ((id == 385) || (id == 10500)) {
                     ByteBuf data = buf.readSlice(length);
                     data.readUnsignedByte(); // data part
                     int index = 1;
@@ -559,6 +561,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
                         if (BitUtil.check(flags, 2)) {
                             position.set("beacon" + index + "Temp", data.readUnsignedShort());
                         }
+
                         index += 1;
                     }
                 } else {

--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -19,8 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.Context;
 import org.traccar.DeviceSession;


### PR DESCRIPTION
New Teltonika devives like FMM640 are sending beacon values as ID=10500 and no longer as ID=385 - see https://wiki.teltonika-gps.com/view/FMM640_Teltonika_Data_Sending_Parameters_ID . For pretrace protocol the parsing of position type (LBS or GPS) had been missing and the parsing of the state bits. The pretrace state bits have different meaning depending on the firmware and device, but anyway parsing helps to enable the displaying of states in the front end.

If you have question about pretrace changes you can discuss it with ben@pretrace.com - I did the changes together with Ben.

I added logger to help me dealing with the data - the logger import can of course be left out - I forgot this.

Would be nice if you could use these small changes or even make a better one.