### PR TITLE
Ruptela Decoder for TCO Driver ID and BLE Beacon ID

### DIFF
--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -92,6 +92,16 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
         }
     }
 
+    private void decodeDriver(Position position, String part1, String part2) {
+        Long driverIdPart1 = (Long) position.getAttributes().remove(part1);
+        Long driverIdPart2 = (Long) position.getAttributes().remove(part2);
+        if (driverIdPart1 != null && driverIdPart2 != null) {
+            ByteBuf driverId = Unpooled.copyLong(driverIdPart1, driverIdPart2);
+            position.set(Position.KEY_DRIVER_UNIQUE_ID, driverId.toString(StandardCharsets.US_ASCII));
+            driverId.release();
+        }
+    }
+
     private void decodeParameter(Position position, int id, ByteBuf buf, int length) {
         switch (id) {
             case 2:
@@ -277,21 +287,11 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     decodeParameter(position, id, buf, 8);
                 }
 
-                Long driverIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 126);
-                Long driverIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 127);
-                if (driverIdPart1 != null && driverIdPart2 != null) {
-                    ByteBuf driverId = Unpooled.copyLong(driverIdPart1, driverIdPart2);
-                    position.set(Position.KEY_DRIVER_UNIQUE_ID, driverId.toString(StandardCharsets.US_ASCII));
-                    driverId.release();
-                }
+                // CAN first driver ID
+                decodeDriver(position, Position.PREFIX_IO + 126, Position.PREFIX_IO + 127);
 
-                driverIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 155);
-                driverIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 156);
-                if (driverIdPart1 != null && driverIdPart2 != null) {
-                    ByteBuf driverId = Unpooled.copyLong(driverIdPart1, driverIdPart2);
-                    position.set(Position.KEY_DRIVER_UNIQUE_ID, driverId.toString(StandardCharsets.US_ASCII));
-                    driverId.release();
-                }
+                // TCO first driver ID
+                decodeDriver(position, Position.PREFIX_IO + 155, Position.PREFIX_IO + 156);
 
                 Long tagIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
                 Long tagIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -285,6 +285,22 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     driverId.release();
                 }
 
+                Long tcoDriverIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 155);
+                Long tcoDriverIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 156);
+                if (tcoDriverIdPart1 != null && tcoDriverIdPart2 != null) {
+                    ByteBuf driverId = Unpooled.copyLong(tcoDriverIdPart1, tcoDriverIdPart2);
+                    position.set(Position.KEY_DRIVER_UNIQUE_ID, driverId.toString(StandardCharsets.US_ASCII));
+                    driverId.release();
+                }
+
+                Long bleBeaconIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
+                Long bleBeaconIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
+                if (bleBeaconIdPart1 != null && bleBeaconIdPart2 != null) {
+                    ByteBuf bleBeaconId = Unpooled.copyLong(bleBeaconIdPart1, bleBeaconIdPart2);
+                    position.set("bleBeaconId", bleBeaconId.toString(StandardCharsets.US_ASCII));
+                    bleBeaconId.release();
+                }
+
                 positions.add(position);
             }
 

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -285,18 +285,18 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     driverId.release();
                 }
 
-                Long tcoDriverIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 155);
-                Long tcoDriverIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 156);
-                if (tcoDriverIdPart1 != null && tcoDriverIdPart2 != null) {
-                    ByteBuf driverId = Unpooled.copyLong(tcoDriverIdPart1, tcoDriverIdPart2);
+                driverIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 155);
+                driverIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 156);
+                if (driverIdPart1 != null && driverIdPart2 != null) {
+                    ByteBuf driverId = Unpooled.copyLong(driverIdPart1, driverIdPart2);
                     position.set(Position.KEY_DRIVER_UNIQUE_ID, driverId.toString(StandardCharsets.US_ASCII));
                     driverId.release();
                 }
 
-                Long bleBeaconIdP1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
-                Long bleBeaconIdP2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
-                if (bleBeaconIdP1 != null && bleBeaconIdP2 != null) {
-                    position.set("bleBeaconId", Long.toHexString(bleBeaconIdP1) + Long.toHexString(bleBeaconIdP2));
+                Long tagIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
+                Long tagIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
+                if (tagIdPart1 != null && tagIdPart2 != null) {
+                    position.set("tagId", Long.toHexString(tagIdPart1) + Long.toHexString(tagIdPart2));
                 }
 
                 positions.add(position);

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -293,12 +293,10 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     driverId.release();
                 }
 
-                Long bleBeaconIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
-                Long bleBeaconIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
-                if (bleBeaconIdPart1 != null && bleBeaconIdPart2 != null) {
-                    ByteBuf bleBeaconId = Unpooled.copyLong(bleBeaconIdPart1, bleBeaconIdPart2);
-                    position.set("bleBeaconId", bleBeaconId.toString(StandardCharsets.US_ASCII));
-                    bleBeaconId.release();
+                Long bleBeaconIdP1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
+                Long bleBeaconIdP2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
+                if (bleBeaconIdP1 != null && bleBeaconIdP2 != null) {
+                    position.set("bleBeaconId", Long.toHexString(bleBeaconIdP1) + Long.toHexString(bleBeaconIdP2));
                 }
 
                 positions.add(position);

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -287,11 +287,8 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     decodeParameter(position, id, buf, 8);
                 }
 
-                // CAN first driver ID
-                decodeDriver(position, Position.PREFIX_IO + 126, Position.PREFIX_IO + 127);
-
-                // TCO first driver ID
-                decodeDriver(position, Position.PREFIX_IO + 155, Position.PREFIX_IO + 156);
+                decodeDriver(position, Position.PREFIX_IO + 126, Position.PREFIX_IO + 127); // can driver
+                decodeDriver(position, Position.PREFIX_IO + 155, Position.PREFIX_IO + 156); // tco driver
 
                 Long tagIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
                 Long tagIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);


### PR DESCRIPTION
Hi,

as I encountered problems with ComputedAttributes (https://github.com/traccar/traccar/issues/5116) I figured out that it'll be easier to extend the Ruptela Protocol Decoder than get ComputedAttributes working like I need it to (but the plan is to return to that). BLE Beacon ID decoding was tested locally, TCO Driver will be tested soon-ish - but from research and mock testing with the data I have, the implementation should work the same as the previous driver one and I'm highly confident that it's ok.

I'm sorry that I'm spamming this PRs, but this one should be the last for some time, and next Ruptela Decoder improvements will be a bigger PR all in one.