### PR TITLE
Lbs for tlt2h

### DIFF
--- a/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -194,7 +194,7 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
                     boolean isPositionValid = parser.next().equals("A");
                     position.setValid(isPositionValid);
 
-                    if(isPositionValid) {
+                    if (isPositionValid) {
                         position.setLatitude(parser.nextCoordinate());
                         position.setLongitude(parser.nextCoordinate());
                         position.setSpeed(parser.nextDouble(0));
@@ -204,8 +204,8 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
                     }
 
                     dateBuilder.setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-                    
-                    if(isPositionValid) {
+
+                    if (isPositionValid) {
                         position.setTime(dateBuilder.getDate());
                     } else {
                         getLastLocation(position, dateBuilder.getDate());

--- a/src/test/java/org/traccar/protocol/Tlt2hProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Tlt2hProtocolDecoderTest.java
@@ -81,6 +81,13 @@ public class Tlt2hProtocolDecoderTest extends ProtocolTest {
                 "#357671031289215#V600#0000#AUTOLOW#1\r\n",
                 "#00735e1c$GPRMC,115647.000,A,5553.6524,N,02632.3128,E,0.00,0.0,130614,0.0,W,A*28"));
 
+        verifyPositions(decoder, false, text(
+                "#860186058100000#MT700#0000#AUTO#1\r\n",
+                "#39#262,03,8CE6,A672$WIFI,154928.00,A,-74,3CA62F52615B,-82,A0E4CB83852D,,,050123*28\r\n##\r\n"));
+
+        verifyPositions(decoder, false, text(
+                "#860186058100000#MT700#0000#AUTO#1\r\n",
+                "#39#262,03,8CE6,A672$GPRMC,115419.00,V,,,,,,,050123,,,A*7D\r\n##\r\n"));
     }
 
 }


### PR DESCRIPTION
This branch adds LBS support for tlt2h protocol.

According to [this protocol](https://www.mictrack.com/downloads/protocols/Mictrack_Communication_Protocol_For_MT700_V1.0.pdf) there is also LBS data available in the packet if this is enabled in the device.

The docs mentions, this LBS data is an optional part of data packet, if it is enabled then it would be provided both in GPS and WiFi packets.