### PR TITLE
a fix to permission check

### DIFF
--- a/src/main/java/org/traccar/api/resource/PermissionsResource.java
+++ b/src/main/java/org/traccar/api/resource/PermissionsResource.java
@@ -48,7 +48,7 @@ public class PermissionsResource  extends BaseResource {
     private void checkPermission(Permission permission) throws StorageException {
         if (permissionsService.notAdmin(getUserId())) {
             permissionsService.checkPermission(permission.getOwnerClass(), getUserId(), permission.getOwnerId());
-            permissionsService.checkPermission(permission.getOwnerClass(), getUserId(), permission.getOwnerId());
+            permissionsService.checkPermission(permission.getPropertyClass(), getUserId(), permission.getPropertyId());
         }
     }
 


### PR DESCRIPTION
A quick fix to permission check. 

Currently, if a manager has access to a single user and a single device, but he/she can assign all other devices to this user, even those device to which the manager doesn't have acces, because the check was only applied to the owner but not property.

With this small change it will fix the issue. The check will be applied to both owner and property to ensure the manager has access to both of them.

