### PR TITLE
fix NullPointerException when attribute key is defined and value is null

### DIFF
--- a/src/main/java/org/traccar/model/ExtendedModel.java
+++ b/src/main/java/org/traccar/model/ExtendedModel.java
@@ -90,7 +90,7 @@ public class ExtendedModel extends BaseModel {
     }
 
     public String getString(String key, String defaultValue) {
-        if (attributes.containsKey(key)) {
+        if (attributes.containsKey(key) && attributes.get(key) != null) {
             return attributes.get(key).toString();
         } else {
             return defaultValue;


### PR DESCRIPTION
Today I got a pretty annoying error that caused the server to not work properly.
The issue came after setting a user attributes field to something like this :
```
{
    ....
    attributes: {
        timezone: "Africa/Algiers",
        telegramChatId: null
    }
    ...
}
```
And got the following error on the server trying to generate a notification :
```
2023-05-28 16:25:51  INFO: [T3bc3c196] error - NullPointerException (ExtendedModel:94 < *:101 < NotificatorTelegram:93 < NotificationManager:110 < ...)
```
This caused by the line 94 in ExtendedModel:
```java
    public String getString(String key, String defaultValue) {
        if (attributes.containsKey(key)) {
            return attributes.get(key).toString(); // Here ******
        } else {
            return defaultValue;
        }
    }
```
If any attribute is explicitely set to null, the containsKey will return true but the actual value is null and calling toString will raise a NullPointerException.