### PR TITLE
Implement JEXL parser settings

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1299,6 +1299,101 @@ public final class Keys {
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES = new BooleanConfigKey(
             "processing.computedAttributes.deviceAttributes",
             List.of(KeyType.CONFIG));
+    /**
+     * Enable annotation constructs processing.
+     * When disabled, parsing a script/expression using syntactic annotation constructs (@annotation) will throw a parsing exception.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_ANNOTATION = new BooleanConfigKey(
+            "processing.computedAttributes.parser.annotation",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable array references processing.
+     *  When disabled, parsing a script/expression using 'obj[ ref ]' where ref is not a string or integer literal will throw a parsing exception;
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_ARRAY_REFERENCES = new BooleanConfigKey(
+            "processing.computedAttributes.parser.arrayReferences",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable lambda declaration.
+     * When disabled, parsing a script/expression using syntactic lambda constructs (->,function) will throw a parsing exception.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LAMBDA = new BooleanConfigKey(
+            "processing.computedAttributes.parser.lambda",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable whether redefining local variables is an error.
+     * When disabled, parsing a script/expression using a local variable or parameter syntax will throw a parsing exception.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL = new BooleanConfigKey(
+            "processing.computedAttributes.parser.lexical",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable whether local variables shade global variables outside their scope.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL_SHADE = new BooleanConfigKey(
+            "processing.computedAttributes.parser.lexicalShade",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable local variables declaration.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES = new BooleanConfigKey(
+            "processing.computedAttributes.parser.localVariables",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable loops processing.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOOPS = new BooleanConfigKey(
+            "processing.computedAttributes.parser.loops",
+            List.of(KeyType.CONFIG));
+    /**
+     * Set whether object method calls are enabled.
+     * When disabled, parsing a script/expression using 'obj.method()' will throw a parsing exception;
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_METHOD_CALLS = new BooleanConfigKey(
+            "processing.computedAttributes.parser.method_calls",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable new instances creation.
+     * When disabled, parsing a script/expression using 'new(...)' will throw a parsing exception; using a class as functor will fail.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION = new BooleanConfigKey(
+            "processing.computedAttributes.parser.newInstanceCreation",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable pragma expressions processing.
+     * When disabled, parsing a script/expression using syntactic pragma constructs (#pragma) will throw a parsing exception.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_PRAGMA = new BooleanConfigKey(
+            "processing.computedAttributes.parser.pragma",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable scripts constructs processing.
+     * When disabled, parsing a script using syntactic script constructs (statements, ...) will throw a parsing exception.
+     * Dangerous, as can be used to escalate privileges on the Traccar server.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_SCRIPT_CONSTRUCTS = new BooleanConfigKey(
+            "processing.computedAttributes.parser.scriptConstructs",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable side effect expressions processing.
+     * When disabled, parsing a script/expression using syntactical constructs modifying variables or members will throw a parsing exception.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT = new BooleanConfigKey(
+            "processing.computedAttributes.parser.sideEffect",
+            List.of(KeyType.CONFIG));
+    /**
+     * Set whether side effect expressions on global variables (aka non-local) are enabled.
+     * When disabled, parsing a script/expression using syntactical constructs modifying variables including all potentially ant-ish variables will throw a parsing exception.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT_GLOBAL = new BooleanConfigKey(
+            "processing.computedAttributes.parser.sideEffectGlobal",
+            List.of(KeyType.CONFIG));
+    /**
+     * Enable array/map/set literal expressions processing.
+     */
+    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_STRUCTURED_LITERAL = new BooleanConfigKey(
+            "processing.computedAttributes.parser.structuredLiteral",
+            List.of(KeyType.CONFIG));
 
     /**
      * Boolean flag to enable or disable reverse geocoder.

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1300,101 +1300,24 @@ public final class Keys {
             "processing.computedAttributes.deviceAttributes",
             List.of(KeyType.CONFIG));
     /**
-     * Enable annotation constructs processing.
-     * When disabled, parsing a script/expression using syntactic annotation constructs (@annotation) will throw a parsing exception.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_ANNOTATION = new BooleanConfigKey(
-            "processing.computedAttributes.parser.annotation",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable array references processing.
-     *  When disabled, parsing a script/expression using 'obj[ ref ]' where ref is not a string or integer literal will throw a parsing exception;
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_ARRAY_REFERENCES = new BooleanConfigKey(
-            "processing.computedAttributes.parser.arrayReferences",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable lambda declaration.
-     * When disabled, parsing a script/expression using syntactic lambda constructs (->,function) will throw a parsing exception.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LAMBDA = new BooleanConfigKey(
-            "processing.computedAttributes.parser.lambda",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable whether redefining local variables is an error.
-     * When disabled, parsing a script/expression using a local variable or parameter syntax will throw a parsing exception.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL = new BooleanConfigKey(
-            "processing.computedAttributes.parser.lexical",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable whether local variables shade global variables outside their scope.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL_SHADE = new BooleanConfigKey(
-            "processing.computedAttributes.parser.lexicalShade",
-            List.of(KeyType.CONFIG));
-    /**
      * Enable local variables declaration.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES = new BooleanConfigKey(
-            "processing.computedAttributes.parser.localVariables",
+            "processing.computedAttributes.localVariables",
             List.of(KeyType.CONFIG));
     /**
      * Enable loops processing.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOOPS = new BooleanConfigKey(
-            "processing.computedAttributes.parser.loops",
-            List.of(KeyType.CONFIG));
-    /**
-     * Set whether object method calls are enabled.
-     * When disabled, parsing a script/expression using 'obj.method()' will throw a parsing exception;
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_METHOD_CALLS = new BooleanConfigKey(
-            "processing.computedAttributes.parser.method_calls",
+            "processing.computedAttributes.loops",
             List.of(KeyType.CONFIG));
     /**
      * Enable new instances creation.
      * When disabled, parsing a script/expression using 'new(...)' will throw a parsing exception; using a class as functor will fail.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION = new BooleanConfigKey(
-            "processing.computedAttributes.parser.newInstanceCreation",
+            "processing.computedAttributes.newInstanceCreation",
             List.of(KeyType.CONFIG));
-    /**
-     * Enable pragma expressions processing.
-     * When disabled, parsing a script/expression using syntactic pragma constructs (#pragma) will throw a parsing exception.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_PRAGMA = new BooleanConfigKey(
-            "processing.computedAttributes.parser.pragma",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable scripts constructs processing.
-     * When disabled, parsing a script using syntactic script constructs (statements, ...) will throw a parsing exception.
-     * Dangerous, as can be used to escalate privileges on the Traccar server.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_SCRIPT_CONSTRUCTS = new BooleanConfigKey(
-            "processing.computedAttributes.parser.scriptConstructs",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable side effect expressions processing.
-     * When disabled, parsing a script/expression using syntactical constructs modifying variables or members will throw a parsing exception.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT = new BooleanConfigKey(
-            "processing.computedAttributes.parser.sideEffect",
-            List.of(KeyType.CONFIG));
-    /**
-     * Set whether side effect expressions on global variables (aka non-local) are enabled.
-     * When disabled, parsing a script/expression using syntactical constructs modifying variables including all potentially ant-ish variables will throw a parsing exception.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT_GLOBAL = new BooleanConfigKey(
-            "processing.computedAttributes.parser.sideEffectGlobal",
-            List.of(KeyType.CONFIG));
-    /**
-     * Enable array/map/set literal expressions processing.
-     */
-    public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_STRUCTURED_LITERAL = new BooleanConfigKey(
-            "processing.computedAttributes.parser.structuredLiteral",
-            List.of(KeyType.CONFIG));
-
     /**
      * Boolean flag to enable or disable reverse geocoder.
      */

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1299,21 +1299,21 @@ public final class Keys {
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES = new BooleanConfigKey(
             "processing.computedAttributes.deviceAttributes",
             List.of(KeyType.CONFIG));
-
+    
     /**
      * Enable local variables declaration.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES = new BooleanConfigKey(
             "processing.computedAttributes.localVariables",
             List.of(KeyType.CONFIG));
-
+    
     /**
      * Enable loops processing.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOOPS = new BooleanConfigKey(
             "processing.computedAttributes.loops",
             List.of(KeyType.CONFIG));
-
+    
     /**
      * Enable new instances creation.
      * When disabled, parsing a script/expression using 'new(...)' will throw a parsing exception;
@@ -1321,7 +1321,7 @@ public final class Keys {
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION = new BooleanConfigKey(
             "processing.computedAttributes.newInstanceCreation",
             List.of(KeyType.CONFIG));
-
+    
     /**
      * Boolean flag to enable or disable reverse geocoder.
      */

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1299,25 +1299,29 @@ public final class Keys {
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES = new BooleanConfigKey(
             "processing.computedAttributes.deviceAttributes",
             List.of(KeyType.CONFIG));
+
     /**
      * Enable local variables declaration.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES = new BooleanConfigKey(
             "processing.computedAttributes.localVariables",
             List.of(KeyType.CONFIG));
+
     /**
      * Enable loops processing.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOOPS = new BooleanConfigKey(
             "processing.computedAttributes.loops",
             List.of(KeyType.CONFIG));
+
     /**
      * Enable new instances creation.
-     * When disabled, parsing a script/expression using 'new(...)' will throw a parsing exception; using a class as functor will fail.
+     * When disabled, parsing a script/expression using 'new(...)' will throw a parsing exception;
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION = new BooleanConfigKey(
             "processing.computedAttributes.newInstanceCreation",
             List.of(KeyType.CONFIG));
+
     /**
      * Boolean flag to enable or disable reverse geocoder.
      */

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1299,21 +1299,21 @@ public final class Keys {
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES = new BooleanConfigKey(
             "processing.computedAttributes.deviceAttributes",
             List.of(KeyType.CONFIG));
-    
+
     /**
      * Enable local variables declaration.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES = new BooleanConfigKey(
             "processing.computedAttributes.localVariables",
             List.of(KeyType.CONFIG));
-    
+
     /**
      * Enable loops processing.
      */
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_LOOPS = new BooleanConfigKey(
             "processing.computedAttributes.loops",
             List.of(KeyType.CONFIG));
-    
+
     /**
      * Enable new instances creation.
      * When disabled, parsing a script/expression using 'new(...)' will throw a parsing exception;
@@ -1321,7 +1321,7 @@ public final class Keys {
     public static final ConfigKey<Boolean> PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION = new BooleanConfigKey(
             "processing.computedAttributes.newInstanceCreation",
             List.of(KeyType.CONFIG));
-    
+
     /**
      * Boolean flag to enable or disable reverse geocoder.
      */

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -57,39 +57,16 @@ public class ComputedAttributesHandler extends BaseDataHandler {
     @Inject
     public ComputedAttributesHandler(Config config, CacheManager cacheManager) {
         this.cacheManager = cacheManager;
-        boolean enableJEXLAnnotation = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_ANNOTATION);
-        boolean enableJEXLArrayReferences = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_ARRAY_REFERENCES);
-        boolean enableJEXLLambdas = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LAMBDA);
-        boolean enableJEXLLexical = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL);
-        boolean enableJEXLLexicalShade = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL_SHADE);
         boolean enableJEXLLocalVariables = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES);
         boolean enableJEXLLoops = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOOPS);
