### PR TITLE
Added Can Properties and Value to Hex Decimal

### DIFF
--- a/src/main/java/org/traccar/model/Position.java
+++ b/src/main/java/org/traccar/model/Position.java
@@ -145,6 +145,24 @@ public class Position extends Message {
     public static final String ALARM_TAMPERING = "tampering";
     public static final String ALARM_REMOVING = "removing";
 
+    public static final String KEY_CAN0 = "can0";
+    public static final String KEY_CAN1 = "can1";
+    public static final String KEY_CAN2 = "can2";
+    public static final String KEY_CAN3 = "can3";
+    public static final String KEY_CAN4 = "can4";
+    public static final String KEY_CAN5 = "can5";
+    public static final String KEY_CAN6 = "can6";
+    public static final String KEY_CAN7 = "can7";
+    public static final String KEY_CAN8 = "can8";
+    public static final String KEY_CAN9 = "can9";
+    public static final String KEY_CAN10 = "can10";
+    public static final String KEY_CAN11 = "can11";
+    public static final String KEY_CAN12 = "can12";
+    public static final String KEY_CAN13 = "can13";
+    public static final String KEY_CAN14 = "can14";
+    public static final String KEY_CAN15 = "can15";
+
+
     public Position() {
     }
 

--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -276,6 +276,22 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
                     break;
             }
         });
+        register(900, null, (p, b) -> p.set(Position.KEY_CAN0, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(901, null, (p, b) -> p.set(Position.KEY_CAN1, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(902, null, (p, b) -> p.set(Position.KEY_CAN2, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(903, null, (p, b) -> p.set(Position.KEY_CAN3, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(904, null, (p, b) -> p.set(Position.KEY_CAN4, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(905, null, (p, b) -> p.set(Position.KEY_CAN5, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(906, null, (p, b) -> p.set(Position.KEY_CAN6, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(907, null, (p, b) -> p.set(Position.KEY_CAN7, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(908, null, (p, b) -> p.set(Position.KEY_CAN8, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(909, null, (p, b) -> p.set(Position.KEY_CAN9, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(910, null, (p, b) -> p.set(Position.KEY_CAN10, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(911, null, (p, b) -> p.set(Position.KEY_CAN11, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(912, null, (p, b) -> p.set(Position.KEY_CAN12, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(913, null, (p, b) -> p.set(Position.KEY_CAN13, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(914, null, (p, b) -> p.set(Position.KEY_CAN14, ByteBufUtil.hexDump(b.readSlice(8))));
+        register(915, null, (p, b) -> p.set(Position.KEY_CAN15, ByteBufUtil.hexDump(b.readSlice(8))));
     }
 
     private void decodeGh3000Parameter(Position position, int id, ByteBuf buf, int length) {


### PR DESCRIPTION
CAN elements a standart on below documentations. If we use with decodeParameter can come just long value on position. I will have plan to change this situation with mask system. It's first step.

That IDs just using with 1 protocol and using with can spesifcly/unique differents(Manual CAN Data)

https://wiki.teltonika-mobility.com/view/TFT100_AVL_ID_List#Manual_CAN_I.2FO_elements