### PR TITLE
2 Bugs on maintenance

### DIFF
--- a/src/main/java/org/traccar/handler/events/MaintenanceEventHandler.java
+++ b/src/main/java/org/traccar/handler/events/MaintenanceEventHandler.java
@@ -51,13 +51,15 @@ public class MaintenanceEventHandler extends BaseEventHandler {
             if (maintenance.getPeriod() != 0) {
                 double oldValue = lastPosition.getDouble(maintenance.getType());
                 double newValue = position.getDouble(maintenance.getType());
-                if (oldValue != 0.0 && newValue != 0.0
-                        && (long) ((oldValue - maintenance.getStart()) / maintenance.getPeriod())
+                if (oldValue != 0.0 && newValue != 0.0 && newValue >= maintenance.getStart()) {
+                    if (oldValue < maintenance.getStart()            
+                        || (long) ((oldValue - maintenance.getStart()) / maintenance.getPeriod())
                         < (long) ((newValue - maintenance.getStart()) / maintenance.getPeriod())) {
-                    Event event = new Event(Event.TYPE_MAINTENANCE, position);
-                    event.setMaintenanceId(maintenance.getId());
-                    event.set(maintenance.getType(), newValue);
-                    events.put(event, position);
+                        Event event = new Event(Event.TYPE_MAINTENANCE, position);
+                        event.setMaintenanceId(maintenance.getId());
+                        event.set(maintenance.getType(), newValue);
+                        events.put(event, position);
+                    }
                 }
             }
         }

--- a/src/main/java/org/traccar/handler/events/MaintenanceEventHandler.java
+++ b/src/main/java/org/traccar/handler/events/MaintenanceEventHandler.java
@@ -52,7 +52,7 @@ public class MaintenanceEventHandler extends BaseEventHandler {
                 double oldValue = lastPosition.getDouble(maintenance.getType());
                 double newValue = position.getDouble(maintenance.getType());
                 if (oldValue != 0.0 && newValue != 0.0 && newValue >= maintenance.getStart()) {
-                    if (oldValue < maintenance.getStart()            
+                    if (oldValue < maintenance.getStart()
                         || (long) ((oldValue - maintenance.getStart()) / maintenance.getPeriod())
                         < (long) ((newValue - maintenance.getStart()) / maintenance.getPeriod())) {
                         Event event = new Event(Event.TYPE_MAINTENANCE, position);

--- a/src/test/java/org/traccar/handler/events/MaintenanceEventHandlerTest.java
+++ b/src/test/java/org/traccar/handler/events/MaintenanceEventHandlerTest.java
@@ -1,0 +1,60 @@
+package org.traccar.handler.events;
+
+import org.junit.Test;
+import org.traccar.BaseTest;
+import org.traccar.model.Maintenance;
+import org.traccar.model.Position;
+import org.traccar.session.cache.CacheManager;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+public class MaintenanceEventHandlerTest extends BaseTest {
+    
+    @Test
+    public void testMaintenanceEventHandler() {
+        Position lastPosition = new Position();
+        lastPosition.setDeviceId(1);
+        lastPosition.setFixTime(new Date(0));
+
+        Position position = new Position();
+        position.setDeviceId(1);
+        position.setFixTime(new Date(0));
+
+        var maintenance = mock(Maintenance.class);
+        when(maintenance.getType()).thenReturn(Position.KEY_TOTAL_DISTANCE);
+        var maintenances = Arrays.asList(maintenance);
+
+        var cacheManager = mock(CacheManager.class);
+        when(cacheManager.getDeviceObjects(anyLong(), eq(Maintenance.class))).thenReturn(maintenances);
+        when(cacheManager.getPosition(anyLong())).thenReturn(lastPosition);
+        MaintenanceEventHandler eventHandler = new MaintenanceEventHandler(cacheManager);        
+
+        when(maintenance.getStart()).thenReturn(10000.0);
+        when(maintenance.getPeriod()).thenReturn(2000.0);                
+ 
+        lastPosition.set(Position.KEY_TOTAL_DISTANCE, 1999);
+        position.set(Position.KEY_TOTAL_DISTANCE, 2001);        
+        assertTrue(eventHandler.analyzePosition(position).isEmpty());
+
+        lastPosition.set(Position.KEY_TOTAL_DISTANCE, 3999);
+        position.set(Position.KEY_TOTAL_DISTANCE, 4001);        
+        assertTrue(eventHandler.analyzePosition(position).isEmpty());
+
+        lastPosition.set(Position.KEY_TOTAL_DISTANCE, 9999);
+        position.set(Position.KEY_TOTAL_DISTANCE, 10001);        
+        assertTrue(eventHandler.analyzePosition(position).size() == 1);
+
+        lastPosition.set(Position.KEY_TOTAL_DISTANCE, 11999);
+        position.set(Position.KEY_TOTAL_DISTANCE, 12001);        
+        assertTrue(eventHandler.analyzePosition(position).size() == 1);
+        
+    }
+
+}


### PR DESCRIPTION
According to the documentation:

> Traccar generates event every time totalDistance attribute gets over maintenance.start + maintenance.interval * N value where N is a natural number.
> 
> Example:
> maintenance.start=6000000, maintenance.interval=8000000
> 
> Events will be generated when totalDistance goes over 6000 km, 14000 km, 22000 km and so on.

The formula isn't coherent with the example because 0 is not a natural number. But the formula is correctly implemented, so, the event **won't be fired** when it goes over 6000 km. This the first bug.

If maintenance.interval < maintenance.start  and maintenance.start is multiple of maintenance.interval then the event will be fired before maintenance.start because the comparison will be on negative numbers. 
Another solution would be to use absolute values on the comparison.  This is the second bug.

### Example:
maintenance.start = 10 000 000
maintenance.interval = 2 000 000

the event **will be fired** when it goes over 2 000 000 
the event **wont' be fired** when it goes over 10 000 000