### PR TITLE
Totem - More accurate/generic Vehicle Status decoding so it does not show wrong values for AT07

### DIFF
--- a/src/main/java/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolDecoder.java
@@ -375,13 +375,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.PREFIX_OUT + 1, BitUtil.check(status, 32 - 9));
         position.set(Position.PREFIX_OUT + 2, BitUtil.check(status, 32 - 10));
         position.set(Position.PREFIX_OUT + 3, BitUtil.check(status, 32 - 11));
-
-        /**
-          * Different Devices have different meaning for bits 12-22
-          * But unfortunately we cannot reliably detect this, so we store the whole status in KEY_STATUS
-          * See: https://github.com/traccar/traccar/pull/4762
-          */
-        position.set(Position.KEY_STATUS, status);
+        position.set(Position.KEY_STATUS, status); // see https://github.com/traccar/traccar/pull/4762
 
         position.setTime(parser.nextDateTime());
 


### PR DESCRIPTION
After checking the AT05, AT07 and AT09 unfortunately part of the Vehicle Status does not have the same meaning.
After checking the Teltonika Protocol Decoder I decided to use the same idea for now - with IO<bit> setting so that the user can then configure their own computed attributes if needed. 
This fixes the currently present (and observed) wrong status info with AT07 devices.

Bit Meaning for different devices:
| Bit   | AT05  | AT07 | AT09 |
| --- | --- | --- | --- |
| 8 | GPS Module Error | GPS Module Error | GPS Module Error |
| 12 | Reserved   | IN2 | OUT4 |
| 13 | IN2 | IN4        | IN2 |
| 14 | IN3        | Shock      | IN3 |
| 15 | IN4        | Idle       | IN4 |
| 16 | Shock      | Low Battery  | Shock |
| 17 | Idle       | Driver Authorization | Idle |
| 18 | Low Battery  | GPS Status | Low Battery |
| 19 | Driver Authorization | Battery charging | Driver Authorization |
| 20 | GPS Status | GSM Jamming| GPS Status |
| 21 | Battery charging | Reserved   | Battery charging |
| 22 | Reserved   | Reserved   | GSM Jamming |