### PR TITLE
Implement SSO with OpenID Connect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ dependencies {
     implementation "com.hivemq:hivemq-mqtt-client:1.3.0"
     implementation "redis.clients:jedis:4.3.1"
     implementation "com.google.firebase:firebase-admin:9.1.1"
+    implementation "com.nimbusds:oauth2-oidc-sdk:10.7.1"
+    implementation "net.minidev:json-smart:2.4.10"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testImplementation "org.mockito:mockito-core:5.1.1"

--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -87,6 +87,7 @@ import org.traccar.storage.DatabaseStorage;
 import org.traccar.storage.MemoryStorage;
 import org.traccar.storage.Storage;
 import org.traccar.web.WebServer;
+import org.traccar.api.security.LoginService;
 import org.traccar.api.security.OpenIDProvider;
 
 import javax.annotation.Nullable;
@@ -173,9 +174,9 @@ public class MainModule extends AbstractModule {
     
     @Singleton
     @Provides
-    public static OpenIDProvider provideOpenIDProvider(Config config) {
+    public static OpenIDProvider provideOpenIDProvider(Config config, LoginService loginService, Storage storage) {
         if (config.getBoolean(Keys.OIDC_ENABLE)) {
-            return new OpenIDProvider(config);
+            return new OpenIDProvider(config, loginService, storage);
         }
         return null;
     }

--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -87,6 +87,7 @@ import org.traccar.storage.DatabaseStorage;
 import org.traccar.storage.MemoryStorage;
 import org.traccar.storage.Storage;
 import org.traccar.web.WebServer;
+import org.traccar.api.security.OpenIDProvider;
 
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
@@ -166,6 +167,15 @@ public class MainModule extends AbstractModule {
     public static LdapProvider provideLdapProvider(Config config) {
         if (config.hasKey(Keys.LDAP_URL)) {
             return new LdapProvider(config);
+        }
+        return null;
+    }
+    
+    @Singleton
+    @Provides
+    public static OpenIDProvider provideOpenIDProvider(Config config) {
+        if (config.getBoolean(Keys.OIDC_ENABLE)) {
+            return new OpenIDProvider(config);
         }
         return null;
     }

--- a/src/main/java/org/traccar/api/resource/SessionResource.java
+++ b/src/main/java/org/traccar/api/resource/SessionResource.java
@@ -169,6 +169,10 @@ public class SessionResource extends BaseResource {
     @Path("openid/auth")
     @GET
     public Response openIdAuth() throws IOException {
+        if (openIdProvider == null) {
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build());
+        }
+
         return Response.seeOther(
             openIdProvider.createAuthRequest()
         ).build();
@@ -178,6 +182,10 @@ public class SessionResource extends BaseResource {
     @Path("openid/callback")
     @GET
     public Response requestToken() throws IOException, StorageException {
+        if (openIdProvider == null) {
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build());
+        }
+        
         // Get full request URI
         StringBuilder requestURL = new StringBuilder(request.getRequestURL().toString());
         String queryString = request.getQueryString();

--- a/src/main/java/org/traccar/api/security/LoginService.java
+++ b/src/main/java/org/traccar/api/security/LoginService.java
@@ -89,6 +89,19 @@ public class LoginService {
         return null;
     }
 
+    public User lookup(String email) throws StorageException {
+        User user = storage.getObject(User.class, new Request(
+                new Columns.All(),
+                new Condition.Equals("email", email)));
+
+        if (user != null) {
+            checkUserEnabled(user);
+            return user;
+        }
+        
+        return null;
+    }
+
     private void checkUserEnabled(User user) throws SecurityException {
         if (user == null) {
             throw new SecurityException("Unknown account");

--- a/src/main/java/org/traccar/api/security/OpenIDProvider.java
+++ b/src/main/java/org/traccar/api/security/OpenIDProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 - 2023 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.api.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+import org.traccar.model.User;
+
+public class OpenIDProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenIDProvider.class);
+
+    private final Boolean force;
+    private final String clientId;
+    private final String authUrl;
+    private final String tokenUrl;
+    private final String userInfoUrl;
+    private final String adminGroup;
+
+    public OpenIDProvider(Config config) {
+        force = config.getBoolean(Keys.OIDC_FORCE);
+        clientId = config.getString(Keys.OIDC_CLIENTID);
+        authUrl = config.getString(Keys.OIDC_AUTHURL);
+        tokenUrl = config.getString(Keys.OIDC_TOKENURL);
+        userInfoUrl = config.getString(Keys.OIDC_USERINFOURL);
+        adminGroup = config.getString(Keys.OIDC_ADMINGROUP);
+    }
+
+}

--- a/src/main/java/org/traccar/api/security/OpenIDProvider.java
+++ b/src/main/java/org/traccar/api/security/OpenIDProvider.java
@@ -61,7 +61,7 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 
 public class OpenIDProvider {
-    private final Boolean force;
+    public final Boolean force;
     private final ClientID clientId;
     private final Secret clientSecret;
     private URI callbackUrl;

--- a/src/main/java/org/traccar/api/security/OpenIDProvider.java
+++ b/src/main/java/org/traccar/api/security/OpenIDProvider.java
@@ -15,30 +15,228 @@
  */
 package org.traccar.api.security;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
+import org.traccar.api.resource.SessionResource;
 import org.traccar.model.User;
+import org.traccar.storage.Storage;
+import org.traccar.storage.StorageException;
+import org.traccar.storage.query.Request;
+import org.traccar.storage.query.Columns;
+import org.traccar.helper.LogAction;
+import org.traccar.helper.ServletHelper;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.List;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import com.google.inject.Inject;
+
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.AuthorizationResponse;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 
 public class OpenIDProvider {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenIDProvider.class);
-
     private final Boolean force;
-    private final String clientId;
-    private final String authUrl;
-    private final String tokenUrl;
-    private final String userInfoUrl;
+    private final ClientID clientId;
+    private final Secret clientSecret;
+    private URI callbackUrl;
+    private URI authUrl;
+    private URI tokenUrl;
+    private URI userInfoUrl;
+    private URI baseUrl;
     private final String adminGroup;
 
-    public OpenIDProvider(Config config) {
+    private Config config;
+    private LoginService loginService;
+    private Storage storage;
+
+    @Inject
+    public OpenIDProvider(Config config, LoginService loginService, Storage storage) {
         force = config.getBoolean(Keys.OIDC_FORCE);
-        clientId = config.getString(Keys.OIDC_CLIENTID);
-        authUrl = config.getString(Keys.OIDC_AUTHURL);
-        tokenUrl = config.getString(Keys.OIDC_TOKENURL);
-        userInfoUrl = config.getString(Keys.OIDC_USERINFOURL);
+        clientId = new ClientID(config.getString(Keys.OIDC_CLIENTID));
+        clientSecret = new Secret(config.getString(Keys.OIDC_CLIENTSECRET));
+
+        this.config = config;
+        this.storage = storage;
+        this.loginService = loginService;
+
+        try {
+            callbackUrl = new URI(config.getString(Keys.WEB_URL, "") + "/api/session/openid/callback");
+            authUrl = new URI(config.getString(Keys.OIDC_AUTHURL, ""));
+            tokenUrl = new URI(config.getString(Keys.OIDC_TOKENURL, ""));
+            userInfoUrl = new URI(config.getString(Keys.OIDC_USERINFOURL, ""));
+            baseUrl = new URI(config.getString(Keys.WEB_URL, ""));
+        } catch (URISyntaxException e) {
+        }
+
         adminGroup = config.getString(Keys.OIDC_ADMINGROUP);
     }
 
+    public URI createAuthRequest() {
+        AuthenticationRequest request = new AuthenticationRequest.Builder(
+                new ResponseType("code"),
+                new Scope("openid", "profile", "email", "groups"),
+                this.clientId,
+                this.callbackUrl)
+                .endpointURI(this.authUrl)
+                .state(new State())
+                .nonce(new Nonce())
+                .build();
+
+        return request.toURI();
+    }
+
+    private OIDCTokenResponse getToken(AuthorizationCode code) {
+        // Credentials to authenticate us to the token endpoint
+        ClientAuthentication clientAuth = new ClientSecretBasic(this.clientId, this.clientSecret);
+        AuthorizationGrant codeGrant = new AuthorizationCodeGrant(code, this.callbackUrl);
+
+        TokenRequest request = new TokenRequest(this.tokenUrl, clientAuth, codeGrant);
+        TokenResponse tokenResponse;
+
+        try {
+            HTTPResponse tokenReq = request.toHTTPRequest().send();
+            tokenResponse = OIDCTokenResponseParser.parse(tokenReq);
+            if (!tokenResponse.indicatesSuccess()) {
+                return null;
+            }
+
+            return (OIDCTokenResponse) tokenResponse.toSuccessResponse();
+        } catch (IOException e) {
+            return null;
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    private AuthorizationCode parseCallback(URI requri) {
+        AuthorizationResponse response;
+
+        try {
+            response = AuthorizationResponse.parse(requri);
+        } catch (ParseException e) {
+            return null;
+        }
+
+        if (!response.indicatesSuccess()) {
+            return null;
+        }
+
+        return response.toSuccessResponse().getAuthorizationCode();
+    }
+
+    private UserInfo getUserInfo(BearerAccessToken token) {
+        UserInfoResponse userInfoResponse;
+
+        try {
+            HTTPResponse httpResponse = new UserInfoRequest(this.userInfoUrl, token)
+                    .toHTTPRequest()
+                    .send();
+
+            userInfoResponse = UserInfoResponse.parse(httpResponse);
+        } catch (IOException e) {
+            return null;
+        } catch (ParseException e) {
+            return null;
+        }
+
+        if (!userInfoResponse.indicatesSuccess()) {
+            // User info request failed - usually from expiring
+            return null;
+        }
+
+        return userInfoResponse.toSuccessResponse().getUserInfo();
+    }
+
+    private User createUser(String name, String email, Boolean administrator) throws StorageException {
+        User user = new User();
+
+        user.setName(name);
+        user.setEmail(email);
+        user.setFixedEmail(true);
+        user.setDeviceLimit(this.config.getInteger(Keys.USERS_DEFAULT_DEVICE_LIMIT));
+
+        int expirationDays = this.config.getInteger(Keys.USERS_DEFAULT_EXPIRATION_DAYS);
+
+        if (expirationDays > 0) {
+            user.setExpirationTime(new Date(System.currentTimeMillis() + expirationDays * 86400000L));
+        }
+
+        if (administrator) {
+            user.setAdministrator(true);
+        }
+
+        user.setId(this.storage.addObject(user, new Request(new Columns.Exclude("id"))));
+
+        return user;
+    }
+
+    public Response handleCallback(URI requri, HttpServletRequest request) throws StorageException {
+        // Parse callback
+        AuthorizationCode authCode = this.parseCallback(requri);
+
+        if (authCode == null) {
+            return Response.ok().entity("Callback parse fail").build();
+        }
+
+        // Get token from IDP
+        OIDCTokenResponse tokens = this.getToken(authCode);
+
+        if (tokens == null) {
+            return Response.ok().entity("Token request failed").build();
+        }
+
+        BearerAccessToken bearerToken = tokens.getOIDCTokens().getBearerAccessToken();
+
+        // Get user info from IDP
+        UserInfo idpUser = this.getUserInfo(bearerToken);
+
+        if (idpUser == null) {
+            return Response.ok().entity("User info request failed").build();
+        }
+
+        String email = idpUser.getEmailAddress();
+        String name = idpUser.getName();
+
+        // Check if user exists
+        User user = this.loginService.lookup(email);
+
+        // If user does not exist, create one
+        if (user == null) {
+            List<String> groups = idpUser.getStringListClaim("groups");
+            Boolean administrator = groups.contains(this.adminGroup);
+            user = this.createUser(name, email, administrator);
+        }
+
+        // Set user session and redirect to homepage
+        request.getSession().setAttribute(SessionResource.USER_ID_KEY, user.getId());
+        LogAction.login(user.getId(), ServletHelper.retrieveRemoteAddress(request));
+        return Response.seeOther(
+                baseUrl).build();
+    }
 }

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -614,14 +614,14 @@ public final class Keys {
     /**
      * OIDC enable.
      */
-    public static final ConfigKey<String> OIDC_ENABLE = new BooleanConfigKey(
+    public static final ConfigKey<Boolean> OIDC_ENABLE = new BooleanConfigKey(
             "oidc.enable",
             List.of(KeyType.CONFIG));
 
     /**
      * Force OIDC authentication.
      */
-    public static final ConfigKey<String> OIDC_FORCE = new BooleanConfigKey(
+    public static final ConfigKey<Boolean> OIDC_FORCE = new BooleanConfigKey(
             "oidc.force",
             List.of(KeyType.CONFIG));
 

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -610,6 +610,62 @@ public final class Keys {
             "ldap.adminGroup",
             List.of(KeyType.CONFIG));
 
+
+    /**
+     * OIDC enable.
+     */
+    public static final ConfigKey<String> OIDC_ENABLE = new BooleanConfigKey(
+            "oidc.enable",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * Force OIDC authentication.
+     */
+    public static final ConfigKey<String> OIDC_FORCE = new BooleanConfigKey(
+            "oidc.force",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * OIDC Client ID.
+     */
+    public static final ConfigKey<String> OIDC_CLIENTID = new StringConfigKey(
+            "oidc.clientId",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * OIDC Client Secret.
+     */
+    public static final ConfigKey<String> OIDC_CLIENTSECRET = new StringConfigKey(
+            "oidc.clientSecret",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * OIDC Authorization URL.
+     */
+    public static final ConfigKey<String> OIDC_AUTHURL = new StringConfigKey(
+            "oidc.authUrl",
+            List.of(KeyType.CONFIG));
+    /**
+     * OIDC Token URL.
+     */
+    public static final ConfigKey<String> OIDC_TOKENURL = new StringConfigKey(
+            "oidc.tokenUrl",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * OIDC User Info URL.
+     */
+    public static final ConfigKey<String> OIDC_USERINFOURL = new StringConfigKey(
+            "oidc.userInfoUrl",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * OIDC group to grant admin access.
+     */
+    public static final ConfigKey<String> OIDC_ADMINGROUP = new StringConfigKey(
+            "oidc.adminGroup",
+            List.of(KeyType.CONFIG));
+
     /**
      * If no data is reported by a device for the given amount of time, status changes from online to unknown. Value is
      * in seconds. Default timeout is 10 minutes.

--- a/src/main/java/org/traccar/model/Server.java
+++ b/src/main/java/org/traccar/model/Server.java
@@ -16,13 +16,16 @@
 package org.traccar.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.traccar.Main;
+import org.traccar.api.security.OpenIDProvider;
 import org.traccar.storage.QueryIgnore;
 import org.traccar.storage.StorageName;
 
 @StorageName("tc_servers")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Server extends ExtendedModel implements UserRestrictions {
-
+    
     private boolean registration;
 
     public boolean getRegistration() {
@@ -261,4 +264,15 @@ public class Server extends ExtendedModel implements UserRestrictions {
         this.newServer = newServer;
     }
 
+    @QueryIgnore
+    public boolean getOidcEnabled() {
+        OpenIDProvider oidc = Main.getInjector().getInstance(OpenIDProvider.class);
+        return oidc != null;
+    }
+
+    @QueryIgnore
+    public boolean getOidcForce() {
+        OpenIDProvider oidc = Main.getInjector().getInstance(OpenIDProvider.class);
+        return oidc != null && oidc.force;
+    }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1027,6 +1027,10 @@
           "303": {
             "description": "Redirect to OpenID Connect identity provider",
             "content": { }
+          },
+          "404": {
+            "description": "OpenID Connect disabled",
+            "content": { }
           }
         }
       }
@@ -1043,11 +1047,19 @@
         ],
         "responses": {
           "303": {
-            "description": "Redirect to homepage",
+            "description": "Successful authentication, redirect to homepage",
+            "content": { }
+          },
+          "403": {
+            "description": "Invalid callback or negative response from identity provider",
             "content": { }
           },
           "404": {
-            "description": "Invalid callback",
+            "description": "OpenID Connect disabled",
+            "content": { }
+          },
+          "500": {
+            "description": "Other OpenID Connect error",
             "content": { }
           }
         }

--- a/swagger.json
+++ b/swagger.json
@@ -1013,6 +1013,46 @@
         }
       }
     },
+    "/session/openid/auth": {
+      "get": {
+        "summary": "Fetch Session information",
+        "tags": [
+          "Session"
+        ],
+        "parameters": [
+          {
+          }
+        ],
+        "responses": {
+          "303": {
+            "description": "Redirect to OpenID Connect identity provider",
+            "content": { }
+          }
+        }
+      }
+    },
+    "/session/openid/callback": {
+      "get": {
+        "summary": "OpenID Callback",
+        "tags": [
+          "Session"
+        ],
+        "parameters": [
+          {
+          }
+        ],
+        "responses": {
+          "303": {
+            "description": "Redirect to homepage",
+            "content": { }
+          },
+          "404": {
+            "description": "Invalid callback",
+            "content": { }
+          }
+        }
+      }
+    },
     "/users": {
       "get": {
         "summary": "Fetch a list of Users",


### PR DESCRIPTION
Implementing OIDC as discussed in #5056. I've also opened a PR on traccar-web (PR) for the frontend changes to show a 'Login with SSO' button and to redirect the user to the identity provider straight away if oidc.force is set.

I'm by no means an expert on OpenID Connect, but it works for me and seems to catch malformed and fabricated callbacks from my testing.

This change does require web.url to be set in order to form the redirect URL sent to the identity provider, not sure if this is a sane requirement or we should try and use the logic to 'guess' the URL here.

The dependencies are Apache 2.0 licensed, so shouldn't be a problem as far as I can see.

Mainly raising this now to get feedback and more testing, my Java is a bit rusty!

So far I've only this with my local instance of Authelia, configured as followed:
```
      - id: traccar
        description: Traccar
        secret: <REDACTED>
        public: false
        redirect_uris:
          - <REDACTED>
        scopes:
          - openid
          - profile
          - groups
          - email
```
with Traccar configured accordingly:
```
<entry key='oidc.enable'>true</entry>
<entry key='oidc.force'>true</entry>
<entry key='oidc.clientId'>traccar</entry>
<entry key='oidc.clientSecret'>REDACTED</entry>
<entry key='oidc.authUrl'>https://authelia/api/oidc/authorize</entry>
<entry key='oidc.tokenUrl'>https://authelia/api/oidc/token</entry>
<entry key='oidc.userInfoUrl'>https://authelia/api/oidc/userinfo</entry>
<entry key='oidc.adminGroup'>admins</entry>
<entry key='web.url'>https://traccar</entry>
```