-        boolean enableJEXLMethodCalls = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_METHOD_CALLS);
         boolean enableJEXLNewInstanceCreation = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION);
-        boolean enableJEXLPragma = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_PRAGMA);
-        boolean enableJEXLScriptConstructs = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_SCRIPT_CONSTRUCTS);
-        boolean enableJEXLSideEffect = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT);
-        boolean enableJEXLSideEffectGlobal = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT_GLOBAL);
-        boolean enableJEXLStructuredLiteral = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_STRUCTURED_LITERAL);
         JexlSandbox sandbox = new JexlSandbox(false);
         sandbox.allow("com.safe.Functions");
-        boolean enableJEXLRegister = true;
         JexlFeatures features = new JexlFeatures()
-                .annotation(enableJEXLAnnotation)
-                .arrayReferenceExpr(enableJEXLArrayReferences)
-                .lambda(enableJEXLLambdas)
-                .lexical(enableJEXLLexical)
-                .lexicalShade(enableJEXLLexicalShade)
                 .localVar(enableJEXLLocalVariables)
                 .loops(enableJEXLLoops)
-                .methodCall(enableJEXLMethodCalls)
                 .newInstance(enableJEXLNewInstanceCreation)
-                .pragma(enableJEXLPragma)
-                .register(enableJEXLRegister)
-                .script(enableJEXLScriptConstructs)
-                .sideEffect(enableJEXLSideEffect)
-                .sideEffectGlobal(enableJEXLSideEffectGlobal)
-                .structuredLiteral(enableJEXLStructuredLiteral);
+                .structuredLiteral(true);
         engine = new JexlBuilder()
                 .strict(true)
                 .namespaces(Collections.singletonMap("math", Math.class))

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -115,7 +115,9 @@ public class ComputedAttributesHandler extends BaseDataHandler {
      */
     @Deprecated
     public Object computeAttribute(Attribute attribute, Position position) throws JexlException {
-        return engine.createScript(features, engine.createInfo(), attribute.getExpression()).execute(prepareContext(position));
+        return engine.createScript(features,
+                engine.createInfo(),
+                attribute.getExpression()).execute(prepareContext(position));
     }
 
     @Override

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -26,10 +26,8 @@ import java.util.Map;
 import java.util.Set;
 
 import io.netty.channel.ChannelHandler;
-import org.apache.commons.jexl3.JexlBuilder;
-import org.apache.commons.jexl3.JexlEngine;
-import org.apache.commons.jexl3.JexlException;
-import org.apache.commons.jexl3.MapContext;
+import org.apache.commons.jexl3.*;
+import org.apache.commons.jexl3.introspection.JexlSandbox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traccar.BaseDataHandler;
@@ -55,14 +53,51 @@ public class ComputedAttributesHandler extends BaseDataHandler {
 
     private final boolean includeDeviceAttributes;
 
+
     @Inject
     public ComputedAttributesHandler(Config config, CacheManager cacheManager) {
         this.cacheManager = cacheManager;
+        boolean enableJEXLAnnotation = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_ANNOTATION);
+        boolean enableJEXLArrayReferences = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_ARRAY_REFERENCES);
+        boolean enableJEXLLambdas = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LAMBDA);
+        boolean enableJEXLLexical = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL);
+        boolean enableJEXLLexicalShade = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LEXICAL_SHADE);
+        boolean enableJEXLLocalVariables = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES);
+        boolean enableJEXLLoops = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOOPS);
+        boolean enableJEXLMethodCalls = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_METHOD_CALLS);
+        boolean enableJEXLNewInstanceCreation = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION);
+        boolean enableJEXLPragma = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_PRAGMA);
+        boolean enableJEXLScriptConstructs = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_SCRIPT_CONSTRUCTS);
+        boolean enableJEXLSideEffect = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT);
+        boolean enableJEXLSideEffectGlobal = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_SIDE_EFFECT_GLOBAL);
+        boolean enableJEXLStructuredLiteral = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_STRUCTURED_LITERAL);
+        JexlSandbox sandbox = new JexlSandbox(false);
+        sandbox.allow("com.safe.Functions");
+        boolean enableJEXLRegister = true;
+        JexlFeatures features = new JexlFeatures()
+                .annotation(enableJEXLAnnotation)
+                .arrayReferenceExpr(enableJEXLArrayReferences)
+                .lambda(enableJEXLLambdas)
+                .lexical(enableJEXLLexical)
+                .lexicalShade(enableJEXLLexicalShade)
+                .localVar(enableJEXLLocalVariables)
+                .loops(enableJEXLLoops)
+                .methodCall(enableJEXLMethodCalls)
+                .newInstance(enableJEXLNewInstanceCreation)
+                .pragma(enableJEXLPragma)
+                .register(enableJEXLRegister)
+                .script(enableJEXLScriptConstructs)
+                .sideEffect(enableJEXLSideEffect)
+                .sideEffectGlobal(enableJEXLSideEffectGlobal)
+                .structuredLiteral(enableJEXLStructuredLiteral);
         engine = new JexlBuilder()
                 .strict(true)
                 .namespaces(Collections.singletonMap("math", Math.class))
