### PR TITLE
add skiplimit and skipAttributes checks for Duplicate filter again

### DIFF
--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -181,7 +181,7 @@ public class FilterHandler extends BaseDataHandler {
             } else {
                 preceding = getLastReceivedPosition(deviceId);
             }
-            if (filterDuplicate(position, preceding)) {
+            if (filterDuplicate(position, preceding) && !skipLimit(position, preceding) && !skipAttributes(position)) {
                 filterType.append("Duplicate ");
             }
             if (filterStatic(position) && !skipLimit(position, preceding) && !skipAttributes(position)) {


### PR DESCRIPTION
the skipAttributes  and skiplimit  checks was ok up to 4.14 ver. but it was removed accidentally in ver 4.15.
