### PR TITLE
feat: generate config keys as pug

### DIFF
--- a/tools/gen_config_doc.py
+++ b/tools/gen_config_doc.py
@@ -2,7 +2,7 @@
 
 import re
 import os
-
+import argparse
 
 _KEYS_FILE = os.path.join(
     os.path.dirname(__file__), "../src/main/java/org/traccar/config/Keys.java"
@@ -72,6 +72,31 @@ def get_html():
     )
 
 
+def get_pug():
+    return ("\n").join(
+        [
+            f"""  div(class='card mt-3')
+    div(class='card-body')
+      h5(class='card-title') {x["key"]} #[span(class='badge badge-dark') config]
+      p(class='card-text') {"#[br] ".join(x["description"])}"""
+            for x in get_config_keys()
+        ]
+    )
+
+
 if __name__ == "__main__":
-    html = get_html()
-    print(html)
+    parser = argparse.ArgumentParser(
+        description="Parses Keys.java to extract keys to be used in configuration files"
+    )
+    parser.add_argument(
+        "--format", choices=["pug", "html"], default="pug", help="default: 'pug'"
+    )
+    args = parser.parse_args()
+
+    def get_output():
+        if args.format == 'html':
+            return get_html()
+        
+        return get_pug()
+
+    print(get_output())

--- a/tools/gen_config_doc.py
+++ b/tools/gen_config_doc.py
@@ -8,50 +8,70 @@ _KEYS_FILE = os.path.join(
     os.path.dirname(__file__), "../src/main/java/org/traccar/config/Keys.java"
 )
 
-def get_config_key_descriptions():
+
+def get_config_keys():
+    """Parses Keys.java to extract keys to be used in configuration files
+
+    Args: None
+
+    Returns:
+        list: A list of dict containing the following keys -
+            'key': A dot separated name of the config key
+            'description': A list of str
+    """
     desc_re = re.compile(r"(/\*\*\n|\s+\*/|\s+\*)")
     key_match_re = re.compile(r"\(\n(.+)\);", re.DOTALL)
     key_split_re = re.compile(r",\s+", re.DOTALL)
-    snippets = []
+    keys = []
 
     with open(_KEYS_FILE, "r") as f:
-        code = f.read()
         config = re.findall(
-            r"(/\*\*.*?\*/)\n\s+(public static final Config.*?;)", code, re.DOTALL
+            r"(/\*\*.*?\*/)\n\s+(public static final Config.*?;)", f.read(), re.DOTALL
         )
         for i in config:
             try:
                 key_match = key_match_re.search(i[1])
                 if key_match:
-                    description = "<br /> ".join(
-                        [
-                            x.strip().replace("\n", "")
-                            for x in desc_re.sub("\n", i[0]).strip().split("\n\n")
-                        ]
-                    )
                     terms = [x.strip() for x in key_split_re.split(key_match.group(1))]
                     key = terms[0].replace('"', "")
-                    default = terms[2] if len(terms) == 3 else None
-                    snippets.append(
-                        f"""        <div class="card mt-3">
-          <div class="card-body">
-              <h5 class="card-title">
-                {key} <span class="badge badge-dark">config</span>
-              </h5>
-              <p class="card-text">
-                {description}{f"<br/ > Default: {default}." if default else ""}
-              </p>
-          </div>
-        </div>"""
+                    description = [
+                        x.strip().replace("\n", "")
+                        for x in desc_re.sub("\n", i[0]).strip().split("\n\n")
+                    ]
+                    if len(terms) == 3:
+                        description.append(f"Default: {terms[2]}")
+                    keys.append(
+                        {
+                            "key": key,
+                            "description": description,
+                        }
                     )
             except IndexError:
                 # will continue if key_match.group(1) or terms[0] does not exist
                 # for some reason
                 pass
 
-    return ("\n").join(snippets)
+    return keys
+
+
+def get_html():
+    return ("\n").join(
+        [
+            f"""        <div class="card mt-3">
+          <div class="card-body">
+              <h5 class="card-title">
+                {x["key"]} <span class="badge badge-dark">config</span>
+              </h5>
+              <p class="card-text">
+                {"<br /> ".join(x["description"])}
+              </p>
+          </div>
+        </div>"""
+            for x in get_config_keys()
+        ]
+    )
 
 
 if __name__ == "__main__":
-    html = get_config_key_descriptions()
+    html = get_html()
     print(html)


### PR DESCRIPTION
ref: https://github.com/traccar/traccar/pull/4786#issuecomment-1003489111

Left the html generation as before. I tested the pug output on an online compiler. Seemed okay.