### PR TITLE
Added support for YP14 from "1903" protocol specification

### DIFF
--- a/src/main/java/org/traccar/protocol/TrvProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TrvProtocolDecoder.java
@@ -59,7 +59,7 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
             .number("(d)")                       // acc
             .number("(dd)")                      // arm status
             .number("(dd)")                      // working mode
-            .number("(?:d{3,5})?,")              // (ignored)
+            .number("(?:d{3,5})?,")
             .number("(d+),")                     // mcc
             .number("(d+),")                     // mnc
             .number("(d+),")                     // lac

--- a/src/main/java/org/traccar/protocol/TrvProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TrvProtocolDecoder.java
@@ -59,7 +59,7 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
             .number("(d)")                       // acc
             .number("(dd)")                      // arm status
             .number("(dd)")                      // working mode
-            .number("(?:[0-2]{3})?,")
+            .number("(?:d{3,5})?,")              // (ignored)
             .number("(d+),")                     // mcc
             .number("(d+),")                     // mnc
             .number("(d+),")                     // lac
@@ -183,7 +183,7 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
 
             return position;
 
-        } else if (type.equals("AP01") || type.equals("AP10") || type.equals("YP03")) {
+        } else if (type.equals("AP01") || type.equals("AP10") || type.equals("YP03") || type.equals("YP14")) {
 
             Parser parser = new Parser(PATTERN, sentence);
             if (!parser.matches()) {

--- a/src/test/java/org/traccar/protocol/TrvProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/TrvProtocolDecoderTest.java
@@ -67,5 +67,7 @@ public class TrvProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, text(
                         "TRVYP14220217A5235.7885N00724.1840E000.0130919177.561000050660000200004,262,01,14635,52789,FritzBox7|DC-39-8F-7E-94-73|-89&FritzBox7|24-4E-5D-71-C3-9C|-90&MY_IOT|80-B4-F7-77-9C-7C|-81&MYAP|44-D4-F7-77-9C-7C|-80#"));
+        
     }
+    
 }

--- a/src/test/java/org/traccar/protocol/TrvProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/TrvProtocolDecoderTest.java
@@ -67,7 +67,7 @@ public class TrvProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, text(
                         "TRVYP14220217A5235.7885N00724.1840E000.0130919177.561000050660000200004,262,01,14635,52789,FritzBox7|DC-39-8F-7E-94-73|-89&FritzBox7|24-4E-5D-71-C3-9C|-90&MY_IOT|80-B4-F7-77-9C-7C|-81&MYAP|44-D4-F7-77-9C-7C|-80#"));
-        
+
     }
-    
+
 }

--- a/src/test/java/org/traccar/protocol/TrvProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/TrvProtocolDecoderTest.java
@@ -65,6 +65,7 @@ public class TrvProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, text(
                 "TRVAP10080524A2232.9806N11404.9355E000.1061830323.8706000908000502,460,0,9520,3671,00,zh-cn,00"));
 
+        verifyPosition(decoder, text(
+                        "TRVYP14220217A5235.7885N00724.1840E000.0130919177.561000050660000200004,262,01,14635,52789,FritzBox7|DC-39-8F-7E-94-73|-89&FritzBox7|24-4E-5D-71-C3-9C|-90&MY_IOT|80-B4-F7-77-9C-7C|-81&MYAP|44-D4-F7-77-9C-7C|-80#"));
     }
-
 }


### PR DESCRIPTION
Hi,

this pull requests adds support for the 1903 protocol devices.
There are 3 simples changes:
- I had to allow more matches for (unused) fields in the otherwise perfectly fitting PATTERN. Strictly according to the 1903 protocol specification.
- allowed "YP14" as new condition to be parsed as position information
- added a test for a YP14 message

Regards