### PR TITLE
Add support for MQTT version 3.x

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -35,6 +35,7 @@ import org.traccar.config.Keys;
 import org.traccar.database.LdapProvider;
 import org.traccar.database.OpenIdProvider;
 import org.traccar.database.StatisticsManager;
+import org.traccar.forward.MqttClientFactory;
 import org.traccar.forward.EventForwarder;
 import org.traccar.forward.EventForwarderJson;
 import org.traccar.forward.EventForwarderAmqp;
@@ -367,7 +368,7 @@ public class MainModule extends AbstractModule {
                 case "kafka":
                     return new EventForwarderKafka(config, objectMapper);
                 case "mqtt":
-                    return new EventForwarderMqtt(config, objectMapper);
+                    return new EventForwarderMqtt(config, objectMapper, new MqttClientFactory());
                 case "json":
                 default:
                     return new EventForwarderJson(config, client);

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -944,6 +944,14 @@ public final class Keys {
             List.of(KeyType.CONFIG));
 
     /**
+     * Events forwarding MQTT version. Default 5. Other valid values: 3
+     */
+    public static final ConfigKey<Integer> EVENT_FORWARD_MQTT_VERSION = new IntegerConfigKey(
+            "event.forward.mqttVersion",
+            List.of(KeyType.CONFIG),
+            5);
+
+    /**
      * Events forwarding headers. Example value:
      * FirstHeader: hello
      * SecondHeader: world

--- a/src/main/java/org/traccar/forward/EventForwarderMqtt.java
+++ b/src/main/java/org/traccar/forward/EventForwarderMqtt.java
@@ -17,10 +17,6 @@ package org.traccar.forward;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hivemq.client.mqtt.datatypes.MqttQos;
-import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
-import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
-import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
 

--- a/src/main/java/org/traccar/forward/EventForwarderMqtt.java
+++ b/src/main/java/org/traccar/forward/EventForwarderMqtt.java
@@ -15,6 +15,8 @@
  */
 package org.traccar.forward;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.traccar.config.Config;
@@ -25,10 +27,11 @@ import java.net.URISyntaxException;
 import java.util.UUID;
 
 public class EventForwarderMqtt implements EventForwarder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventForwarderMqtt.class);
     private final MqttClient client;
     private final ObjectMapper objectMapper;
 
