### PR TITLE
Allow websocket connection trough "Basic Authorization" headers

### DIFF
--- a/src/main/java/org/traccar/api/AsyncSocketServlet.java
+++ b/src/main/java/org/traccar/api/AsyncSocketServlet.java
@@ -20,15 +20,10 @@ import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.traccar.Context;
 import org.traccar.api.resource.SessionResource;
 import org.traccar.config.Keys;
-import org.traccar.model.User;
-import org.traccar.storage.StorageException;
 
 import javax.servlet.http.HttpSession;
-import javax.ws.rs.WebApplicationException;
 import java.time.Duration;
 
-import static org.traccar.api.security.SecurityRequestFilter.AUTHORIZATION_HEADER;
-import static org.traccar.api.security.SecurityRequestFilter.decodeBasicAuth;
 
 public class AsyncSocketServlet extends JettyWebSocketServlet {
 
@@ -36,26 +31,11 @@ public class AsyncSocketServlet extends JettyWebSocketServlet {
     public void configure(JettyWebSocketServletFactory factory) {
         factory.setIdleTimeout(Duration.ofMillis(Context.getConfig().getLong(Keys.WEB_TIMEOUT)));
         factory.setCreator((req, resp) -> {
-            String authHeader = req.getHeader(AUTHORIZATION_HEADER);
-            if (authHeader != null) {
-                try {
-                    String[] auth = decodeBasicAuth(authHeader);
-                    User user = Context.getPermissionsManager().login(auth[0], auth[1]);
-
-                    if (user != null) {
-                        return new AsyncSocket(user.getId());
-                    }
-                    return  null;
-                } catch (StorageException e) {
-                    throw new WebApplicationException(e);
-                }
+            if (req.getSession() != null) {
+                long userId = (Long) ((HttpSession) req.getSession()).getAttribute(SessionResource.USER_ID_KEY);
+                return new AsyncSocket(userId);
             } else {
-                if (req.getSession() != null) {
-                    long userId = (Long) ((HttpSession) req.getSession()).getAttribute(SessionResource.USER_ID_KEY);
-                    return new AsyncSocket(userId);
-                } else {
-                    return null;
-                }
+                return null;
             }
         });
     }

--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -48,13 +48,8 @@ import org.slf4j.LoggerFactory;
 import org.traccar.Context;
 import org.traccar.LifecycleObject;
 import org.traccar.Main;
-import org.traccar.api.DateParameterConverterProvider;
+import org.traccar.api.*;
 import org.traccar.config.Config;
-import org.traccar.api.AsyncSocketServlet;
-import org.traccar.api.CorsResponseFilter;
-import org.traccar.api.MediaFilter;
-import org.traccar.api.ObjectMapperProvider;
-import org.traccar.api.ResourceErrorHandler;
 import org.traccar.api.security.SecurityRequestFilter;
 import org.traccar.api.resource.ServerResource;
 import org.traccar.config.Keys;
@@ -165,6 +160,7 @@ public class WebServer implements LifecycleObject {
 
     private void initApi(Config config, ServletContextHandler servletHandler) {
         servletHandler.addServlet(new ServletHolder(new AsyncSocketServlet()), "/api/socket");
+        servletHandler.addFilter(SecurityRequestFilter.class, "/api/socket", EnumSet.allOf(DispatcherType.class));
         JettyWebSocketServletContainerInitializer.configure(servletHandler, null);
 
         String mediaPath = config.getString(Keys.MEDIA_PATH);


### PR DESCRIPTION
I´m currently using angular as the client app with an implemented HTTP Interceptor to put the "Authorization" headers on each request, 
it would be great if we could connect to the WebSocket using the "Authorization" headers, 

besides.... my session is always getting null value for the "userId", which throws an parse error  on line
```
long userId = (Long) ((HttpSession) req.getSession()).getAttribute(SessionResource.USER_ID_KEY);
```
Allowing the connection trough the header would solve the problem.