### PR TITLE
pass language param to OpenCage Geocoder

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -181,7 +181,7 @@ public class MainModule extends AbstractModule {
                 case "mapquest":
                     return new MapQuestGeocoder(url, key, cacheSize, addressFormat);
                 case "opencage":
-                    return new OpenCageGeocoder(url, key, cacheSize, addressFormat);
+                    return new OpenCageGeocoder(url, key, language, cacheSize, addressFormat);
                 case "bingmaps":
                     return new BingMapsGeocoder(url, key, cacheSize, addressFormat);
                 case "factual":

--- a/src/main/java/org/traccar/geocoder/OpenCageGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/OpenCageGeocoder.java
@@ -26,9 +26,7 @@ public class OpenCageGeocoder extends JsonGeocoder {
             url = "https://api.opencagedata.com/geocode/v1";
         }
         url += "/json?q=%f,%f&no_annotations=1&key=" + key;
-        if (language == null) {
-            url += "&language=en";
-        } else {
+        if (language != null) {
             url += "&language=" + language;
         }
         return url;

--- a/src/main/java/org/traccar/geocoder/OpenCageGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/OpenCageGeocoder.java
@@ -21,16 +21,21 @@ import javax.json.JsonObject;
 
 public class OpenCageGeocoder extends JsonGeocoder {
 
-    private static String formatUrl(String url, String key) {
+    private static String formatUrl(String url, String key, String language) {
         if (url == null) {
             url = "https://api.opencagedata.com/geocode/v1";
         }
         url += "/json?q=%f,%f&no_annotations=1&key=" + key;
+        if (language != null) {
+            url += "&language=" + language;
+        } else {
+            url += "&language=en";
+        }
         return url;
     }
 
-    public OpenCageGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
-        super(formatUrl(url, key), cacheSize, addressFormat);
+    public OpenCageGeocoder(String url, String key, String language, int cacheSize, AddressFormat addressFormat) {
+        super(formatUrl(url, key, language), cacheSize, addressFormat);
     }
 
     @Override

--- a/src/main/java/org/traccar/geocoder/OpenCageGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/OpenCageGeocoder.java
@@ -26,10 +26,10 @@ public class OpenCageGeocoder extends JsonGeocoder {
             url = "https://api.opencagedata.com/geocode/v1";
         }
         url += "/json?q=%f,%f&no_annotations=1&key=" + key;
-        if (language != null) {
-            url += "&language=" + language;
-        } else {
+        if (language == null) {
             url += "&language=en";
+        } else {
+            url += "&language=" + language;
         }
         return url;
     }

--- a/src/test/java/org/traccar/geocoder/GeocoderTest.java
+++ b/src/test/java/org/traccar/geocoder/GeocoderTest.java
@@ -41,7 +41,7 @@ public class GeocoderTest {
     @Test
     public void testOpenCage() {
         Geocoder geocoder = new OpenCageGeocoder(
-                "http://api.opencagedata.com/geocode/v1", "SECRET", 0, new AddressFormat());
+                "http://api.opencagedata.com/geocode/v1", "SECRET", "en", 0, new AddressFormat());
         String address = geocoder.getAddress(34.116302, -118.051519, null);
         assertEquals("Charleston Road, California, US", address);
     }

--- a/src/test/java/org/traccar/geocoder/GeocoderTest.java
+++ b/src/test/java/org/traccar/geocoder/GeocoderTest.java
@@ -41,7 +41,7 @@ public class GeocoderTest {
     @Test
     public void testOpenCage() {
         Geocoder geocoder = new OpenCageGeocoder(
-                "http://api.opencagedata.com/geocode/v1", "SECRET", "en", 0, new AddressFormat());
+                "http://api.opencagedata.com/geocode/v1", "SECRET", null, 0, new AddressFormat());
         String address = geocoder.getAddress(34.116302, -118.051519, null);
         assertEquals("Charleston Road, California, US", address);
     }


### PR DESCRIPTION
follows the same logic as Nominatim which also accepts a language param to allow user to see response in their language