### PR TITLE
Speed is expected as knots value.

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -236,7 +236,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
             }
         });
         register(80, fmbXXX, (p, b) -> p.set("dataMode", b.readUnsignedByte()));
-        register(81, fmbXXX, (p, b) -> p.set(Position.KEY_OBD_SPEED, b.readUnsignedByte()));
+        register(81, fmbXXX, (p, b) -> p.set(Position.KEY_OBD_SPEED, UnitsConverter.knotsFromKph(b.readUnsignedByte())));
         register(82, fmbXXX, (p, b) -> p.set(Position.KEY_THROTTLE, b.readUnsignedByte()));
         register(83, fmbXXX, (p, b) -> p.set(Position.KEY_FUEL_USED, b.readUnsignedInt() * 0.1));
         register(84, fmbXXX, (p, b) -> p.set(Position.KEY_FUEL_LEVEL, b.readUnsignedShort() * 0.1));


### PR DESCRIPTION
OBD speed showed wrong in GUI, because it's expected to be saved as knot. To fix that value should be converted to knot's from km/h as used in other code location's. 
