### PR TITLE
Fix SQL dropping millisecond time precision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation "commons-codec:commons-codec:1.15"
     implementation "com.h2database:h2:1.4.200"
     implementation "mysql:mysql-connector-java:8.0.26"
+    implementation "org.mariadb.jdbc:mariadb-java-client:2.7.4"
     implementation "org.postgresql:postgresql:42.2.23"
     implementation "com.microsoft.sqlserver:mssql-jdbc:9.4.0.jre11"
     implementation "com.zaxxer:HikariCP:5.0.0"

--- a/schema/changelog-4.0-clean.xml
+++ b/schema/changelog-4.0-clean.xml
@@ -129,7 +129,7 @@
       <column name="uniqueid" type="VARCHAR(128)">
         <constraints nullable="false" unique="true" />
       </column>
-      <column name="lastupdate" type="timestamp" />
+      <column name="lastupdate" type="TIMESTAMP(6)" />
       <column name="positionid" type="INT" />
       <column name="groupid" type="INT" />
       <column name="attributes" type="VARCHAR(4000)" />
@@ -162,7 +162,7 @@
       <column name="type" type="VARCHAR(128)">
         <constraints nullable="false" />
       </column>
-      <column name="servertime" type="TIMESTAMP">
+      <column name="servertime" type="TIMESTAMP(6)">
         <constraints nullable="false" />
       </column>
       <column name="deviceid" type="INT" />
@@ -296,13 +296,13 @@
       <column name="deviceid" type="INT">
         <constraints nullable="false" />
       </column>
-      <column name="servertime" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+      <column name="servertime" type="TIMESTAMP(6)" defaultValueComputed="CURRENT_TIMESTAMP">
         <constraints nullable="false" />
       </column>
-      <column name="devicetime" type="TIMESTAMP">
+      <column name="devicetime" type="TIMESTAMP(6)">
         <constraints nullable="false" />
       </column>
-      <column name="fixtime" type="TIMESTAMP">
+      <column name="fixtime" type="TIMESTAMP(6)">
         <constraints nullable="false" />
       </column>
       <column name="valid" type="BOOLEAN">

--- a/schema/changelog-4.15.xml
+++ b/schema/changelog-4.15.xml
@@ -61,6 +61,12 @@
     <addForeignKeyConstraint baseTableName="tc_device_order" baseColumnNames="deviceid" constraintName="fk_device_order_deviceid" referencedTableName="tc_devices" referencedColumnNames="id" onDelete="CASCADE" />
     <addForeignKeyConstraint baseTableName="tc_device_order" baseColumnNames="orderid" constraintName="fk_device_order_orderid" referencedTableName="tc_orders" referencedColumnNames="id" onDelete="CASCADE" />
 
+    <modifyDataType tableName="tc_positions" columnName="fixtime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_positions" columnName="servertime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_positions" columnName="devicetime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_events" columnName="servertime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_devices" columnName="lastupdate" newDataType="TIMESTAMP(6)" />
+
   </changeSet>
 
 </databaseChangeLog>

--- a/schema/changelog-4.15.xml
+++ b/schema/changelog-4.15.xml
@@ -64,7 +64,7 @@
     <modifyDataType tableName="tc_positions" columnName="fixtime" newDataType="TIMESTAMP(6)" />
     <modifyDataType tableName="tc_positions" columnName="servertime" newDataType="TIMESTAMP(6)" />
     <modifyDataType tableName="tc_positions" columnName="devicetime" newDataType="TIMESTAMP(6)" />
-    <modifyDataType tableName="tc_events" columnName="servertime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_events" columnName="eventtime" newDataType="TIMESTAMP(6)" />
     <modifyDataType tableName="tc_devices" columnName="lastupdate" newDataType="TIMESTAMP(6)" />
 
   </changeSet>

--- a/schema/changelog-4.15.xml
+++ b/schema/changelog-4.15.xml
@@ -61,12 +61,6 @@
     <addForeignKeyConstraint baseTableName="tc_device_order" baseColumnNames="deviceid" constraintName="fk_device_order_deviceid" referencedTableName="tc_devices" referencedColumnNames="id" onDelete="CASCADE" />
     <addForeignKeyConstraint baseTableName="tc_device_order" baseColumnNames="orderid" constraintName="fk_device_order_orderid" referencedTableName="tc_orders" referencedColumnNames="id" onDelete="CASCADE" />
 
-    <modifyDataType tableName="tc_positions" columnName="fixtime" newDataType="TIMESTAMP(6)" />
-    <modifyDataType tableName="tc_positions" columnName="servertime" newDataType="TIMESTAMP(6)" />
-    <modifyDataType tableName="tc_positions" columnName="devicetime" newDataType="TIMESTAMP(6)" />
-    <modifyDataType tableName="tc_events" columnName="eventtime" newDataType="TIMESTAMP(6)" />
-    <modifyDataType tableName="tc_devices" columnName="lastupdate" newDataType="TIMESTAMP(6)" />
-
   </changeSet>
 
 </databaseChangeLog>

--- a/schema/changelog-fractional-time.xml
+++ b/schema/changelog-fractional-time.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+  logicalFilePath="changelog-fractional-time">
+
+  <changeSet author="author" id="changelog-fractional-time">
+
+    <modifyDataType tableName="tc_positions" columnName="fixtime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_positions" columnName="servertime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_positions" columnName="devicetime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_events" columnName="eventtime" newDataType="TIMESTAMP(6)" />
+    <modifyDataType tableName="tc_devices" columnName="lastupdate" newDataType="TIMESTAMP(6)" />
+
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
I have tested the code and I found a serious problem (as it seems to me), that have existed in traccar even before my pull request. As it turns out, traccar doesn't save fractional TIMESTAMP values, it saves only seconds (not milliseconds). Which means that duplicate comparison didn't work for protocols that send milliseconds:

position.getFixTime().getTime() == last.getFixTime().getTime() returns false for seemingly duplicate position (that I send repeatedly). When comparing to last received position (as was implemented before) this problem did not appear (because positions were kept inside IdentityManager in RAM). But if we take values from DB that cuts off milliseconds, it becomes a problem.

Compare:

    the new received position had value 1626692627800
    and the position from DB has value 1626692627000

Honestly, I really think that traccar should save milliseconds in the database. Some usecases demand location data more frequent than once per second.

Something like this: ALTER TABLE tc_positions CHANGE COLUMN fixtime TIMESTAMP(6) and other time-related columns.

I would like to ask other users to test whether their databases also drop millisecond precision.