+                .sandbox(sandbox)
+                .features(features)
                 .create();
         includeDeviceAttributes = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES);
+
     }
 
     private MapContext prepareContext(Position position) {

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -64,6 +64,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
         this.cacheManager = cacheManager;
         JexlSandbox sandbox = new JexlSandbox(false);
         sandbox.allow("com.safe.Functions");
+        sandbox.allow(Math.class.getName());
         features = new JexlFeatures()
                 .localVar(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES))
                 .loops(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOOPS))

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -57,19 +57,15 @@ public class ComputedAttributesHandler extends BaseDataHandler {
 
     private final boolean includeDeviceAttributes;
 
-
     @Inject
     public ComputedAttributesHandler(Config config, CacheManager cacheManager) {
         this.cacheManager = cacheManager;
-        boolean enableJEXLLocalVariables = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES);
-        boolean enableJEXLLoops = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOOPS);
-        boolean enableJEXLNewInstanceCreation = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION);
         JexlSandbox sandbox = new JexlSandbox(false);
         sandbox.allow("com.safe.Functions");
         JexlFeatures features = new JexlFeatures()
-                .localVar(enableJEXLLocalVariables)
-                .loops(enableJEXLLoops)
-                .newInstance(enableJEXLNewInstanceCreation)
+                .localVar(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES))
+                .loops(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOOPS))
+                .newInstance(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION))
                 .structuredLiteral(true);
         engine = new JexlBuilder()
                 .strict(true)
