### PR TITLE
Ruptela Decoder - implement Extended protocol extended messages merging

### DIFF
--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -236,7 +236,18 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 buf.readUnsignedByte(); // timestamp extension
 
                 if (type == MSG_EXTENDED_RECORDS) {
-                    buf.readUnsignedByte(); // record extension
+                    int b = buf.readUnsignedByte(); // record extension
+                    int noRecordsToMerge = (b & 0xf0) >> 4;
+                    int currentRecord = b & 0x0f;
+
+                    if (currentRecord > 0 && noRecordsToMerge >= currentRecord) {
+                        if (!positions.isEmpty()
+                                && positions.get(positions.size() - 1).getDeviceTime()
+                                   .compareTo(position.getDeviceTime()) == 0) {
+                            position = positions.remove(positions.size() - 1);
+                        }
+                    }
+
                 }
 
                 buf.readUnsignedByte(); // priority (reserved)

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -238,7 +238,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
 
                 if (type == MSG_EXTENDED_RECORDS) {
                     int recordExtension = buf.readUnsignedByte();
-                    int mergeRecordCount = BitUtil.between(recordExtension, 4, 8);
+                    int mergeRecordCount = BitUtil.from(recordExtension, 4);
                     int currentRecord = BitUtil.to(recordExtension, 4);
 
                     if (currentRecord > 0 && currentRecord <= mergeRecordCount) {

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -124,7 +124,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + 2, readValue(buf, length, false));
                 break;
             case 29:
-                position.set(Position.KEY_POWER, readValue(buf, length, false));
+                position.set(Position.KEY_POWER, readValue(buf, length, false) * 0.001);
                 break;
             case 30:
                 position.set(Position.KEY_BATTERY, readValue(buf, length, false) * 0.001);

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -22,6 +22,7 @@ import org.traccar.BaseProtocolDecoder;
 import org.traccar.session.DeviceSession;
 import org.traccar.NetworkMessage;
 import org.traccar.Protocol;
+import org.traccar.helper.BitUtil;
 import org.traccar.helper.DataConverter;
 import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Position;
@@ -236,9 +237,9 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 buf.readUnsignedByte(); // timestamp extension
 
                 if (type == MSG_EXTENDED_RECORDS) {
-                    int b = buf.readUnsignedByte(); // record extension
-                    int noRecordsToMerge = (b & 0xf0) >> 4;
-                    int currentRecord = b & 0x0f;
+                    int recordExtension = buf.readUnsignedByte(); // record extension
+                    int noRecordsToMerge = BitUtil.between(recordExtension, 4, 8);
+                    int currentRecord = BitUtil.to(recordExtension, 4);
 
                     if (currentRecord > 0 && noRecordsToMerge >= currentRecord) {
                         if (!positions.isEmpty()
@@ -247,7 +248,6 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                             position = positions.remove(positions.size() - 1);
                         }
                     }
-
                 }
 
                 buf.readUnsignedByte(); // priority (reserved)

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -238,15 +238,11 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
 
                 if (type == MSG_EXTENDED_RECORDS) {
                     int recordExtension = buf.readUnsignedByte();
-                    int noRecordsToMerge = BitUtil.between(recordExtension, 4, 8);
+                    int mergeRecordCount = BitUtil.between(recordExtension, 4, 8);
                     int currentRecord = BitUtil.to(recordExtension, 4);
 
-                    if (currentRecord > 0 && currentRecord <= noRecordsToMerge) {
-                        if (!positions.isEmpty()
-                                && positions.get(positions.size() - 1).getDeviceTime()
-                                   .compareTo(position.getDeviceTime()) == 0) {
-                            position = positions.remove(positions.size() - 1);
-                        }
+                    if (currentRecord > 0 && currentRecord <= mergeRecordCount) {
+                        position = positions.remove(positions.size() - 1);
                     }
                 }
 

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -241,7 +241,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     int noRecordsToMerge = BitUtil.between(recordExtension, 4, 8);
                     int currentRecord = BitUtil.to(recordExtension, 4);
 
-                    if (currentRecord > 0 && noRecordsToMerge >= currentRecord) {
+                    if (currentRecord > 0 && currentRecord <= noRecordsToMerge) {
                         if (!positions.isEmpty()
                                 && positions.get(positions.size() - 1).getDeviceTime()
                                    .compareTo(position.getDeviceTime()) == 0) {

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -237,7 +237,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                 buf.readUnsignedByte(); // timestamp extension
 
                 if (type == MSG_EXTENDED_RECORDS) {
-                    int recordExtension = buf.readUnsignedByte(); // record extension
+                    int recordExtension = buf.readUnsignedByte();
                     int noRecordsToMerge = BitUtil.between(recordExtension, 4, 8);
                     int currentRecord = BitUtil.to(recordExtension, 4);
 


### PR DESCRIPTION
Hi,

since some time I have noticed strange behavior on some Ruptela devices, where seemingly IOs were not sent to the server. After some digging I found out that in fact - device was sending two records, and I was just seeing the last one. After some digging in the documentation I found out that this is called Extended protocol extended messages merging, as Ruptela devices are sending more records with the same header if it cannot fit all the IOs in a single one. 

Documentation: [Ruptela Protocol 1.67](https://pdfcoffee.com/ruptela-protocol-v167pdf-4-pdf-free.html) page 15, heading "2.4 Extended protocol extended records".

I have been running this in limited testing on my staging setup and it looks good. I added the (hopefully) redundant time check, just to be more sure we are not merging wrong records. Also the line is broken because of checkstyle limit and I'm not entirely sure how else should I break it to be 'in style'. I'll extend the testing to more devices tomorrow and report back if there are any unforeseen consequences, but I think it's coded so that it fails gracefully if something does not check out.