### PR TITLE
added Battery Level as IO 113 in TeltonikaProtocolDecoder.java

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -256,6 +256,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
         register(89, fmbXXX, (p, b) -> p.set("fuelLevelPercentage", b.readUnsignedByte()));
         register(90, null, (p, b) -> p.set(Position.KEY_DOOR, b.readUnsignedShort()));
         register(110, fmbXXX, (p, b) -> p.set(Position.KEY_FUEL_CONSUMPTION, b.readUnsignedShort() * 0.1));
+        register(113, fmbXXX, (p, b) -> p.set(Position.KEY_BATTERY_LEVEL, b.readUnsignedByte()));
         register(179, null, (p, b) -> p.set(Position.PREFIX_OUT + 1, b.readUnsignedByte() > 0));
         register(180, null, (p, b) -> p.set(Position.PREFIX_OUT + 2, b.readUnsignedByte() > 0));
         register(181, null, (p, b) -> p.set(Position.KEY_PDOP, b.readUnsignedShort() * 0.1));


### PR DESCRIPTION
I saw that someone made some changes to TeltonikaProtocolDecoder recently but I think Battery Level on io113 for FMBXXX was missed out.
Documentation: [https://wiki.teltonika-gps.com/view/FMC130_Teltonika_Data_Sending_Parameters_ID](https://wiki.teltonika-gps.com/view/FMC130_Teltonika_Data_Sending_Parameters_ID)