### PR TITLE
MQTT notificator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation "com.zaxxer:HikariCP:5.0.1"
     implementation "io.netty:netty-all:4.1.93.Final"
     implementation "org.slf4j:slf4j-jdk14:2.0.7"
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
     implementation "com.google.inject:guice:$guiceVersion"
     implementation "com.google.inject.extensions:guice-servlet:$guiceVersion"
     implementation "org.owasp.encoder:encoder:1.2.3"

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1163,6 +1163,33 @@ public final class Keys {
             List.of(KeyType.CONFIG));
 
     /**
+     * MQTT Server URL;
+     */
+    public static final ConfigKey<String> NOTIFICATOR_MQTT_SERVER_URL = new StringConfigKey(
+            "notificator.mqtt.server.url",
+            List.of(KeyType.CONFIG));
+    /**
+     * MQTT Server Client ID;
+     */
+    public static final ConfigKey<String> NOTIFICATOR_MQTT_CLIENT_ID = new StringConfigKey(
+            "notificator.mqtt.client.id",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * MQTT Server Username;
+     */
+    public static final ConfigKey<String> NOTIFICATOR_MQTT_USERNAME = new StringConfigKey(
+            "notificator.mqtt.username",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * MQTT Server Password;
+     */
+    public static final ConfigKey<String> NOTIFICATOR_MQTT_PASSWORD = new StringConfigKey(
+            "notificator.mqtt.password",
+            List.of(KeyType.CONFIG));
+
+    /**
      * Maximum time period for reports in seconds. Can be useful to prevent users to request unreasonably long reports.
      * By default there is no limit.
      */

--- a/src/main/java/org/traccar/notification/NotificatorManager.java
+++ b/src/main/java/org/traccar/notification/NotificatorManager.java
@@ -49,7 +49,8 @@ public class NotificatorManager {
             "firebase", NotificatorFirebase.class,
             "traccar", NotificatorTraccar.class,
             "telegram", NotificatorTelegram.class,
-            "pushover", NotificatorPushover.class);
+            "pushover", NotificatorPushover.class,
+            "mqtt", NotificatorMqtt.class);
 
     private final Injector injector;
 

--- a/src/main/java/org/traccar/notification/NotificatorManager.java
+++ b/src/main/java/org/traccar/notification/NotificatorManager.java
@@ -29,7 +29,7 @@ import org.traccar.notificators.NotificatorSms;
 import org.traccar.notificators.NotificatorTelegram;
 import org.traccar.notificators.NotificatorTraccar;
 import org.traccar.notificators.NotificatorWeb;
-
+import org.traccar.notificators.NotificatorMqtt;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Arrays;

--- a/src/main/java/org/traccar/notificators/NotificatorMqtt.java
+++ b/src/main/java/org/traccar/notificators/NotificatorMqtt.java
@@ -1,0 +1,64 @@
+package org.traccar.notificators;
+
+import com.google.gson.Gson;
+import net.minidev.json.parser.JSONParser;
+import org.eclipse.paho.client.mqttv3.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+import org.traccar.model.Event;
+import org.traccar.model.Notification;
+import org.traccar.model.Position;
+import org.traccar.model.User;
+import org.traccar.notification.MessageException;
+import org.traccar.notification.NotificationFormatter;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.client.Entity;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+@Singleton
+public class NotificatorMqtt implements Notificator{
+    private static final Logger LOGGER = LoggerFactory.getLogger(NotificatorMqtt.class);
+    private final IMqttClient publisher;
+    private final MqttConnectOptions options = new MqttConnectOptions();
+
+    private final NotificationFormatter notificationFormatter;
+    @Inject
+    public NotificatorMqtt(Config config, NotificationFormatter notificationFormatter) throws MqttException {
+        this.notificationFormatter = notificationFormatter;
+        publisher = new MqttClient(config.getString(Keys.NOTIFICATOR_MQTT_SERVER_URL)
+                ,config.getString(Keys.NOTIFICATOR_MQTT_CLIENT_ID));
+        if(config.getString(Keys.NOTIFICATOR_MQTT_USERNAME) != null) {
+            options.setUserName(config.getString(Keys.NOTIFICATOR_MQTT_USERNAME));
+            options.setPassword(config.getString(Keys.NOTIFICATOR_MQTT_PASSWORD).toCharArray());
+        }
+        options.setAutomaticReconnect(true);
+        options.setCleanSession(true);
+        options.setConnectionTimeout(10);
+        publisher.connect(options);
+    }
+
+    @Override
+    public void send(Notification notification, User user, Event event, Position position) throws MessageException {
+        if ( !publisher.isConnected()) {
+            try {
+                publisher.connect(options);
+            } catch (MqttException e) {
+                LOGGER.warn("Mqtt error", e);
+            }
+        }
+        var shortMessage = notificationFormatter.formatMessage(user, event, position, "short");
+        MqttMessage message = new MqttMessage();
+        message.setPayload(new Gson().toJson(shortMessage).getBytes());
+        message.setQos(0);
+        try {
+            publisher.publish(String.valueOf(event.getDeviceId()),message);
+        } catch (MqttException e) {
+            LOGGER.warn("Mqtt error", e);
+        }
+    }
+}


### PR DESCRIPTION
Hi
I have been working on supporting MQTT notifications on Traccar using Eclipse Paho client.
MQTT is a lightweight publish-subscribe messaging protocol and it can be used also for Push Notifications on mobile apps.
Keys to configure the MQTT:
```
<entry key="notificator.mqtt.server.url">tcp://localhost:1883</entry>
<entry key="notificator.mqtt.client.id">traccar</entry>
<entry key="notificator.mqtt.username"></entry>
<entry key="notificator.mqtt.password"></entry>
```
First two keys are required, and the last two keys are needed only if MQTT server is secured with username and password.

Please review the changes and provide your feedback. Thank you!

Best regards