### PR TITLE
Support native location messages for Telegram

### DIFF
--- a/src/main/java/org/traccar/notificators/NotificatorTelegram.java
+++ b/src/main/java/org/traccar/notificators/NotificatorTelegram.java
@@ -81,7 +81,7 @@ public class NotificatorTelegram extends Notificator {
         });
     }
 
-    private LocationMessage createMessage(Position position) {
+    private LocationMessage createLocationMessage(Position position) {
         LocationMessage locationMessage = new LocationMessage();
         locationMessage.chatId = chatId;
         locationMessage.latitude = position.getLatitude();
@@ -94,8 +94,7 @@ public class NotificatorTelegram extends Notificator {
     @Override
     public void sendSync(long userId, Event event, Position position) {
         if (position != null) {
-            LocationMessage locationMessage = createMessage(position);
-            executeRequest(urlSendLocation, locationMessage);
+            executeRequest(urlSendLocation, createLocationMessage(position));
         }
         TextMessage message = new TextMessage();
         message.chatId = chatId;


### PR DESCRIPTION
1. I decided it would be very convenient, if Telegram bots would send location native to Telegram chats.
2. Also, I think users would benefit if bot sent full message instead on short one. It shouldn't be that short as Firebase notification. (There I forgot to add `getBody()` to the code to convert to string.)

What do you think, @tananaev ?

![Screenshot_20210420-184756](https://user-images.githubusercontent.com/100644/115416889-3440cf00-a209-11eb-9bfb-4c0fa057776d.png)
