### PR TITLE
Ruptela - Heartbeat support & extended records spanning multiple messages fix

### DIFF
--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -51,6 +51,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_SMS_VIA_GPRS = 8;
     public static final int MSG_DTCS = 9;
     public static final int MSG_IDENTIFICATION = 15;
+    public static final int MSG_HEARTBEAT = 16;
     public static final int MSG_SET_IO = 17;
     public static final int MSG_FILES = 37;
     public static final int MSG_EXTENDED_RECORDS = 68;
@@ -388,7 +389,7 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
 
             return null;
 
-        } else if (type == MSG_IDENTIFICATION) {
+        } else if (type == MSG_IDENTIFICATION || type == MSG_HEARTBEAT) {
 
             ByteBuf content = Unpooled.buffer();
             content.writeByte(1);

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -227,103 +227,92 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
 
             List<Position> positions = new LinkedList<>();
 
-            try {
-                buf.readUnsignedByte(); // records left
-                int count = buf.readUnsignedByte();
+            buf.readUnsignedByte(); // records left
+            int count = buf.readUnsignedByte();
 
-                for (int i = 0; i < count; i++) {
-                    Position position = new Position(getProtocolName());
-                    position.setDeviceId(deviceSession.getDeviceId());
+            for (int i = 0; i < count; i++) {
+                Position position = new Position(getProtocolName());
+                position.setDeviceId(deviceSession.getDeviceId());
 
-                    position.setTime(new Date(buf.readUnsignedInt() * 1000));
-                    buf.readUnsignedByte(); // timestamp extension
+                position.setTime(new Date(buf.readUnsignedInt() * 1000));
+                buf.readUnsignedByte(); // timestamp extension
 
-                    if (type == MSG_EXTENDED_RECORDS) {
-                        int recordExtension = buf.readUnsignedByte();
-                        int mergeRecordCount = BitUtil.from(recordExtension, 4);
-                        int currentRecord = BitUtil.to(recordExtension, 4);
+                if (type == MSG_EXTENDED_RECORDS) {
+                    int recordExtension = buf.readUnsignedByte();
+                    int mergeRecordCount = BitUtil.from(recordExtension, 4);
+                    int currentRecord = BitUtil.to(recordExtension, 4);
 
-                        if (currentRecord > 0 && currentRecord <= mergeRecordCount) {
-                            if (positions.size() == 0) {
-                                getLastLocation(position, null);
-                            } else {
-                                position = positions.remove(positions.size() - 1);
-                            }
+                    if (currentRecord > 0 && currentRecord <= mergeRecordCount) {
+                        if (positions.size() == 0) {
+                            getLastLocation(position, null);
+                        } else {
+                            position = positions.remove(positions.size() - 1);
                         }
                     }
-
-                    buf.readUnsignedByte(); // priority (reserved)
-
-                    int longitude = buf.readInt();
-                    int latitude = buf.readInt();
-                    if (longitude > Integer.MIN_VALUE && latitude > Integer.MIN_VALUE) {
-                        position.setValid(true);
-                        position.setLongitude(longitude / 10000000.0);
-                        position.setLatitude(latitude / 10000000.0);
-                        position.setAltitude(buf.readUnsignedShort() / 10.0);
-                        position.setCourse(buf.readUnsignedShort() / 100.0);
-                        position.set(Position.KEY_SATELLITES, buf.readUnsignedByte());
-                        position.setSpeed(UnitsConverter.knotsFromKph(buf.readUnsignedShort()));
-                        position.set(Position.KEY_HDOP, buf.readUnsignedByte() / 10.0);
-                    } else {
-                        buf.skipBytes(8);
-                        getLastLocation(position, null);
-                    }
-
-                    if (type == MSG_EXTENDED_RECORDS) {
-                        position.set(Position.KEY_EVENT, buf.readUnsignedShort());
-                    } else {
-                        position.set(Position.KEY_EVENT, buf.readUnsignedByte());
-                    }
-
-                    // Read 1 byte data
-                    int valueCount = buf.readUnsignedByte();
-                    for (int j = 0; j < valueCount; j++) {
-                        int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
-                        decodeParameter(position, id, buf, 1);
-                    }
-
-                    // Read 2 byte data
-                    valueCount = buf.readUnsignedByte();
-                    for (int j = 0; j < valueCount; j++) {
-                        int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
-                        decodeParameter(position, id, buf, 2);
-                    }
-
-                    // Read 4 byte data
-                    valueCount = buf.readUnsignedByte();
-                    for (int j = 0; j < valueCount; j++) {
-                        int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
-                        decodeParameter(position, id, buf, 4);
-                    }
-
-                    // Read 8 byte data
-                    valueCount = buf.readUnsignedByte();
-                    for (int j = 0; j < valueCount; j++) {
-                        int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
-                        decodeParameter(position, id, buf, 8);
-                    }
-
-                    decodeDriver(position, Position.PREFIX_IO + 126, Position.PREFIX_IO + 127); // can driver
-                    decodeDriver(position, Position.PREFIX_IO + 155, Position.PREFIX_IO + 156); // tco driver
-
-                    Long tagIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
-                    Long tagIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
-                    if (tagIdPart1 != null && tagIdPart2 != null) {
-                        position.set("tagId", Long.toHexString(tagIdPart1) + Long.toHexString(tagIdPart2));
-                    }
-
-                    positions.add(position);
                 }
-            } catch (Exception e) {
-                ByteBuf content = Unpooled.buffer();
-                content.writeByte(0);
-                ByteBuf response = RuptelaProtocolEncoder.encodeContent(0, content);
-                content.release();
-                if (channel != null) {
-                    channel.writeAndFlush(new NetworkMessage(response, remoteAddress));
+
+                buf.readUnsignedByte(); // priority (reserved)
+
+                int longitude = buf.readInt();
+                int latitude = buf.readInt();
+                if (longitude > Integer.MIN_VALUE && latitude > Integer.MIN_VALUE) {
+                    position.setValid(true);
+                    position.setLongitude(longitude / 10000000.0);
+                    position.setLatitude(latitude / 10000000.0);
+                    position.setAltitude(buf.readUnsignedShort() / 10.0);
+                    position.setCourse(buf.readUnsignedShort() / 100.0);
+                    position.set(Position.KEY_SATELLITES, buf.readUnsignedByte());
+                    position.setSpeed(UnitsConverter.knotsFromKph(buf.readUnsignedShort()));
+                    position.set(Position.KEY_HDOP, buf.readUnsignedByte() / 10.0);
+                } else {
+                    buf.skipBytes(8);
+                    getLastLocation(position, null);
                 }
-                throw e;
+
+                if (type == MSG_EXTENDED_RECORDS) {
+                    position.set(Position.KEY_EVENT, buf.readUnsignedShort());
+                } else {
+                    position.set(Position.KEY_EVENT, buf.readUnsignedByte());
+                }
+
+                // Read 1 byte data
+                int valueCount = buf.readUnsignedByte();
+                for (int j = 0; j < valueCount; j++) {
+                    int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
+                    decodeParameter(position, id, buf, 1);
+                }
+
+                // Read 2 byte data
+                valueCount = buf.readUnsignedByte();
+                for (int j = 0; j < valueCount; j++) {
+                    int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
+                    decodeParameter(position, id, buf, 2);
+                }
+
+                // Read 4 byte data
+                valueCount = buf.readUnsignedByte();
+                for (int j = 0; j < valueCount; j++) {
+                    int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
+                    decodeParameter(position, id, buf, 4);
+                }
+
+                // Read 8 byte data
+                valueCount = buf.readUnsignedByte();
+                for (int j = 0; j < valueCount; j++) {
+                    int id = type == MSG_EXTENDED_RECORDS ? buf.readUnsignedShort() : buf.readUnsignedByte();
+                    decodeParameter(position, id, buf, 8);
+                }
+
+                decodeDriver(position, Position.PREFIX_IO + 126, Position.PREFIX_IO + 127); // can driver
+                decodeDriver(position, Position.PREFIX_IO + 155, Position.PREFIX_IO + 156); // tco driver
+
+                Long tagIdPart1 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 760);
+                Long tagIdPart2 = (Long) position.getAttributes().remove(Position.PREFIX_IO + 761);
+                if (tagIdPart1 != null && tagIdPart2 != null) {
+                    position.set("tagId", Long.toHexString(tagIdPart1) + Long.toHexString(tagIdPart2));
+                }
+
+                positions.add(position);
             }
 
             if (channel != null) {

--- a/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/RuptelaProtocolDecoder.java
@@ -243,7 +243,11 @@ public class RuptelaProtocolDecoder extends BaseProtocolDecoder {
                     int currentRecord = BitUtil.to(recordExtension, 4);
 
                     if (currentRecord > 0 && currentRecord <= mergeRecordCount) {
-                        position = positions.remove(positions.size() - 1);
+                        if (positions.size() == 0) {
+                            getLastLocation(position, null);
+                        } else {
+                            position = positions.remove(positions.size() - 1);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Hi,

this pull request fixes a bug (first reported to me by Joao Santos via email, thanks!) where Ruptela Extended Messages could split the records to merge in two messages. Eg: the device buffered a lot of extended records (more than 11 that go into one message) because of network problems or some such, and then when it started sending them it could happen that first message contained some records that should be merged with the records in second message. When that second message came, the system previously errored out because it couldn't merge them, as the array of records (= positions in Traccar) was empty. So the correct solution is/was to get the last stored record/position and merge it with that one. 
I was finally able to replicate this and figure it out. I'm also preparing some more changes for a later PR, and I hope I'll be able to extend the tests too - current sample has too much PII to include in the tests.

I included a simple Heartbeat implementation as I noticed that the devices do behave in a nicer way if they get a positive response to the heartbeat message.