### PR TITLE
Fix for watch protocol with zero base stations

### DIFF
--- a/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/WatchProtocolDecoder.java
@@ -142,8 +142,8 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
         Network network = new Network();
 
         int cellCount = Integer.parseInt(values[index++]);
-        index += 1; // timing advance
         if (cellCount > 0) {
+            index += 1; // timing advance
             int mcc = !values[index].isEmpty() ? Integer.parseInt(values[index++]) : 0;
             int mnc = !values[index].isEmpty() ? Integer.parseInt(values[index++]) : 0;
 
@@ -164,8 +164,11 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
 
             for (int i = 0; i < wifiCount; i++) {
                 index += 1; // wifi name
-                network.addWifiAccessPoint(WifiAccessPoint.from(
-                        values[index++], Integer.parseInt(values[index++])));
+                String macAddress = values[index++];
+                String rssi = values[index++];
+                if (!macAddress.isEmpty() && !macAddress.equals("0") && !rssi.isEmpty()) {
+                    network.addWifiAccessPoint(WifiAccessPoint.from(macAddress, Integer.parseInt(rssi)));
+                }
             }
         }
 

--- a/src/test/java/org/traccar/ProtocolTest.java
+++ b/src/test/java/org/traccar/ProtocolTest.java
@@ -14,6 +14,7 @@ import org.traccar.helper.DataConverter;
 import org.traccar.model.CellTower;
 import org.traccar.model.Command;
 import org.traccar.model.Position;
+import org.traccar.model.WifiAccessPoint;
 
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
@@ -310,12 +311,20 @@ public class ProtocolTest extends BaseTest {
             assertTrue(attributes.get(Position.KEY_RESULT) instanceof String);
         }
 
-        if (position.getNetwork() != null && position.getNetwork().getCellTowers() != null) {
-            for (CellTower cellTower : position.getNetwork().getCellTowers()) {
-                checkInteger(cellTower.getMobileCountryCode(), 0, 999);
-                checkInteger(cellTower.getMobileNetworkCode(), 0, 999);
-                checkInteger(cellTower.getLocationAreaCode(), 1, 65535);
-                checkInteger(cellTower.getCellId(), 0, 268435455);
+        if (position.getNetwork() != null) {
+            if (position.getNetwork().getCellTowers() != null) {
+                for (CellTower cellTower : position.getNetwork().getCellTowers()) {
+                    checkInteger(cellTower.getMobileCountryCode(), 0, 999);
+                    checkInteger(cellTower.getMobileNetworkCode(), 0, 999);
+                    checkInteger(cellTower.getLocationAreaCode(), 1, 65535);
+                    checkInteger(cellTower.getCellId(), 0, 268435455);
+                }
+            }
+
+            if (position.getNetwork().getWifiAccessPoints() != null) {
+                for (WifiAccessPoint wifiAccessPoint : position.getNetwork().getWifiAccessPoints()) {
+                    assertTrue("validation failed for mac address with zero value", !wifiAccessPoint.getMacAddress().equals("0"));
+                }
             }
         }
 

--- a/src/test/java/org/traccar/protocol/WatchProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/WatchProtocolDecoderTest.java
@@ -143,6 +143,9 @@ public class WatchProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, buffer(
                 "[ZJ*014111001350304*0038*008a*UD,070318,021027,V,00.000000,N,000.000000,E,0,0,0,0,100,18,1000,50,00000000,4,255,460,0,9346,5223,42,9346,5214,20,9784,4083,11,9346,5221,5]"));
 
+        verifyPosition(decoder, buffer(
+                "[3G*8800000015*00DD*UD,010120,025946,V,0.0,N,0.0,E,22.0,0,-1,0,100,98,0,0,00000000,0,5,eduroam,f4:db:e6:d2:a8:00,-53,eduroam,f4:db:e6:da:d0:80,-79,eduroam,78:0c:f0:24:f9:80,-82,Lions,b0:be:76:0a:05:9a,-82,tubs-guest,0,-53,0.0]"));
+
     }
 
     @Test


### PR DESCRIPTION
The issue discussion started at Traccar forum [here](https://www.traccar.org/forums/topic/watch-protocol-numberformatexception/#post-72333).

The documentation is attached [here](https://github.com/traccar/traccar/files/8994431/Communication.protocol-V3.0_20210423.pdf).

The problem was because of timing advance, as it was still retrieved even if base station information was not attached or base stations count was zero.

If there is no base station information attached or base station number is zero then it means there is no TA as well, as TA is a part of base stations information.
 So, TA moved to inner block.

A check for invalid mac address with value of 0 has been applied. A verification for this has been created in protocol test.

The rest of the conversation can be seen in PR #4874 