### PR TITLE
Megastel Protocol - Exstended with WiFi data and Protocol Encoder

### DIFF
--- a/src/main/java/org/traccar/protocol/MegastekProtocol.java
+++ b/src/main/java/org/traccar/protocol/MegastekProtocol.java
@@ -19,15 +19,24 @@ import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import org.traccar.BaseProtocol;
 import org.traccar.PipelineBuilder;
-import org.traccar.TrackerServer;
 import org.traccar.config.Config;
+import org.traccar.TrackerServer;
+import org.traccar.model.Command;
 
 import javax.inject.Inject;
 
 public class MegastekProtocol extends BaseProtocol {
-
+        
     @Inject
-    public MegastekProtocol(Config config) {
+    public MegastekProtocol(Config config) {        
+            setSupportedDataCommands(
+            Command.TYPE_CUSTOM,
+            Command.TYPE_SET_CONNECTION,
+            Command.TYPE_SET_TIMEZONE,
+            Command.TYPE_GET_DEVICE_STATUS,
+            Command.TYPE_FACTORY_RESET,
+            Command.TYPE_REBOOT_DEVICE,
+            Command.TYPE_POSITION_PERIODIC);
         addServer(new TrackerServer(config, getName(), false) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
@@ -35,6 +44,7 @@ public class MegastekProtocol extends BaseProtocol {
                 pipeline.addLast(new StringEncoder());
                 pipeline.addLast(new StringDecoder());
                 pipeline.addLast(new MegastekProtocolDecoder(MegastekProtocol.this));
+                pipeline.addLast(new MegastekProtocolEncoder(MegastekProtocol.this));
             }
         });
     }

--- a/src/main/java/org/traccar/protocol/MegastekProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/MegastekProtocolEncoder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 - 2019 Anton Tananaev (anton@traccar.org)
+ * Copyright 2018 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.traccar.StringProtocolEncoder;
+import org.traccar.model.Command;
+import org.traccar.Protocol;
+import org.traccar.config.Keys;
+import org.traccar.helper.model.AttributeUtil;
+import org.traccar.helper.Checksum;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class MegastekProtocolEncoder extends StringProtocolEncoder {
+
+    public MegastekProtocolEncoder(Protocol protocol) {
+        super(protocol);
+    }
+	
+	public static String formatAddChecksumdOld(String string) {
+        return String.format("$%s;%02X\\r\\n", string, Checksum.xor(string));
+    }
+    
+    private String W051command(Command command) {
+        DateFormat deviceDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        deviceDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return deviceDateFormat.format(new Date());
+	}
+
+    @Override
+    protected Object encodeCommand(Command command) {
+	    boolean alternative = AttributeUtil.lookup(getCacheManager(), Keys.PROTOCOL_ALTERNATIVE.withPrefix(getProtocolName()), command.getDeviceId());
+	    
+	    if(!alternative) {
+		    // Protocol V2.00
+	        switch (command.getType()) {
+	            case Command.TYPE_CUSTOM:
+	            	if (Command.KEY_DATA == "W051,now;") {
+		            	return formatCommand(command, "$GPRS,%s;W051,%s;!", Command.KEY_UNIQUE_ID, W051command(command));
+	            	} else {
+		            	return formatCommand(command, "$GPRS,%s;%s!", Command.KEY_UNIQUE_ID, Command.KEY_DATA);
+	            	}
+	            case Command.TYPE_SET_CONNECTION:
+	                return formatCommand(command, "$GPRS,%s;W003,%s,%s;!", Command.KEY_UNIQUE_ID, Command.KEY_SERVER, Command.KEY_PORT);
+	            case Command.TYPE_SET_TIMEZONE:
+	                return formatCommand(command, "$GPRS,%s;W020,%s;!", Command.KEY_UNIQUE_ID, Command.KEY_TIMEZONE);
+	            case Command.TYPE_GET_DEVICE_STATUS:
+	                return formatCommand(command, "$GPRS,%s;R029;!", Command.KEY_UNIQUE_ID);
+	            case Command.TYPE_FACTORY_RESET:
+	                return formatCommand(command, "$GPRS,%s;C099;!", Command.KEY_UNIQUE_ID);
+	            case Command.TYPE_REBOOT_DEVICE:
+	            	return formatCommand(command, "$GPRS,%s;W100;!", Command.KEY_UNIQUE_ID);
+	            case Command.TYPE_POSITION_PERIODIC:
+		            return formatCommand(command, "$GPRS,%s;W005,%s;!", Command.KEY_UNIQUE_ID, Command.KEY_FREQUENCY);
+	            default:
+	                return null;
+	        }
+        } else {
+	        // Protocol V1.00
+	        switch (command.getType()) {
+		        case Command.TYPE_CUSTOM:
+		            return formatAddChecksumdOld(formatCommand(command, ",%s,%s", Command.KEY_UNIQUE_ID, Command.KEY_DATA));
+		        case Command.TYPE_POSITION_PERIODIC:
+		        	return formatAddChecksumdOld(formatCommand(command, ",%s,0013,%s", Command.KEY_UNIQUE_ID, Command.KEY_FREQUENCY));
+	            default:
+	                return null;
+	        }
+        }
+    }
+
+}


### PR DESCRIPTION
Improvements on MegastekProtocolDecoder decodeNew;
- Added WifiAccessPoint (for LBS Geolocation).
- BatteryLevel (percentage) was wrongly stored as battery what is battery voltage.
- Satellite counts now all satellites (BDS, GPS and Glonass).
- Belt status set to KEY_LOCK
- A 'restart' was not covered, this will now trigger a ALARM_POWER_ON.
- A 'detect water'. was not covered, this will now trigger a ALARM_FUEL_LEAK (most similar of all Alarm options)
- Command Response messages (for new and old protocol) including for new protocol sending current timestamp back to the device on request (Q051;).

Added;
- MegastekProtocolEncoder, for new and old protocol. New protocol has more SupportedDataCommands. With Custom Commands only need to enter the actual command and not the full message including device id. This part is only tested with  the new protocol.

--
The old and the already existing new Megastek protocol in Traccar could perhaps better be divided up in two protocols? Megastek and Megastek2 like with Xexun and Xexun2 protocol?