### PR TITLE
Add ability to filter devices by attribute

### DIFF
--- a/src/main/java/org/traccar/api/resource/DeviceResource.java
+++ b/src/main/java/org/traccar/api/resource/DeviceResource.java
@@ -75,7 +75,8 @@ public class DeviceResource extends BaseObjectResource<Device> {
     public Collection<Device> get(
             @QueryParam("all") boolean all, @QueryParam("userId") long userId,
             @QueryParam("uniqueId") List<String> uniqueIds,
-            @QueryParam("id") List<Long> deviceIds) throws StorageException {
+            @QueryParam("id") List<Long> deviceIds,
+            @QueryParam("attribute") List<String> attributes) throws StorageException {
 
         if (!uniqueIds.isEmpty() || !deviceIds.isEmpty()) {
 
@@ -111,6 +112,13 @@ public class DeviceResource extends BaseObjectResource<Device> {
                     permissionsService.checkUser(getUserId(), userId);
                     conditions.add(new Condition.Permission(User.class, userId, baseClass).excludeGroups());
                 }
+            }
+
+            for (String attribute: attributes) {
+                String[] parts = attribute.split(":");
+                String path = "$." + parts[0];
+                String value = parts[1];
+                conditions.add(new Condition.JsonContains("attributes", value, path));
             }
 
             return storage.getObjects(baseClass, new Request(new Columns.All(), Condition.merge(conditions)));

--- a/src/main/java/org/traccar/storage/DatabaseStorage.java
+++ b/src/main/java/org/traccar/storage/DatabaseStorage.java
@@ -231,6 +231,10 @@ public class DatabaseStorage extends Storage {
             if (condition.getDeviceId() > 0) {
                 results.put("deviceId", condition.getDeviceId());
             }
+        } else if (genericCondition instanceof Condition.JsonContains) {
+            var condition = (Condition.JsonContains) genericCondition;
+            results.put("attributeKey", condition.getPath());
+            results.put("attributeValue", condition.getValue());
         }
         return results;
     }
@@ -294,6 +298,12 @@ public class DatabaseStorage extends Storage {
                 }
                 result.append(")");
 
+            } else if (genericCondition instanceof Condition.JsonContains) {
+
+                var condition = (Condition.JsonContains) genericCondition;
+                result.append("JSON_CONTAINS(");
+                result.append(condition.getColumn());
+                result.append(", :attributeValue, :attributeKey)");
             }
         }
         return result.toString();

--- a/src/main/java/org/traccar/storage/query/Condition.java
+++ b/src/main/java/org/traccar/storage/query/Condition.java
@@ -208,4 +208,27 @@ public interface Condition {
         }
     }
 
+    class JsonContains implements Condition {
+        private final String column;
+        private final String value;
+        private final String path;
+        public JsonContains(String column, String value, String path) {
+            this.column = column;
+            this.value = value;
+            this.path = path;
+        }
+
+        public String getColumn() {
+            return this.column;
+        }
+
+        public String getValue() {
+            return this.value;
+        }
+
+        public String getPath() {
+            return this.path;
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #3776 
This simply adds a new query parameter to filter by attributes. My use case is similar to @marlomgirardi. Need to get the devices with a specified attribute and value. As @tsmgeek mentions you can just pull the complete list of devices and filter from there, but my concern that the request could take longer as you have more devices.

My intention is to request comments and feedback and maybe hear from the community any other use cases that are not covered by this implementation.

The current limitiations are:
- `JSON_CONTAINS` is specific to MySQL and MariaDB (it doesn't work on H2 databases);
- The filter looks for an exact match
- If you add multiple attribute parameters to the query it all conditions must match

**Additional Notes:**
I need to add documentation, but before I do that I want to get feedback.