@@ -78,7 +74,6 @@ public class ComputedAttributesHandler extends BaseDataHandler {
                 .features(features)
                 .create();
         includeDeviceAttributes = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES);
-
     }
 
     private MapContext prepareContext(Position position) {

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -55,6 +55,8 @@ public class ComputedAttributesHandler extends BaseDataHandler {
 
     private final JexlEngine engine;
 
+    private final JexlFeatures features;
+
     private final boolean includeDeviceAttributes;
 
     @Inject
@@ -62,7 +64,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
         this.cacheManager = cacheManager;
         JexlSandbox sandbox = new JexlSandbox(false);
         sandbox.allow("com.safe.Functions");
-        JexlFeatures features = new JexlFeatures()
+        features = new JexlFeatures()
                 .localVar(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOCAL_VARIABLES))
                 .loops(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_LOOPS))
                 .newInstance(config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_NEW_INSTANCE_CREATION))
@@ -71,7 +73,6 @@ public class ComputedAttributesHandler extends BaseDataHandler {
                 .strict(true)
                 .namespaces(Collections.singletonMap("math", Math.class))
                 .sandbox(sandbox)
-                .features(features)
                 .create();
         includeDeviceAttributes = config.getBoolean(Keys.PROCESSING_COMPUTED_ATTRIBUTES_DEVICE_ATTRIBUTES);
     }
