### PR TITLE
Minor tweaks to OpenID Connect integration

### DIFF
--- a/src/main/java/org/traccar/api/security/LoginService.java
+++ b/src/main/java/org/traccar/api/security/LoginService.java
@@ -43,6 +43,7 @@ public class LoginService {
 
     private final String serviceAccountToken;
     private final boolean forceLdap;
+    private final boolean forceOpenId;
 
     @Inject
     public LoginService(
@@ -53,6 +54,7 @@ public class LoginService {
         this.ldapProvider = ldapProvider;
         serviceAccountToken = config.getString(Keys.WEB_SERVICE_ACCOUNT_TOKEN);
         forceLdap = config.getBoolean(Keys.LDAP_FORCE);
+        forceOpenId = config.getBoolean(Keys.OPENID_FORCE);
     }
 
     public User login(String token) throws StorageException, GeneralSecurityException, IOException {
@@ -69,6 +71,10 @@ public class LoginService {
     }
 
     public User login(String email, String password) throws StorageException {
+        if (forceOpenId) {
+            return null;
+        }
+
         email = email.trim();
         User user = storage.getObject(User.class, new Request(
                 new Columns.All(),

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -665,12 +665,12 @@ public final class Keys {
 
     /**
      * OpenID Connect group to grant admin access.
-     * Defaults to admins.
+     * If this is not provided, no groups will be granted admin access.
+     * This option will only work if your OpenID provider supports the groups scope.
      */
     public static final ConfigKey<String> OPENID_ADMINGROUP = new StringConfigKey(
             "openid.adminGroup",
-            List.of(KeyType.CONFIG),
-            "admins");
+            List.of(KeyType.CONFIG));
 
     /**
      * If no data is reported by a device for the given amount of time, status changes from online to unknown. Value is

--- a/src/main/java/org/traccar/database/OpenIdProvider.java
+++ b/src/main/java/org/traccar/database/OpenIdProvider.java
@@ -94,9 +94,15 @@ public class OpenIdProvider {
     }
 
     public URI createAuthUri() {
+        Scope scope = new Scope("openid", "profile", "email");
+
+        if (adminGroup != null) {
+            scope.add("groups");
+        }
+
         AuthenticationRequest.Builder request = new AuthenticationRequest.Builder(
                 new ResponseType("code"),
-                new Scope("openid", "profile", "email", "groups"),
+                scope,
                 clientId,
                 callbackUrl);
 
@@ -156,9 +162,9 @@ public class OpenIdProvider {
 
             UserInfo userInfo = getUserInfo(bearerToken);
 
-            User user = loginService.login(
-                userInfo.getEmailAddress(), userInfo.getName(),
-                userInfo.getStringListClaim("groups").contains(adminGroup));
+            Boolean administrator = adminGroup != null && userInfo.getStringListClaim("groups").contains(adminGroup);
+
+            User user = loginService.login(userInfo.getEmailAddress(), userInfo.getName(), administrator);
 
             request.getSession().setAttribute(SessionResource.USER_ID_KEY, user.getId());
             LogAction.login(user.getId(), ServletHelper.retrieveRemoteAddress(request));


### PR DESCRIPTION
Including anything I come across whilst preparing documentation (work in progress).

### 1. Make adminGroup parameter optional/don't evaluate groups if it isnt provided
I think its sensible to require the openid, profile and email scopes as:
- openid - required
- email - we're mapping to accounts based on email! Aside: We should maybe look into using the 'sub' token in the future, and perhaps tie that in with storing the LDAP DN (I think they're analogous),
- profile - its useful to know the users name

Although my local SSO service (Authelia) supports groups and it seems like enterprise directories like Okta do too, public providers like Google seem not to, which does makes sense.