### PR TITLE
fix: AMQP auto close connection

### DIFF
--- a/src/main/java/org/traccar/forward/AmqpClient.java
+++ b/src/main/java/org/traccar/forward/AmqpClient.java
@@ -47,13 +47,6 @@ public class AmqpClient {
             Connection connection = factory.newConnection();
             channel = connection.createChannel();
             channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, true);
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                try {
-                    connection.close();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }));
         } catch (IOException | TimeoutException e) {
             throw new RuntimeException("Error while creating and configuring RabbitMQ channel", e);
         }

--- a/src/main/java/org/traccar/forward/AmqpClient.java
+++ b/src/main/java/org/traccar/forward/AmqpClient.java
@@ -43,7 +43,8 @@ public class AmqpClient {
             throw new RuntimeException("Error while setting URI for RabbitMQ connection factory", e);
         }
 
-        try (Connection connection = factory.newConnection()) {
+        try {
+            Connection connection = factory.newConnection();
             channel = connection.createChannel();
             channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, true);
         } catch (IOException | TimeoutException e) {

--- a/src/main/java/org/traccar/forward/AmqpClient.java
+++ b/src/main/java/org/traccar/forward/AmqpClient.java
@@ -47,6 +47,13 @@ public class AmqpClient {
             Connection connection = factory.newConnection();
             channel = connection.createChannel();
             channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, true);
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    connection.close();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
         } catch (IOException | TimeoutException e) {
             throw new RuntimeException("Error while creating and configuring RabbitMQ channel", e);
         }


### PR DESCRIPTION
Currently, the AMQP connection is being closed after the completion of block execution.
I made a mistake in my last PR #5136.