### PR TITLE
Filter speed 0.0 and course 0 (N) reports

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -885,6 +885,13 @@ public final class Keys {
             Collections.singletonList(KeyType.GLOBAL));
 
     /**
+     * Filter positions with exactly zero speed values and zero course (north).
+     */
+    public static final ConfigKey<Boolean> FILTER_STATIC_NORTH = new ConfigKey<>(
+            "filter.staticNorth",
+            Collections.singletonList(KeyType.GLOBAL));
+
+    /**
      * Filter records by distance. The values is specified in meters. If the new position is less far than this value
      * from the last one it gets filtered out.
      */

--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -37,6 +37,7 @@ public class FilterHandler extends BaseDataHandler {
     private boolean filterApproximate;
     private int filterAccuracy;
     private boolean filterStatic;
+    private boolean filterStaticNorth;
     private int filterDistance;
     private int filterMaxSpeed;
     private long filterMinPeriod;
@@ -51,6 +52,7 @@ public class FilterHandler extends BaseDataHandler {
         filterAccuracy = config.getInteger(Keys.FILTER_ACCURACY);
         filterApproximate = config.getBoolean(Keys.FILTER_APPROXIMATE);
         filterStatic = config.getBoolean(Keys.FILTER_STATIC);
+        filterStaticNorth = config.getBoolean(Keys.FILTER_STATIC_NORTH);
         filterDistance = config.getInteger(Keys.FILTER_DISTANCE);
         filterMaxSpeed = config.getInteger(Keys.FILTER_MAX_SPEED);
         filterMinPeriod = config.getInteger(Keys.FILTER_MIN_PERIOD) * 1000;
@@ -94,6 +96,10 @@ public class FilterHandler extends BaseDataHandler {
 
     private boolean filterStatic(Position position) {
         return filterStatic && position.getSpeed() == 0.0;
+    }
+
+    private boolean filterStaticNorth(Position position) {
+        return filterStaticNorth && position.getSpeed() == 0.0 && position.getCourse() == 0;
     }
 
     private boolean filterDistance(Position position, Position last) {
@@ -169,6 +175,9 @@ public class FilterHandler extends BaseDataHandler {
         }
         if (filterStatic(position) && !skipLimit(position, last) && !skipAttributes(position)) {
             filterType.append("Static ");
+        }
+        if (filterStaticNorth(position) && !skipLimit(position, last) && !skipAttributes(position)) {
+            filterType.append("StaticNorth ");
         }
         if (filterDistance(position, last) && !skipLimit(position, last) && !skipAttributes(position)) {
             filterType.append("Distance ");

--- a/src/test/java/org/traccar/handler/FilterHandlerTest.java
+++ b/src/test/java/org/traccar/handler/FilterHandlerTest.java
@@ -26,6 +26,7 @@ public class FilterHandlerTest extends BaseTest {
         config.setString(Keys.FILTER_FUTURE, String.valueOf(5 * 60));
         config.setString(Keys.FILTER_APPROXIMATE, String.valueOf(true));
         config.setString(Keys.FILTER_STATIC, String.valueOf(true));
+        config.setString(Keys.FILTER_STATIC_NORTH, String.valueOf(true));
         config.setString(Keys.FILTER_DISTANCE, String.valueOf(10));
         config.setString(Keys.FILTER_MAX_SPEED, String.valueOf(500));
         config.setString(Keys.FILTER_SKIP_LIMIT, String.valueOf(10));


### PR DESCRIPTION
## Problem

The Android traccar client occasionally sends location reports that are very far from the true location. I've witnessed this happen during the course of a drive with otherwise accurate reports.

The only common thing all these reports have is their speed is 0.0 and course is 0.

The reports often have suspicious integer accuracy and often 1000+
`filter.accuracy` didn't work reliably as some are reported at the 100s range and look otherwise valid.

`filter.static` cut out too many valid reports.

I decided to add this `filter.staticNorth` to filter reports with both speed 0.0 and course 0.

## Testing

Branched from `tags/v4.14`.
`tracker-server.jar` built and mounted into container.

Traccar container has been running with this build for the past month without issue.