### PR TITLE
Totem - basic support for SMS and GPRS commands

### DIFF
--- a/src/main/java/org/traccar/protocol/TotemProtocol.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocol.java
@@ -25,7 +25,7 @@ import org.traccar.model.Command;
 public class TotemProtocol extends BaseProtocol {
 
     public TotemProtocol() {
-        setSupportedDataCommands(
+        String[] supportedCommands = new String[]{
                 Command.TYPE_CUSTOM,
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_FACTORY_RESET,
@@ -33,7 +33,12 @@ public class TotemProtocol extends BaseProtocol {
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_ENGINE_RESUME,
                 Command.TYPE_ENGINE_STOP
-        );
+        };
+        setSupportedDataCommands(supportedCommands);
+
+        setTextCommandEncoder(new TotemProtocolSmsEncoder(this));
+        setSupportedTextCommands(supportedCommands);
+
         addServer(new TrackerServer(false, getName()) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline) {

--- a/src/main/java/org/traccar/protocol/TotemProtocol.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocol.java
@@ -25,7 +25,7 @@ import org.traccar.model.Command;
 public class TotemProtocol extends BaseProtocol {
 
     public TotemProtocol() {
-        String[] supportedCommands = new String[]{
+        setSupportedDataCommands(
                 Command.TYPE_CUSTOM,
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_FACTORY_RESET,
@@ -33,11 +33,18 @@ public class TotemProtocol extends BaseProtocol {
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_ENGINE_RESUME,
                 Command.TYPE_ENGINE_STOP
-        };
-        setSupportedDataCommands(supportedCommands);
+        );
 
         setTextCommandEncoder(new TotemProtocolSmsEncoder(this));
-        setSupportedTextCommands(supportedCommands);
+        setSupportedTextCommands(
+                Command.TYPE_CUSTOM,
+                Command.TYPE_REBOOT_DEVICE,
+                Command.TYPE_FACTORY_RESET,
+                Command.TYPE_GET_VERSION,
+                Command.TYPE_POSITION_SINGLE,
+                Command.TYPE_ENGINE_RESUME,
+                Command.TYPE_ENGINE_STOP
+        );
 
         addServer(new TrackerServer(false, getName()) {
             @Override

--- a/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2015 Irving Gonzalez
- * Copyright 2015 - 2019 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2019 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,40 +15,27 @@
  */
 package org.traccar.protocol;
 
-import org.traccar.StringProtocolEncoder;
 import org.traccar.model.Command;
 import org.traccar.Protocol;
+import org.traccar.helper.Checksum;
 
-public class TotemProtocolEncoder extends StringProtocolEncoder {
+public class TotemProtocolEncoder extends TotemProtocolSmsEncoder {
 
     public TotemProtocolEncoder(Protocol protocol) {
         super(protocol);
     }
 
+    private String encodeCommand(String commandString) {
+        String builtCommand = String.format("$$%04dCF%s", 10 + commandString.getBytes().length, commandString);
+        return String.format("%s%02X", builtCommand, Checksum.xor(builtCommand));
+    }
+
     @Override
-    protected Object encodeCommand(Command command) {
+    protected String encodeCommand(Command command) {
 
         initDevicePassword(command, "000000");
 
-        switch (command.getType()) {
-            case Command.TYPE_CUSTOM:
-                return formatCommand(command, "*%s,%s#", Command.KEY_DEVICE_PASSWORD, Command.KEY_DATA);
-            case Command.TYPE_REBOOT_DEVICE:
-                return formatCommand(command, "*%s,006#", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_FACTORY_RESET:
-                return formatCommand(command, "*%s,007#", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_GET_VERSION:
-                return formatCommand(command, "*%s,056#", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_POSITION_SINGLE:
-                return formatCommand(command, "*%s,012#", Command.KEY_DEVICE_PASSWORD);
-            // Assuming PIN 8 (Output C) is the power wire, like manual says but it can be PIN 5,7,8
-            case Command.TYPE_ENGINE_STOP:
-                return formatCommand(command, "*%s,025,C,1#", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_ENGINE_RESUME:
-                return formatCommand(command, "*%s,025,C,0#", Command.KEY_DEVICE_PASSWORD);
-            default:
-                return null;
-        }
+        return encodeCommand(super.getCommandString(command));
     }
 
 }

--- a/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
@@ -27,23 +27,26 @@ public class TotemProtocolEncoder extends StringProtocolEncoder {
         super(protocol);
     }
 
-    protected String getCommandString(Command command) {
+    public static String formatContent(Command command) {
         switch (command.getType()) {
             case Command.TYPE_CUSTOM:
-                return formatCommand(command, "%s,%s", Command.KEY_DEVICE_PASSWORD, Command.KEY_DATA);
+                return String.format("%s,%s",
+                                     command.getAttributes().get(Command.KEY_DEVICE_PASSWORD),
+                                     command.getAttributes().get(Command.KEY_DATA)
+                                    );
             case Command.TYPE_REBOOT_DEVICE:
-                return formatCommand(command, "%s,006", Command.KEY_DEVICE_PASSWORD);
+                return String.format("%s,006", command.getAttributes().get(Command.KEY_DEVICE_PASSWORD));
             case Command.TYPE_FACTORY_RESET:
-                return formatCommand(command, "%s,007", Command.KEY_DEVICE_PASSWORD);
+                return String.format("%s,007", command.getAttributes().get(Command.KEY_DEVICE_PASSWORD));
             case Command.TYPE_GET_VERSION:
-                return formatCommand(command, "%s,056", Command.KEY_DEVICE_PASSWORD);
+                return String.format("%s,056", command.getAttributes().get(Command.KEY_DEVICE_PASSWORD));
             case Command.TYPE_POSITION_SINGLE:
-                return formatCommand(command, "%s,012", Command.KEY_DEVICE_PASSWORD);
+                return String.format("%s,012", command.getAttributes().get(Command.KEY_DEVICE_PASSWORD));
             // Assuming PIN 8 (Output C) is the power wire, like manual says but it can be PIN 5,7,8
             case Command.TYPE_ENGINE_STOP:
-                return formatCommand(command, "%s,025,C,1", Command.KEY_DEVICE_PASSWORD);
+                return String.format("%s,025,C,1", command.getAttributes().get(Command.KEY_DEVICE_PASSWORD));
             case Command.TYPE_ENGINE_RESUME:
-                return formatCommand(command, "%s,025,C,0", Command.KEY_DEVICE_PASSWORD);
+                return String.format("%s,025,C,0", command.getAttributes().get(Command.KEY_DEVICE_PASSWORD));
             default:
                 return null;
         }
@@ -54,7 +57,7 @@ public class TotemProtocolEncoder extends StringProtocolEncoder {
 
         initDevicePassword(command, "000000");
 
-        String commandString = getCommandString(command);
+        String commandString = formatContent(command);
         String builtCommand = String.format("$$%04dCF%s", 10 + commandString.getBytes().length, commandString);
 
         return String.format("%s%02X", builtCommand, Checksum.xor(builtCommand));

--- a/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2015 Irving Gonzalez
  * Copyright 2016 - 2019 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolEncoder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Irving Gonzalez
- * Copyright 2016 - 2019 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2019 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,49 @@
  */
 package org.traccar.protocol;
 
+import org.traccar.StringProtocolEncoder;
 import org.traccar.model.Command;
 import org.traccar.Protocol;
 import org.traccar.helper.Checksum;
 
-public class TotemProtocolEncoder extends TotemProtocolSmsEncoder {
+public class TotemProtocolEncoder extends StringProtocolEncoder {
 
     public TotemProtocolEncoder(Protocol protocol) {
         super(protocol);
     }
 
-    private String encodeCommand(String commandString) {
-        String builtCommand = String.format("$$%04dCF%s", 10 + commandString.getBytes().length, commandString);
-        return String.format("%s%02X", builtCommand, Checksum.xor(builtCommand));
+    protected String getCommandString(Command command) {
+        switch (command.getType()) {
+            case Command.TYPE_CUSTOM:
+                return formatCommand(command, "%s,%s", Command.KEY_DEVICE_PASSWORD, Command.KEY_DATA);
+            case Command.TYPE_REBOOT_DEVICE:
+                return formatCommand(command, "%s,006", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_FACTORY_RESET:
+                return formatCommand(command, "%s,007", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_GET_VERSION:
+                return formatCommand(command, "%s,056", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_POSITION_SINGLE:
+                return formatCommand(command, "%s,012", Command.KEY_DEVICE_PASSWORD);
+            // Assuming PIN 8 (Output C) is the power wire, like manual says but it can be PIN 5,7,8
+            case Command.TYPE_ENGINE_STOP:
+                return formatCommand(command, "%s,025,C,1", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_ENGINE_RESUME:
+                return formatCommand(command, "%s,025,C,0", Command.KEY_DEVICE_PASSWORD);
+            default:
+                return null;
+        }
     }
 
     @Override
-    protected String encodeCommand(Command command) {
+    protected Object encodeCommand(Command command) {
 
         initDevicePassword(command, "000000");
 
-        return encodeCommand(super.getCommandString(command));
+        String commandString = getCommandString(command);
+        String builtCommand = String.format("$$%04dCF%s", 10 + commandString.getBytes().length, commandString);
+
+        return String.format("%s%02X", builtCommand, Checksum.xor(builtCommand));
+
     }
 
 }

--- a/src/main/java/org/traccar/protocol/TotemProtocolSmsEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolSmsEncoder.java
@@ -16,10 +16,11 @@
  */
 package org.traccar.protocol;
 
+import org.traccar.StringProtocolEncoder;
 import org.traccar.model.Command;
 import org.traccar.Protocol;
 
-public class TotemProtocolSmsEncoder extends TotemProtocolEncoder {
+public class TotemProtocolSmsEncoder extends StringProtocolEncoder {
 
     public TotemProtocolSmsEncoder(Protocol protocol) {
         super(protocol);
@@ -30,7 +31,7 @@ public class TotemProtocolSmsEncoder extends TotemProtocolEncoder {
 
         initDevicePassword(command, "000000");
 
-        return String.format("*%s#", super.getCommandString(command));
+        return String.format("*%s#", TotemProtocolEncoder.formatContent(command));
     }
 
 }

--- a/src/main/java/org/traccar/protocol/TotemProtocolSmsEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolSmsEncoder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 Irving Gonzalez
+ * Copyright 2015 - 2019 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.traccar.StringProtocolEncoder;
+import org.traccar.model.Command;
+import org.traccar.Protocol;
+
+public class TotemProtocolSmsEncoder extends StringProtocolEncoder {
+
+    public TotemProtocolSmsEncoder(Protocol protocol) {
+        super(protocol);
+    }
+
+    protected String getCommandString(Command command) {
+        switch (command.getType()) {
+            case Command.TYPE_CUSTOM:
+                return formatCommand(command, "%s,%s", Command.KEY_DEVICE_PASSWORD, Command.KEY_DATA);
+            case Command.TYPE_REBOOT_DEVICE:
+                return formatCommand(command, "%s,006", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_FACTORY_RESET:
+                return formatCommand(command, "%s,007", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_GET_VERSION:
+                return formatCommand(command, "%s,056", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_POSITION_SINGLE:
+                return formatCommand(command, "%s,012", Command.KEY_DEVICE_PASSWORD);
+            // Assuming PIN 8 (Output C) is the power wire, like manual says but it can be PIN 5,7,8
+            case Command.TYPE_ENGINE_STOP:
+                return formatCommand(command, "%s,025,C,1", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_ENGINE_RESUME:
+                return formatCommand(command, "%s,025,C,0", Command.KEY_DEVICE_PASSWORD);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    protected String encodeCommand(Command command) {
+
+        initDevicePassword(command, "000000");
+
+        return String.format("*%s#", getCommandString(command));
+    }
+
+}

--- a/src/main/java/org/traccar/protocol/TotemProtocolSmsEncoder.java
+++ b/src/main/java/org/traccar/protocol/TotemProtocolSmsEncoder.java
@@ -16,44 +16,21 @@
  */
 package org.traccar.protocol;
 
-import org.traccar.StringProtocolEncoder;
 import org.traccar.model.Command;
 import org.traccar.Protocol;
 
-public class TotemProtocolSmsEncoder extends StringProtocolEncoder {
+public class TotemProtocolSmsEncoder extends TotemProtocolEncoder {
 
     public TotemProtocolSmsEncoder(Protocol protocol) {
         super(protocol);
     }
 
-    protected String getCommandString(Command command) {
-        switch (command.getType()) {
-            case Command.TYPE_CUSTOM:
-                return formatCommand(command, "%s,%s", Command.KEY_DEVICE_PASSWORD, Command.KEY_DATA);
-            case Command.TYPE_REBOOT_DEVICE:
-                return formatCommand(command, "%s,006", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_FACTORY_RESET:
-                return formatCommand(command, "%s,007", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_GET_VERSION:
-                return formatCommand(command, "%s,056", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_POSITION_SINGLE:
-                return formatCommand(command, "%s,012", Command.KEY_DEVICE_PASSWORD);
-            // Assuming PIN 8 (Output C) is the power wire, like manual says but it can be PIN 5,7,8
-            case Command.TYPE_ENGINE_STOP:
-                return formatCommand(command, "%s,025,C,1", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_ENGINE_RESUME:
-                return formatCommand(command, "%s,025,C,0", Command.KEY_DEVICE_PASSWORD);
-            default:
-                return null;
-        }
-    }
-
     @Override
-    protected String encodeCommand(Command command) {
+    protected Object encodeCommand(Command command) {
 
         initDevicePassword(command, "000000");
 
-        return String.format("*%s#", getCommandString(command));
+        return String.format("*%s#", super.getCommandString(command));
     }
 
 }

--- a/src/test/java/org/traccar/protocol/TotemProtocolEncoderTest.java
+++ b/src/test/java/org/traccar/protocol/TotemProtocolEncoderTest.java
@@ -15,10 +15,24 @@ public class TotemProtocolEncoderTest extends ProtocolTest {
 
         Command command = new Command();
         command.setDeviceId(2);
-        command.setType(Command.TYPE_ENGINE_STOP);
+        command.setType(Command.TYPE_REBOOT_DEVICE);
         command.set(Command.KEY_DEVICE_PASSWORD, "000000");
 
-        assertEquals("*000000,025,C,1#", encoder.encodeCommand(command));
+        assertEquals("$$0020CF000000,0061D", encoder.encodeCommand(command));
+
+    }
+    
+    @Test
+    public void testSmsEncode() throws Exception {
+
+        var encoder = new TotemProtocolSmsEncoder(null);
+
+        Command command = new Command();
+        command.setDeviceId(2);
+        command.setType(Command.TYPE_REBOOT_DEVICE);
+        command.set(Command.KEY_DEVICE_PASSWORD, "000000");
+
+        assertEquals("*000000,006#", encoder.encodeCommand(command));
 
     }
 


### PR DESCRIPTION
As mentioned in PR #4787 (also contains protocol documentation) I tried my hand at implementing SMS and GPRS commands for the Totem protocol. 

It's not yet finished, still have to test it on real devices, but basic tests look OK. I opened this pull request as I'm not proficient Java developer and am seeking feedback on code/organization. As the base format between modes is quite similar, I organized it so that the actual command get build only in one place, and then formatted for SMS or GPRS sending.

I know you are probably very busy, so I would like to thank you for taking time to review this.