@@ -113,7 +114,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
      */
     @Deprecated
     public Object computeAttribute(Attribute attribute, Position position) throws JexlException {
-        return engine.createExpression(attribute.getExpression()).evaluate(prepareContext(position));
+        return engine.createScript(features, engine.createInfo(), attribute.getExpression()).execute(prepareContext(position));
     }
 
     @Override

--- a/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
+++ b/src/main/java/org/traccar/handler/ComputedAttributesHandler.java
@@ -26,8 +26,12 @@ import java.util.Map;
 import java.util.Set;
 
 import io.netty.channel.ChannelHandler;
-import org.apache.commons.jexl3.*;
+import org.apache.commons.jexl3.JexlFeatures;
+import org.apache.commons.jexl3.JexlEngine;
+import org.apache.commons.jexl3.JexlBuilder;
 import org.apache.commons.jexl3.introspection.JexlSandbox;
+import org.apache.commons.jexl3.JexlException;
+import org.apache.commons.jexl3.MapContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traccar.BaseDataHandler;


### PR DESCRIPTION
Following https://github.com/traccar/traccar/issues/5028, this PR adds various preferences options to extend or disable JEXL functionality on-demand. The parser now runs in the JEXL Sandbox, which should stop most, if not any, RCE attacks. The following configuration lines were added:

- `processing.computedAttributes.parser.annotation` - if disabled, using `@annotation` constructs will result in an exception
- `processing.computedAttributes.parser.arrayReferences` - if disabled, using 'obj[ ref ]' where ref is not a string or integer literal will result in a parsing exception;
- `processing.computedAttributes.parser.lambda` - enable lambda declaration
- `processing.computedAttributes.parser.lexical` - with this on, redefining local variables will result in an exception
- `processing.computedAttributes.parser.lexicalShade` - with this on, local variables will shade global ones outside their scope
- `processing.computedAttributes.parser.localVariables` - with this on, local variables declaration will be allowed
- `processing.computedAttributes.parser.loops` - enable loop execution
- `processing.computedAttributes.parser.method_calls` - if this is disabled, using `obj.samplemethod()` would result in an exception
- `processing.computedAttributes.parser.newInstanceCreation` - if this is disabled, using `new()` will result in an exception
- `processing.computedAttributes.parser.pragma` - enable pragma expressions
- `processing.computedAttributes.parser.scriptConstructs` - enable script constructs
- `processing.computedAttributes.parser.sideEffect` - modifying variables or members using constructs will result in an exception
- `processing.computedAttributes.parser.sideEffectGlobal` - same as `sideEffect`, but in global scope
- `processing.computedAttributes.parser.structuredLiteral` - enable array/map/set literal expressions processing
I'd like @tananaev to review this PR and check if there any flaws or mistakes in my solution. 
I also want to point out the `scriptConstructs` option - it appears dangerous to me. I tried this JEXL expression:
`"''.getClass().forName('java.lang.Runtime').getRuntime().exec('bash')"`
to execute Bash on the machine, which works, if JEXL is not running under the Sandbox. If it does, this does not work. However, as I'm not experienced enough for this, I can't figure out if this expression can be altered to be successfully used in the Sandbox environment, so, Anton, please check this out.

References:
[JexlFeatures](https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-jexl/apidocs/org/apache/commons/jexl3/JexlFeatures.html)
[JexlOptions](https://commons.apache.org/proper/commons-jexl/apidocs/org/apache/commons/jexl3/JexlOptions.html)
[JexlSandbox](https://commons.apache.org/proper/commons-jexl/apidocs/org/apache/commons/jexl3/introspection/JexlSandbox.html)
[Jexl Syntax](https://commons.apache.org/proper/commons-jexl/reference/syntax.html)