### PR TITLE
changed-session-retreival-permission-to-manager

### DIFF
--- a/src/main/java/org/traccar/api/resource/SessionResource.java
+++ b/src/main/java/org/traccar/api/resource/SessionResource.java
@@ -123,7 +123,7 @@ public class SessionResource extends BaseResource {
     @Path("{id}")
     @GET
     public User get(@PathParam("id") long userId) throws StorageException {
-        permissionsService.checkAdmin(getUserId());
+        permissionsService.checkUser(getUserId(), userId);
         User user = storage.getObject(User.class, new Request(
                 new Columns.All(), new Condition.Equals("id", userId)));
         request.getSession().setAttribute(USER_ID_KEY, user.getId());


### PR DESCRIPTION
Upto yet, only admins are able to retreive session information for other users.

With this change, the managers will be also able to retreive session information for the users they manage them.