### PR TITLE
Throw overspeed event immediately, accounting for minimumDuration

### DIFF
--- a/src/main/java/org/traccar/session/state/OverspeedProcessor.java
+++ b/src/main/java/org/traccar/session/state/OverspeedProcessor.java
@@ -34,7 +34,7 @@ public final class OverspeedProcessor {
         if (oldState) {
             boolean newState = position.getSpeed() > speedLimit;
             if (newState) {
-                setEvent(state, position, speedLimit, minimalDuration);
+                checkEvent(state, position, speedLimit, minimalDuration);
             } else {
                 state.setOverspeedState(false);
                 state.setOverspeedTime(null);
@@ -45,11 +45,11 @@ public final class OverspeedProcessor {
             state.setOverspeedTime(position.getFixTime());
             state.setOverspeedGeofenceId(geofenceId);
 
-            setEvent(state, position, speedLimit, minimalDuration);
+            checkEvent(state, position, speedLimit, minimalDuration);
         }
     }
 
-    private static void setEvent(OverspeedState state, Position position, double speedLimit, long minimalDuration) {
+    private static void checkEvent(OverspeedState state, Position position, double speedLimit, long minimalDuration) {
         if (state.getOverspeedTime() != null) {
             long oldTime = state.getOverspeedTime().getTime();
             long newTime = position.getFixTime().getTime();

--- a/src/main/java/org/traccar/session/state/OverspeedProcessor.java
+++ b/src/main/java/org/traccar/session/state/OverspeedProcessor.java
@@ -34,22 +34,7 @@ public final class OverspeedProcessor {
         if (oldState) {
             boolean newState = position.getSpeed() > speedLimit;
             if (newState) {
-                if (state.getOverspeedTime() != null) {
-                    long oldTime = state.getOverspeedTime().getTime();
-                    long newTime = position.getFixTime().getTime();
-                    if (newTime - oldTime > minimalDuration) {
-
-                        Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, position);
-                        event.set(ATTRIBUTE_SPEED, position.getSpeed());
-                        event.set(Position.KEY_SPEED_LIMIT, speedLimit);
-                        event.setGeofenceId(state.getOverspeedGeofenceId());
-
-                        state.setOverspeedTime(null);
-                        state.setOverspeedGeofenceId(0);
-                        state.setEvent(event);
-
-                    }
-                }
+                setEvent(state, position, speedLimit, minimalDuration);
             } else {
                 state.setOverspeedState(false);
                 state.setOverspeedTime(null);
@@ -59,7 +44,27 @@ public final class OverspeedProcessor {
             state.setOverspeedState(true);
             state.setOverspeedTime(position.getFixTime());
             state.setOverspeedGeofenceId(geofenceId);
+
+            setEvent(state, position, speedLimit, minimalDuration);
         }
     }
 
+    private static void setEvent(OverspeedState state, Position position, double speedLimit, long minimalDuration) {
+        if (state.getOverspeedTime() != null) {
+            long oldTime = state.getOverspeedTime().getTime();
+            long newTime = position.getFixTime().getTime();
+            if (newTime - oldTime >= minimalDuration) {
+
+                Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, position);
+                event.set(ATTRIBUTE_SPEED, position.getSpeed());
+                event.set(Position.KEY_SPEED_LIMIT, speedLimit);
+                event.setGeofenceId(state.getOverspeedGeofenceId());
+
+                state.setOverspeedTime(null);
+                state.setOverspeedGeofenceId(0);
+                state.setEvent(event);
+
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5103 

As soon as a speed limit is broken, an overspeed event is thrown. Current functionality waits until the 2nd reading of the overspeed instance before throwing the event.