### PR TITLE
Add an alarm code on Watch protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
@@ -89,6 +89,8 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
             return Position.ALARM_GEOFENCE_EXIT;
         } else if (BitUtil.check(status, 2)) {
             return Position.ALARM_GEOFENCE_ENTER;
+        } else if (BitUtil.check(status, 14)) {
+            return Position.ALARM_POWER_CUT; // some 2G devices raise this alarm when the device is unplugged from its charger
         } else if (BitUtil.check(status, 16)) {
             return Position.ALARM_SOS;
         } else if (BitUtil.check(status, 17)) {

--- a/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
@@ -90,7 +90,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
         } else if (BitUtil.check(status, 2)) {
             return Position.ALARM_GEOFENCE_ENTER;
         } else if (BitUtil.check(status, 14)) {
-            return Position.ALARM_POWER_CUT; // some 2G devices raise this alarm when the device is unplugged from its charger
+            return Position.ALARM_POWER_CUT; // raised by some 2G devices when unplugged from their charger
         } else if (BitUtil.check(status, 16)) {
             return Position.ALARM_SOS;
         } else if (BitUtil.check(status, 17)) {

--- a/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
@@ -90,7 +90,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
         } else if (BitUtil.check(status, 2)) {
             return Position.ALARM_GEOFENCE_ENTER;
         } else if (BitUtil.check(status, 14)) {
-            return Position.ALARM_POWER_CUT; // raised by some 2G devices when unplugged from their charger
+            return Position.ALARM_POWER_CUT;
         } else if (BitUtil.check(status, 16)) {
             return Position.ALARM_SOS;
         } else if (BitUtil.check(status, 17)) {


### PR DESCRIPTION
Some 2G devices send a 00004000 code when the device is removed from its charger. This is very useful as many cheap devices have a strange magnet connector which is very easy to unplug by accident. If not working, the feature might have to be activated by sending AON,1# to the device. Does NOT work on 4G devices which send a "sos" alert in that situation (00010000).