### PR TITLE
Append items in gitignore for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ nbactions.xml
 .gradle
 out
 build
+.vscode
+bin


### PR DESCRIPTION
The `bin` folder is generated by `Extension Pack for Java` in `VS Code`.
The `.vscode` folder is generated by `VS Code` directly.

These are generated in the development environment, ignoring them helps keep the git tree clean.