### PR TITLE
Ruptela IO decoding for Odometer, OBD Odometer and OBD Speed

### DIFF
--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -108,6 +108,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 30:
                 position.set(Position.KEY_BATTERY, readValue(buf, length, false) * 0.001);
                 break;
+            case 65:
+                position.set(Position.KEY_ODOMETER, readValue(buf, length, true));
+                break;
             case 74:
                 position.set(Position.PREFIX_TEMP + 3, readValue(buf, length, true) * 0.1);
                 break;
@@ -115,6 +118,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 79:
             case 80:
                 position.set(Position.PREFIX_TEMP + (id - 78), readValue(buf, length, true) * 0.1);
+                break;
+            case 95:
+                position.set(Position.KEY_OBD_SPEED, UnitsConverter.knotsFromKph(readValue(buf, length, true)));
                 break;
             case 134:
                 if (readValue(buf, length, false) > 0) {
@@ -128,6 +134,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 break;
             case 197:
                 position.set(Position.KEY_RPM, readValue(buf, length, false) * 0.125);
+                break;
+            case 645:
+                position.set(Position.KEY_OBD_ODOMETER, readValue(buf, length, true) * 1000);
                 break;
             default:
                 position.set(Position.PREFIX_IO + id, readValue(buf, length, false));

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -108,6 +108,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 30:
                 position.set(Position.KEY_BATTERY, readValue(buf, length, false) * 0.001);
                 break;
+            case 32:
+                position.set(Position.KEY_DEVICE_TEMP, readValue(buf, length, true));
+                break;
             case 65:
                 position.set(Position.KEY_ODOMETER, readValue(buf, length, true));
                 break;
@@ -132,8 +135,21 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     position.set(Position.KEY_ALARM, Position.ALARM_ACCELERATION);
                 }
                 break;
+            case 170:
+                position.set(Position.KEY_CHARGE, readValue(buf, length, false) > 0);
+                break;
             case 197:
                 position.set(Position.KEY_RPM, readValue(buf, length, false) * 0.125);
+                break;
+            case 410:
+                if (readValue(buf, length, false) > 0) {
+                    position.set(Position.KEY_ALARM, Position.ALARM_TOW);
+                }
+                break;
+            case 411:
+                if (readValue(buf, length, false) > 0) {
+                    position.set(Position.KEY_ALARM, Position.ALARM_ACCIDENT);
+                }
                 break;
             case 645:
                 position.set(Position.KEY_OBD_ODOMETER, readValue(buf, length, true) * 1000);


### PR DESCRIPTION
Hi,

Ruptela IO List: [FMIO list.xlsx](https://doc.ruptela.com/resources/Storage/FMIO%20List/FMIO%20list.xlsx)

I want to update the Ruptela Protocol decoder with more data from the official FMIO list. First commit is a basic implementation of Odometer, OBD Odometer and OBD Speed -> which put me in a bit of a dilemma. Odometer and OBD Odometer map cleanly to the existing Position KEYs, but there are several possible IO Attributes that could map for OBD Speed for example. I currently took the one from the same group as OBD Odometer, as this looked the more sane option. But IO "165  - TCO Vehicle Speed" could also map into this KEY and "176 - GPS speed" too and "210 - CAN wheel based speed" and so on. What would be the best here? Do we completely avoid setting KEY_OBD_SPEED? This is just an example, there are several such KEYs, already implemented KEY_RPM among them. 

My thinking is that KEY_OBD_SPEED stays mapped like I mapped it here, because it makes logical sense with KEY_OBD_ODOMETER and we leave all other IO Attributes that don't map "cleanly" with the default ioNUMBER mapping?

Also another question would be, the Teltonika decoder is decoding a lot of "custom" KEYs, do we want that with this protocol too? To me, it looks cleaner with the ioNUMBER mapping for the ones that don't cleanly map into existing Position.KEY_* ?

I will be going thorough other Position.KEY_*s shortly and push additional commits if I find clean mappings/get feedback on the above questions.