### PR TITLE
new event according to AVL ID obtained

### DIFF
--- a/src/main/java/org/traccar/model/Position.java
+++ b/src/main/java/org/traccar/model/Position.java
@@ -21,6 +21,15 @@ import org.traccar.database.QueryIgnore;
 
 public class Position extends Message {
 
+
+    public static final String crash = "crash";
+    public static final String  limited_crash_trace_nc = "limitedCrashTraceNotCalibrate";
+    public static final String limited_crash_trace_c = "limitedCrashTraceCalibrate";
+    public static final String full_crash_trace_cn = "fullCrashTraceNotCalibrate";
+    public static final String full_crash_trace_n = "fullCrashTraceCalibrate";
+    public static final String crash_detected  = "crashDetected";
+    public static final String battery_present = "batteryPresent";
+    public static final String battery_unplug = "batteryUnplug";
     public static final String KEY_ORIGINAL = "raw";
     public static final String KEY_INDEX = "index";
     public static final String KEY_HDOP = "hdop";

--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -284,6 +284,42 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
             case 241:
                 position.set(Position.KEY_OPERATOR, readValue(buf, length, false));
                 break;
+            case 247:
+                switch ((int) readValue(buf, length, false)) {
+                    case 1:
+                        position.set(Position.KEY_ALARM, Position.crash);
+                        break;
+                    case 2:
+                        position.set(Position.KEY_ALARM, Position.limited_crash_trace_nc);
+                        break;
+                    case 3:
+                        position.set(Position.KEY_ALARM, Position.limited_crash_trace_c);
+                        break;
+                    case 4:
+                        position.set(Position.KEY_ALARM, Position.full_crash_trace_cn);
+                        break;
+                    case 5:
+                        position.set(Position.KEY_ALARM, Position.full_crash_trace_n);
+                        break;
+                    case 6:
+                        position.set(Position.KEY_ALARM, Position.crash_detected);
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case 252:
+                switch ((int) readValue(buf, length, false)) {
+                    case 0:
+                        position.set(Position.KEY_ALARM, Position.battery_present);
+                        break;
+                    case 1:
+                        position.set(Position.KEY_ALARM, Position.battery_unplug);
+                        break;
+                    default:
+                        break;
+                }
+                break;
             case 253:
                 switch ((int) readValue(buf, length, false)) {
                     case 1:


### PR DESCRIPTION
I have a teltonika brand gps that sends events 247 and 252 and is not reflected in the decoder. Which behaves in the same way as event 253 where it extracts its value and overwrites the event.

![image](https://user-images.githubusercontent.com/22747286/141318975-b99f3b9d-c07e-40d5-b445-9fde3de9cf8b.png)

This information was obtained from:
https://wiki.teltonika-mobility.com/view/Full_AVL_ID_List