### PR TITLE
Change devicelimit userlimit permission to match with LDAP

### DIFF
--- a/src/main/java/org/traccar/model/User.java
+++ b/src/main/java/org/traccar/model/User.java
@@ -167,7 +167,7 @@ public class User extends ExtendedModel {
         this.expirationTime = expirationTime;
     }
 
-    private int deviceLimit;
+    private int deviceLimit = -1;
 
     public int getDeviceLimit() {
         return deviceLimit;
@@ -177,7 +177,7 @@ public class User extends ExtendedModel {
         this.deviceLimit = deviceLimit;
     }
 
-    private int userLimit;
+    private int userLimit = -1;
 
     public int getUserLimit() {
         return userLimit;


### PR DESCRIPTION
When you are linking traccar to an external system when LDAP is enabled, automatically the devicelimit and userlimit is set to 0, which leads the user cannot create any user and well as add any devices. You will need to log to traccar via the UI and manually change the limits in order to create a user or add a new device. 
So I have made the changes the default value as -1 for devicelimit and userlimit on User.java.