### PR TITLE
Fix Ignition State updating on JM-VL01 and similar devices

### DIFF
--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -964,6 +964,10 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
         if (buf.readableBytes() == 4 + 6) {
             position.set(Position.KEY_ODOMETER, buf.readUnsignedInt());
         }
+        
+        if (type == MSG_GPS_2 && buf.readableBytes() >= 5) {
+            position.set(Position.KEY_IGNITION, buf.readUnsignedByte() > 0);
+        }
     }
 
     private Object decodeExtended(Channel channel, SocketAddress remoteAddress, ByteBuf buf) {

--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -965,7 +965,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_ODOMETER, buf.readUnsignedInt());
         }
         
-        if (type == MSG_GPS_2 && buf.readableBytes() >= 5) {
+        if (type == MSG_GPS_2 && (buf.readableBytes() == 9 || buf.readableBytes() == 13)) {
             position.set(Position.KEY_IGNITION, buf.readUnsignedByte() > 0);
         }
     }


### PR DESCRIPTION
Updates Ignition State from 0xA0 location packet (MSG_GPS_2).
This information was previously ignored, and Ignition State was only obtained from 0x13 Heartbeat Packet (MSG_STATUS).

Ignition State is now updated immediately, rather than waiting considerable time for the next Heartbeat, which caused Notifications to be delayed or missed completely.

Note: There are still a few readable byes in the 0xA0 packet that are ignored.