### PR TITLE
Take "steps" value from LK frames in Watch protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
@@ -244,7 +244,8 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
                     getLastLocation(position, null);
 
                     position.set(Position.KEY_BATTERY_LEVEL, Integer.parseInt(values[2]));
-
+                    position.set(Position.KEY_STEPS, Integer.parseInt(values[0]));
+                    
                     return position;
                 }
             }

--- a/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
@@ -245,7 +245,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
 
                     position.set(Position.KEY_BATTERY_LEVEL, Integer.parseInt(values[2]));
                     position.set(Position.KEY_STEPS, Integer.parseInt(values[0]));
-                    
+
                     return position;
                 }
             }


### PR DESCRIPTION
"Steps" counter value is currently parsed from a complete GPS frame only, but according to the protocol it is also transmitted in all "LK" keepalive frames, as well as the battery level.

Example :
`[3G*123456789*000D*LK,12345,0,98]
`means 12345 steps counted and 98% battery level.
Note : for this value to be incremented, the device should receive a 'PEDO,1' command (and 'PEDO,0' to stop the counter)