### PR TITLE
Ruptela IO Decoding improvements

### DIFF
--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -177,7 +177,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 }
                 break;
             case 415:
-                if (readValue(buf, length, false) != 1) {
+                if (readValue(buf, length, false) == 0) {
                     position.set(Position.KEY_ALARM, Position.ALARM_GPS_ANTENNA_CUT);
                 }
                 break;

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -157,14 +157,14 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.KEY_CHARGE, readValue(buf, length, false) > 0);
                 break;
             case 173:
-                position.set(Position.KEY_MOTION, readValue(buf, length, false) == 1);
+                position.set(Position.KEY_MOTION, readValue(buf, length, false) > 0);
                 break;
             case 197:
                 position.set(Position.KEY_RPM, readValue(buf, length, false) * 0.125);
                 break;
             case 251:
             case 409:
-                position.set(Position.KEY_IGNITION, readValue(buf, length, false) == 1);
+                position.set(Position.KEY_IGNITION, readValue(buf, length, false) > 0);
                 break;
             case 410:
                 if (readValue(buf, length, false) > 0) {

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -132,6 +132,11 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 80:
                 position.set(Position.PREFIX_TEMP + (id - 78), readValue(buf, length, true) * 0.1);
                 break;
+            case 88:
+                if (readValue(buf, length, false) == 1) {
+                    position.set(Position.KEY_ALARM, Position.ALARM_JAMMING);
+                }
+                break;
             case 95:
                 position.set(Position.KEY_OBD_SPEED, UnitsConverter.knotsFromKph(readValue(buf, length, true)));
                 break;
@@ -144,6 +149,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 if (readValue(buf, length, false) > 0) {
                     position.set(Position.KEY_ALARM, Position.ALARM_ACCELERATION);
                 }
+                break;
+            case 150:
+                position.set(Position.KEY_OPERATOR, readValue(buf, length, false));
                 break;
             case 170:
                 position.set(Position.KEY_CHARGE, readValue(buf, length, false) > 0);
@@ -175,6 +183,11 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 break;
             case 645:
                 position.set(Position.KEY_OBD_ODOMETER, readValue(buf, length, true) * 1000);
+                break;
+            case 758:
+                if (readValue(buf, length, false) == 1) {
+                    position.set(Position.KEY_ALARM, Position.ALARM_TAMPERING);
+                }
                 break;
             default:
                 position.set(Position.PREFIX_IO + id, readValue(buf, length, false));

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -97,7 +97,20 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 2:
             case 3:
             case 4:
+            case 5:
                 position.set("di" + (id - 1), readValue(buf, length, false));
+                break;
+            case 20:
+                position.set("ai3", readValue(buf, length, false));
+                break;
+            case 21:
+                position.set("ai4", readValue(buf, length, false));
+                break;
+            case 22:
+                position.set("ai1", readValue(buf, length, false));
+                break;
+            case 23:
+                position.set("ai2", readValue(buf, length, false));
                 break;
             case 29:
                 position.set(Position.KEY_POWER, readValue(buf, length, false));
@@ -135,6 +148,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 170:
                 position.set(Position.KEY_CHARGE, readValue(buf, length, false) > 0);
                 break;
+            case 173:
+                position.set(Position.KEY_MOTION, readValue(buf, length, false) == 1);
+                break;
             case 197:
                 position.set(Position.KEY_RPM, readValue(buf, length, false) * 0.125);
                 break;
@@ -150,6 +166,11 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 411:
                 if (readValue(buf, length, false) > 0) {
                     position.set(Position.KEY_ALARM, Position.ALARM_ACCIDENT);
+                }
+                break;
+            case 415:
+                if (readValue(buf, length, false) != 1) {
+                    position.set(Position.KEY_ALARM, Position.ALARM_GPS_ANTENNA_CUT);
                 }
                 break;
             case 645:

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -99,9 +99,6 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 4:
                 position.set("di" + (id - 1), readValue(buf, length, false));
                 break;
-            case 5:
-                position.set(Position.KEY_IGNITION, readValue(buf, length, false) == 1);
-                break;
             case 29:
                 position.set(Position.KEY_POWER, readValue(buf, length, false));
                 break;
@@ -140,6 +137,10 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 break;
             case 197:
                 position.set(Position.KEY_RPM, readValue(buf, length, false) * 0.125);
+                break;
+            case 251:
+            case 409:
+                position.set(Position.KEY_IGNITION, readValue(buf, length, false) == 1);
                 break;
             case 410:
                 if (readValue(buf, length, false) > 0) {

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -133,7 +133,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_TEMP + (id - 78), readValue(buf, length, true) * 0.1);
                 break;
             case 88:
-                if (readValue(buf, length, false) == 1) {
+                if (readValue(buf, length, false) > 0) {
                     position.set(Position.KEY_ALARM, Position.ALARM_JAMMING);
                 }
                 break;

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -98,19 +98,19 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
             case 3:
             case 4:
             case 5:
-                position.set("di" + (id - 1), readValue(buf, length, false));
+                position.set(Position.PREFIX_IN + (id - 1), readValue(buf, length, false));
                 break;
             case 20:
-                position.set("ai3", readValue(buf, length, false));
+                position.set(Position.PREFIX_ADC + 3, readValue(buf, length, false));
                 break;
             case 21:
-                position.set("ai4", readValue(buf, length, false));
+                position.set(Position.PREFIX_ADC + 4, readValue(buf, length, false));
                 break;
             case 22:
-                position.set("ai1", readValue(buf, length, false));
+                position.set(Position.PREFIX_ADC + 1, readValue(buf, length, false));
                 break;
             case 23:
-                position.set("ai2", readValue(buf, length, false));
+                position.set(Position.PREFIX_ADC + 2, readValue(buf, length, false));
                 break;
             case 29:
                 position.set(Position.KEY_POWER, readValue(buf, length, false));


### PR DESCRIPTION
Hi,

another set of Ruptela IO improvements that builds upon https://github.com/traccar/traccar/pull/5113.

Main motivation was that I missed the IGNITION decoding. Previous implementation was rather simplistic, as different Ruptela devices have different "designated" ignition inputs now (it might be that in the past all of them were at DIN4) and the possibility of defining custom ignition logic (eg. which input is actual ignition & other possibilities).  I'm always vary of changing stuff that could break ignition decoding for some setups (eg. where the device does not have custom ignition defined and only relies on DIN4 being the ignition) - but on the other hand, without this change it absolutely breaks (at least some) properly configured Ruptela devices. Anyone affected could still use computed attributes for IGNITION, and everyone else can use DIN4 for other uses too.

Also added some other decoding alarms/ios.