### PR TITLE
KEY_DRIVER_UNIQUE_ID is hardcoded on copyAttributes

### DIFF
--- a/src/main/java/org/traccar/handler/CopyAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/CopyAttributesHandler.java
@@ -34,11 +34,6 @@ public class CopyAttributesHandler extends BaseDataHandler {
     protected Position handlePosition(Position position) {
         String attributesString = identityManager.lookupAttributeString(
                 position.getDeviceId(), "processing.copyAttributes", "", false, true);
-        if (attributesString.isEmpty()) {
-            attributesString = Position.KEY_DRIVER_UNIQUE_ID;
-        } else {
-            attributesString += "," + Position.KEY_DRIVER_UNIQUE_ID;
-        }
         Position last = identityManager.getLastPosition(position.getDeviceId());
         if (last != null) {
             for (String attribute : attributesString.split("[ ,]")) {


### PR DESCRIPTION
Why are we forcing KEY_DRIVER_UNIQUE_ID on copyAttributes?
Also, if exists why should it be duplicated?