### PR TITLE
Add AMQP(RabbitMQ) Forwarder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     implementation "redis.clients:jedis:4.4.1"
     implementation "com.google.firebase:firebase-admin:9.1.1"
     implementation "com.nimbusds:oauth2-oidc-sdk:10.9.1"
+    implementation "com.rabbitmq:amqp-client:5.18.0"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testImplementation "org.mockito:mockito-core:5.3.1"

--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -37,10 +37,12 @@ import org.traccar.database.OpenIdProvider;
 import org.traccar.database.StatisticsManager;
 import org.traccar.forward.EventForwarder;
 import org.traccar.forward.EventForwarderJson;
+import org.traccar.forward.EventForwarderAmqp;
 import org.traccar.forward.EventForwarderKafka;
 import org.traccar.forward.EventForwarderMqtt;
 import org.traccar.forward.PositionForwarder;
 import org.traccar.forward.PositionForwarderJson;
+import org.traccar.forward.PositionForwarderAmqp;
 import org.traccar.forward.PositionForwarderKafka;
 import org.traccar.forward.PositionForwarderRedis;
 import org.traccar.forward.PositionForwarderUrl;
@@ -360,6 +362,8 @@ public class MainModule extends AbstractModule {
         if (config.hasKey(Keys.EVENT_FORWARD_URL)) {
             String forwardType = config.getString(Keys.EVENT_FORWARD_TYPE);
             switch (forwardType) {
+                case "amqp":
+                    return new EventForwarderAmqp(config, objectMapper);
                 case "kafka":
                     return new EventForwarderKafka(config, objectMapper);
                 case "mqtt":
@@ -379,6 +383,8 @@ public class MainModule extends AbstractModule {
             switch (config.getString(Keys.FORWARD_TYPE)) {
                 case "json":
                     return new PositionForwarderJson(config, client, objectMapper);
+                case "amqp":
+                    return new PositionForwarderAmqp(config, objectMapper);
                 case "kafka":
                     return new PositionForwarderKafka(config, objectMapper);
                 case "redis":

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -837,7 +837,15 @@ public final class Keys {
             "url");
 
     /**
-     * Position forwarding Kafka topic.
+     * Position forwarding AMQP exchange.
+     */
+    public static final ConfigKey<String> FORWARD_EXCHANGE = new StringConfigKey(
+            "forward.exchange",
+            List.of(KeyType.CONFIG),
+            "traccar");
+
+    /**
+     * Position forwarding Kafka topic or AQMP Routing Key.
      */
     public static final ConfigKey<String> FORWARD_TOPIC = new StringConfigKey(
             "forward.topic",
@@ -906,7 +914,15 @@ public final class Keys {
             "json");
 
     /**
-     * Events forwarding Kafka topic.
+     * Events forwarding AMQP exchange.
+     */
+    public static final ConfigKey<String> EVENT_FORWARD_EXCHANGE = new StringConfigKey(
+            "event.forward.exchange",
+            List.of(KeyType.CONFIG),
+            "traccar");
+
+    /**
+     * Events forwarding Kafka topic or AQMP Routing Key.
      */
     public static final ConfigKey<String> EVENT_FORWARD_TOPIC = new StringConfigKey(
             "event.forward.topic",

--- a/src/main/java/org/traccar/forward/AmqpClient.java
+++ b/src/main/java/org/traccar/forward/AmqpClient.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.MessageProperties;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeoutException;
+
+public class AmqpClient {
+    private final Channel channel;
+    private final String exchange;
+    private final String topic;
+
+    AmqpClient(String connectionUrl, String exchange, String topic) {
+        this.exchange = exchange;
+        this.topic = topic;
+
+        ConnectionFactory factory = new ConnectionFactory();
+        try {
+            factory.setUri(connectionUrl);
+        } catch (NoSuchAlgorithmException | URISyntaxException | KeyManagementException e) {
+            throw new RuntimeException("Error while setting URI for RabbitMQ connection factory", e);
+        }
+
+        try (Connection connection = factory.newConnection()) {
+            channel = connection.createChannel();
+            channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, true);
+        } catch (IOException | TimeoutException e) {
+            throw new RuntimeException("Error while creating and configuring RabbitMQ channel", e);
+        }
+    }
+
+    public void publishMessage(String message) throws IOException {
+        channel.basicPublish(exchange, topic, MessageProperties.PERSISTENT_TEXT_PLAIN, message.getBytes());
+    }
+}

--- a/src/main/java/org/traccar/forward/EventForwarderAmqp.java
+++ b/src/main/java/org/traccar/forward/EventForwarderAmqp.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+
+public class EventForwarderAmqp implements EventForwarder {
+
+    private final Channel channel;
+    private final ObjectMapper objectMapper;
+
+    private final String exchange;
+    private final String topic;
+
+    public EventForwarderAmqp(Config config, ObjectMapper objectMapper) {
+        ConnectionFactory factory = new ConnectionFactory();
+        try {
+            factory.setUri(config.getString(Keys.EVENT_FORWARD_URL));
+        } catch (NoSuchAlgorithmException | URISyntaxException | KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            Connection connection  = factory.newConnection();
+            exchange = config.getString(Keys.EVENT_FORWARD_EXCHANGE);
+            topic = config.getString(Keys.EVENT_FORWARD_TOPIC);
+            channel = connection.createChannel();
+            channel.exchangeDeclare(exchange, "topic", true);
+            this.objectMapper = objectMapper;
+        } catch (IOException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void forward(EventData eventData, ResultHandler resultHandler) {
+        try {
+            String value = objectMapper.writeValueAsString(eventData);
+
+            BasicProperties properties = new BasicProperties.Builder()
+                    .contentType("application/json")
+                    .contentEncoding("string")
+                    .deliveryMode(2)
+                    .priority(10)
+                    .build();
+
+            channel.basicPublish(exchange, topic, properties, value.getBytes());
+            resultHandler.onResult(true, null);
+        } catch (IOException e) {
+            resultHandler.onResult(false, e);
+        }
+    }
+}

--- a/src/main/java/org/traccar/forward/EventForwarderAmqp.java
+++ b/src/main/java/org/traccar/forward/EventForwarderAmqp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Anton Tananaev (anton@traccar.org)
+ * Copyright 2023 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/traccar/forward/PositionForwarderAmqp.java
+++ b/src/main/java/org/traccar/forward/PositionForwarderAmqp.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+
+public class PositionForwarderAmqp implements PositionForwarder {
+
+    private final Channel channel;
+    private final ObjectMapper objectMapper;
+
+    private final String exchange;
+    private final String topic;
+
+    public PositionForwarderAmqp(Config config, ObjectMapper objectMapper) {
+        ConnectionFactory factory = new ConnectionFactory();
+        try {
+            factory.setUri(config.getString(Keys.FORWARD_URL));
+        } catch (NoSuchAlgorithmException | URISyntaxException | KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            Connection connection  = factory.newConnection();
+            topic = config.getString(Keys.FORWARD_TOPIC);
+            exchange = config.getString(Keys.EVENT_FORWARD_EXCHANGE);
+            channel = connection.createChannel();
+            channel.exchangeDeclare(exchange, "topic", true);
+            this.objectMapper = objectMapper;
+        } catch (IOException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void forward(PositionData positionData, ResultHandler resultHandler) {
+        try {
+            String value = objectMapper.writeValueAsString(positionData);
+
+            BasicProperties properties = new BasicProperties.Builder()
+                    .contentType("application/json")
+                    .contentEncoding("string")
+                    .deliveryMode(2)
+                    .priority(10)
+                    .build();
+
+            channel.basicPublish(exchange, topic, properties, value.getBytes());
+            resultHandler.onResult(true, null);
+        } catch (IOException e) {
+            resultHandler.onResult(false, e);
+        }
+    }
+}

--- a/src/main/java/org/traccar/forward/PositionForwarderAmqp.java
+++ b/src/main/java/org/traccar/forward/PositionForwarderAmqp.java
@@ -15,63 +15,31 @@
  */
 package org.traccar.forward;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rabbitmq.client.AMQP.BasicProperties;
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
+
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Properties;
-import java.util.concurrent.TimeoutException;
 
 public class PositionForwarderAmqp implements PositionForwarder {
 
-    private final Channel channel;
+    private final AmqpClient amqpClient;
     private final ObjectMapper objectMapper;
 
-    private final String exchange;
-    private final String topic;
-
     public PositionForwarderAmqp(Config config, ObjectMapper objectMapper) {
-        ConnectionFactory factory = new ConnectionFactory();
-        try {
-            factory.setUri(config.getString(Keys.FORWARD_URL));
-        } catch (NoSuchAlgorithmException | URISyntaxException | KeyManagementException e) {
-            throw new RuntimeException(e);
-        }
-
-        try {
-            Connection connection  = factory.newConnection();
-            topic = config.getString(Keys.FORWARD_TOPIC);
-            exchange = config.getString(Keys.EVENT_FORWARD_EXCHANGE);
-            channel = connection.createChannel();
-            channel.exchangeDeclare(exchange, "topic", true);
-            this.objectMapper = objectMapper;
-        } catch (IOException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+        String connectionUrl = config.getString(Keys.FORWARD_URL);
+        String exchange = config.getString(Keys.FORWARD_EXCHANGE);
+        String topic = config.getString(Keys.FORWARD_TOPIC);
+        amqpClient = new AmqpClient(connectionUrl, exchange, topic);
+        this.objectMapper = objectMapper;
     }
 
     @Override
     public void forward(PositionData positionData, ResultHandler resultHandler) {
         try {
             String value = objectMapper.writeValueAsString(positionData);
-
-            BasicProperties properties = new BasicProperties.Builder()
-                    .contentType("application/json")
-                    .contentEncoding("string")
-                    .deliveryMode(2)
-                    .priority(10)
-                    .build();
-
-            channel.basicPublish(exchange, topic, properties, value.getBytes());
+            amqpClient.publishMessage(value);
             resultHandler.onResult(true, null);
         } catch (IOException e) {
             resultHandler.onResult(false, e);

--- a/src/main/java/org/traccar/forward/PositionForwarderAmqp.java
+++ b/src/main/java/org/traccar/forward/PositionForwarderAmqp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Anton Tananaev (anton@traccar.org)
+ * Copyright 2023 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add support to forward events and positions to AMQP (RabbitMQ).

Config:

```xml
<entry key="forward.url">amqp://guest:guest@localhost:5672</entry>
<entry key="forward.type">amqp</entry>
<entry key="forward.exchange">traccar</entry>
<entry key="forward.topic">positions</entry>

<entry key="event.forward.url">amqp://guest:guest@localhost:5672</entry>
<entry key="event.forward.type">amqp</entry>
<entry key="event.forward.exchange">traccar</entry>
<entry key="event.forward.topic">events</entry>
```