### PR TITLE
Catch all webexceptions in JsonGeocoder

### DIFF
--- a/src/main/java/org/traccar/geocoder/JsonGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/JsonGeocoder.java
@@ -22,7 +22,7 @@ import org.traccar.Main;
 import org.traccar.database.StatisticsManager;
 
 import javax.json.JsonObject;
-import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.InvocationCallback;
 import java.util.AbstractMap;
@@ -116,7 +116,7 @@ public abstract class JsonGeocoder implements Geocoder {
         } else {
             try {
                 return handleResponse(latitude, longitude, request.get(JsonObject.class), null);
-            } catch (ClientErrorException e) {
+            } catch (WebApplicationException e) {
                 LOGGER.warn("Geocoder network error", e);
             }
         }


### PR DESCRIPTION
When a service is down (like positionstack recently often is), it might send a 503 Service Unavailable which is not covered by a ClientErrorException. Using the superclass of this, will enable the position to be handled correctly still.