-    public EventForwarderMqtt(Config config, ObjectMapper objectMapper) {
+    public EventForwarderMqtt(Config config, ObjectMapper objectMapper, MqttClientFactory clientFactory) {
         URI url;
         try {
             url = new URI(config.getString(Keys.EVENT_FORWARD_URL));
@@ -51,13 +54,8 @@ public class EventForwarderMqtt implements EventForwarder {
                 password = userInfo.substring(delimiter);
             }
         }
-
-        if(version==3) {
-            client = new MqttClientV3(host, port, username, password, topic);
-        }
-        else {
-            client = new MqttClientV5(host, port, username, password, topic);
-        }
+        LOGGER.info("Creating EventForwarderMqtt for MQTT version " + version);
+        client = clientFactory.create(version, host, port, username, password, topic);
         this.objectMapper = objectMapper;
     }
 

--- a/src/main/java/org/traccar/forward/MqttClient.java
+++ b/src/main/java/org/traccar/forward/MqttClient.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+public interface MqttClient {
+    void publish(byte[] payload, ResultHandler resultHandler);
+}

--- a/src/main/java/org/traccar/forward/MqttClientFactory.java
+++ b/src/main/java/org/traccar/forward/MqttClientFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 - 2023 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+public class MqttClientFactory {
+    public MqttClient create(int version, String host, int port, String username, String password, String topic) {
+        if(version==3) {
+            return new MqttClientV3(host, port, username, password, topic);
+        }
+        else {
+            return new MqttClientV5(host, port, username, password, topic);
+        }
+    }
+}

--- a/src/main/java/org/traccar/forward/MqttClientV3.java
+++ b/src/main/java/org/traccar/forward/MqttClientV3.java
@@ -15,24 +15,18 @@
  */
 package org.traccar.forward;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
 import com.hivemq.client.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
-import org.traccar.config.Config;
-import org.traccar.config.Keys;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.UUID;
 
 public class MqttClientV3 implements MqttClient {
     private final Mqtt3AsyncClient client;
     private final String topic;
 
-    public MqttClientV3(final String host, int port, String user, String password, String topic) {
+    public MqttClientV3(String host, int port, String user, String password, String topic) {
         Mqtt3SimpleAuth simpleAuth = null;
         if (user != null && password != null) {
             simpleAuth = Mqtt3SimpleAuth.builder()
@@ -59,7 +53,7 @@ public class MqttClientV3 implements MqttClient {
     }
 
     @Override
-    public void publish(final byte[] payload, ResultHandler resultHandler) {
+    public void publish(byte[] payload, ResultHandler resultHandler) {
         client.publishWith()
                 .topic(topic)
                 .qos(MqttQos.AT_LEAST_ONCE)

--- a/src/main/java/org/traccar/forward/MqttClientV3.java
+++ b/src/main/java/org/traccar/forward/MqttClientV3.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 - 2023 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
+import com.hivemq.client.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+public class MqttClientV3 implements MqttClient {
+    private final Mqtt3AsyncClient client;
+    private final String topic;
+
+    public MqttClientV3(final String host, int port, String user, String password, String topic) {
+        Mqtt3SimpleAuth simpleAuth = null;
+        if (user != null && password != null) {
+            simpleAuth = Mqtt3SimpleAuth.builder()
+                    .username(user)
+                    .password(password.getBytes())
+                    .build();
+        }
+        client = Mqtt3Client.builder()
+                .identifier("traccar-" + UUID.randomUUID())
+                .serverHost(host)
+                .serverPort(port)
+                .simpleAuth(simpleAuth)
+                .automaticReconnectWithDefaultConfig()
+                .buildAsync();
+
+        client.connectWith()
+                .send()
+                .whenComplete((message, e) -> {
+                    if (e != null) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        this.topic = topic;
+    }
+
+    @Override
+    public void publish(final byte[] payload, ResultHandler resultHandler) {
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(payload)
+                .send()
+                .whenComplete((message, e) -> resultHandler.onResult(e == null, e));
+    }
+}

--- a/src/main/java/org/traccar/forward/MqttClientV5.java
+++ b/src/main/java/org/traccar/forward/MqttClientV5.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 - 2023 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.forward;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
+import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+public class MqttClientV5 implements MqttClient {
+    private final Mqtt5AsyncClient client;
+    private final String topic;
+
+    public MqttClientV5(final String host, int port, String user, String password, String topic) {
+        Mqtt5SimpleAuth simpleAuth = null;
+        if (user != null && password != null) {
+            simpleAuth = Mqtt5SimpleAuth.builder()
+                    .username(user)
+                    .password(password.getBytes())
+                    .build();
+        }
+        client = Mqtt5Client.builder()
+                .identifier("traccar-" + UUID.randomUUID())
+                .serverHost(host)
+                .serverPort(port)
+                .simpleAuth(simpleAuth)
+                .automaticReconnectWithDefaultConfig()
+                .buildAsync();
+
+        client.connectWith()
+                .send()
+                .whenComplete((message, e) -> {
+                    if (e != null) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        this.topic = topic;
+    }
+
+    @Override
+    public void publish(final byte[] payload, ResultHandler resultHandler) {
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(payload)
+                .send()
+                .whenComplete((message, e) -> resultHandler.onResult(e == null, e));
+    }
+}

--- a/src/main/java/org/traccar/forward/MqttClientV5.java
+++ b/src/main/java/org/traccar/forward/MqttClientV5.java
@@ -15,24 +15,18 @@
  */
 package org.traccar.forward;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
 import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
-import org.traccar.config.Config;
-import org.traccar.config.Keys;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.UUID;
 
 public class MqttClientV5 implements MqttClient {
     private final Mqtt5AsyncClient client;
     private final String topic;
 
-    public MqttClientV5(final String host, int port, String user, String password, String topic) {
+    public MqttClientV5(String host, int port, String user, String password, String topic) {
         Mqtt5SimpleAuth simpleAuth = null;
         if (user != null && password != null) {
             simpleAuth = Mqtt5SimpleAuth.builder()
@@ -59,7 +53,7 @@ public class MqttClientV5 implements MqttClient {
     }
 
     @Override
-    public void publish(final byte[] payload, ResultHandler resultHandler) {
+    public void publish(byte[] payload, ResultHandler resultHandler) {
         client.publishWith()
                 .topic(topic)
                 .qos(MqttQos.AT_LEAST_ONCE)

--- a/src/test/java/org/traccar/forward/EventForwarderMqttTest.java
+++ b/src/test/java/org/traccar/forward/EventForwarderMqttTest.java
@@ -1,0 +1,51 @@
+package org.traccar.forward;
+
+import org.junit.jupiter.api.Test;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+
+public class EventForwarderMqttTest {
+
+    @Test
+    public void testCorrectClientIsCreated() {
+        ObjectMapper objectMapperMock = mock(ObjectMapper.class);
+        MqttClientFactory clientFactoryMock = mock(MqttClientFactory.class);
+        Config configMock = mock(Config.class);
+        when(configMock.getString(Keys.EVENT_FORWARD_URL)).thenReturn("mqtt://tester:passwd@localhost:1883");
+        when(configMock.getInteger(Keys.EVENT_FORWARD_MQTT_VERSION)).thenReturn(3);
+        when(configMock.getString(Keys.EVENT_FORWARD_TOPIC)).thenReturn("testTopic");
+
+        EventForwarderMqtt mqttForwarder = new EventForwarderMqtt(configMock, objectMapperMock, clientFactoryMock);
+
+        verify(clientFactoryMock).create(3, "localhost", 1883, "tester", "passwd", "testTopic");
+    }
+
+    @Test
+    public void testForwardForwardsCorrectPayload() throws Exception{
+        ObjectMapper objectMapperMock = mock(ObjectMapper.class);
+        MqttClientFactory clientFactoryMock = mock(MqttClientFactory.class);
+        Config configMock = mock(Config.class);
+        EventData eventDataMock = mock(EventData.class);
+        ResultHandler resultHandlerMock = mock(ResultHandler.class);
+        MqttClient clientMock = mock(MqttClient.class);
+
+        when(configMock.getString(Keys.EVENT_FORWARD_URL)).thenReturn("mqtt://tester:passwd@localhost:1883");
+        when(configMock.getInteger(Keys.EVENT_FORWARD_MQTT_VERSION)).thenReturn(3);
+        when(configMock.getString(Keys.EVENT_FORWARD_TOPIC)).thenReturn("testTopic");
+        when(objectMapperMock.writeValueAsString(eventDataMock)).thenReturn("testDataFromObjectMapper");
+        when(clientFactoryMock.create(anyInt(), any(), anyInt(), any(), any(), any())).thenReturn(clientMock);
+
+        EventForwarderMqtt mqttForwarder = new EventForwarderMqtt(configMock, objectMapperMock, clientFactoryMock);
+        mqttForwarder.forward(eventDataMock, resultHandlerMock);
+
+        verify(clientMock).publish("testDataFromObjectMapper".getBytes(), resultHandlerMock);
+    }
+
+}

--- a/src/test/java/org/traccar/forward/MqttClientFactoryTest.java
+++ b/src/test/java/org/traccar/forward/MqttClientFactoryTest.java
@@ -1,0 +1,24 @@
+package org.traccar.forward;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MqttClientFactoryTest {
+
+    @Test
+    public void testVersion3CreatesVersion3Client() {
+        MqttClientFactory factoryToTest = new MqttClientFactory();
+        
+        MqttClient client = factoryToTest.create(3, "host", 1883, "user", "password", "topic");
+        assertTrue( client instanceof MqttClientV3); 
+    }
+
+    @Test
+    public void testVersion5CreatesVersion5Client() {
+        MqttClientFactory factoryToTest = new MqttClientFactory();
+        
+        MqttClient client = factoryToTest.create(5, "host", 1883, "user", "password", "topic");
+        assertTrue( client instanceof MqttClientV5); 
+    }
+
+}


### PR DESCRIPTION
I had issues connecting with traccar to my aedes broker that currently only supports MQTT 3.x. It doesn't support MQTT5 yet.
It seems like the hivemq client library's Mqtt5AsyncClient doesn't fallback to MQTT 3.x when the server doesn't support version 5 features. The hivemq dev have a completely separate package structure (redudant) for v3 and v5. The classes don't have common interfaces.

I've added a setting to tell traccar which version to use. If the setting is not there or different from v3 version 5 like before will be used by default.

Discussion was here: https://www.traccar.org/forums/topic/release-56-mqtt-support-for-event-forwarding/page/3/

In my setup I could finally connect to my MQTT broker with these changes.