### PR TITLE
Add increment value attribute on Duplicate Device Name for Route Report.

### DIFF
--- a/src/main/java/org/traccar/reports/RouteReportProvider.java
+++ b/src/main/java/org/traccar/reports/RouteReportProvider.java
@@ -42,6 +42,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class RouteReportProvider {
 
@@ -66,7 +69,13 @@ public class RouteReportProvider {
         }
         return result;
     }
+    private final Map<String, Integer> uniqueSheetsTitle = new HashMap<>();
 
+    private String getUniqueSheetName(String key) {
+        AtomicInteger atomic = new AtomicInteger(uniqueSheetsTitle.getOrDefault(key, -1));
+        uniqueSheetsTitle.put(key, atomic.incrementAndGet());
+        return (uniqueSheetsTitle.get(key) > 0 ? key + "-" + uniqueSheetsTitle.get(key) : key);
+    }
     public void getExcel(OutputStream outputStream,
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Date from, Date to) throws StorageException, IOException {
@@ -78,7 +87,7 @@ public class RouteReportProvider {
             var positions = PositionUtil.getPositions(storage, device.getId(), from, to);
             DeviceReportSection deviceRoutes = new DeviceReportSection();
             deviceRoutes.setDeviceName(device.getName());
-            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
+            sheetNames.add(WorkbookUtil.createSafeSheetName(getUniqueSheetName(deviceRoutes.getDeviceName())));
             if (device.getGroupId() > 0) {
                 Group group = storage.getObject(Group.class, new Request(
                         new Columns.All(), new Condition.Equals("id", device.getGroupId())));

--- a/src/main/java/org/traccar/reports/RouteReportProvider.java
+++ b/src/main/java/org/traccar/reports/RouteReportProvider.java
@@ -44,13 +44,13 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class RouteReportProvider {
 
     private final Config config;
     private final ReportUtils reportUtils;
     private final Storage storage;
+    private final Map<String, Integer> namesCount = new HashMap<>();
 
     @Inject
     public RouteReportProvider(Config config, ReportUtils reportUtils, Storage storage) {
@@ -69,12 +69,11 @@ public class RouteReportProvider {
         }
         return result;
     }
-    private final Map<String, Integer> uniqueSheetsTitle = new HashMap<>();
+
 
     private String getUniqueSheetName(String key) {
-        AtomicInteger atomic = new AtomicInteger(uniqueSheetsTitle.getOrDefault(key, -1));
-        uniqueSheetsTitle.put(key, atomic.incrementAndGet());
-        return (uniqueSheetsTitle.get(key) > 0 ? key + "-" + uniqueSheetsTitle.get(key) : key);
+        namesCount.compute(key, (k, value) -> (value == null) ? 1 : (value + 1));
+        return (namesCount.get(key) > 1 ? key + "-" + namesCount.get(key) : key);
     }
     public void getExcel(OutputStream outputStream,
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,


### PR DESCRIPTION
[fix] Excel limitation workaround for duplicate Sheets names
[Forum discussion](https://www.traccar.org/forums/topic/report-route-if-there-are-duplicate-device-names/)
[Expected result](https://github.com/traccar/traccar/files/11714435/report-110623135938.xlsx)

Declaring uniqueSheetsTitle
Add private method getUniqueSheetName
Usage in getExcel sheetNames