### PR TITLE
make DatabaseStorage support pagination

### DIFF
--- a/src/main/java/org/traccar/database/CommandsManager.java
+++ b/src/main/java/org/traccar/database/CommandsManager.java
@@ -33,6 +33,7 @@ import org.traccar.storage.StorageException;
 import org.traccar.storage.query.Columns;
 import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Order;
+import org.traccar.storage.query.Pagination;
 import org.traccar.storage.query.Request;
 
 import jakarta.annotation.Nullable;
@@ -108,7 +109,8 @@ public class CommandsManager implements BroadcastInterface {
             var commands = storage.getObjects(QueuedCommand.class, new Request(
                     new Columns.All(),
                     new Condition.Equals("deviceId", deviceId),
-                    new Order("id", false, count)));
+                    new Order("id", false),
+                    new Pagination(0, 1)));
             Map<Event, Position> events = new HashMap<>();
             for (var command : commands) {
                 storage.removeObject(QueuedCommand.class, new Request(

--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -34,6 +34,7 @@ import org.traccar.storage.StorageException;
 import org.traccar.storage.query.Columns;
 import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Order;
+import org.traccar.storage.query.Pagination;
 import org.traccar.storage.query.Request;
 
 import jakarta.inject.Inject;
@@ -99,7 +100,8 @@ public class FilterHandler extends ChannelInboundHandlerAdapter {
                 new Condition.And(
                         new Condition.Equals("deviceId", deviceId),
                         new Condition.Compare("fixTime", "<=", "time", date)),
-                new Order("fixTime", true, 1)));
+                new Order("fixTime", true),
+                new Pagination(0, 1)));
     }
 
     private boolean filterInvalid(Position position) {

--- a/src/main/java/org/traccar/helper/model/UserUtil.java
+++ b/src/main/java/org/traccar/helper/model/UserUtil.java
@@ -23,6 +23,7 @@ import org.traccar.storage.Storage;
 import org.traccar.storage.StorageException;
 import org.traccar.storage.query.Columns;
 import org.traccar.storage.query.Order;
+import org.traccar.storage.query.Pagination;
 import org.traccar.storage.query.Request;
 
 import java.util.Date;
@@ -36,7 +37,8 @@ public final class UserUtil {
     public static boolean isEmpty(Storage storage) throws StorageException {
         return storage.getObjects(User.class, new Request(
                 new Columns.Include("id"),
-                new Order("id", false, 1))).isEmpty();
+                new Order("id", false),
+                new Pagination(0, 1))).isEmpty();
     }
 
     public static String getDistanceUnit(Server server, User user) {

--- a/src/main/java/org/traccar/reports/SummaryReportProvider.java
+++ b/src/main/java/org/traccar/reports/SummaryReportProvider.java
@@ -33,6 +33,7 @@ import org.traccar.storage.StorageException;
 import org.traccar.storage.query.Columns;
 import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Order;
+import org.traccar.storage.query.Pagination;
 import org.traccar.storage.query.Request;
 
 import jakarta.inject.Inject;
@@ -72,7 +73,8 @@ public class SummaryReportProvider {
                 new Condition.And(
                         new Condition.Equals("deviceId", deviceId),
                         new Condition.Between("fixTime", "from", from, "to", to)),
-                new Order("fixTime", end, 1)));
+                new Order("fixTime", end),
+                new Pagination(0, 1)));
     }
 
     private Collection<SummaryReportItem> calculateDeviceResult(

--- a/src/main/java/org/traccar/storage/DatabaseStorage.java
+++ b/src/main/java/org/traccar/storage/DatabaseStorage.java
@@ -25,6 +25,7 @@ import org.traccar.model.Permission;
 import org.traccar.storage.query.Columns;
 import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Order;
+import org.traccar.storage.query.Pagination;
 import org.traccar.storage.query.Request;
 
 import jakarta.inject.Inject;
@@ -68,6 +69,7 @@ public class DatabaseStorage extends Storage {
         query.append(" FROM ").append(getStorageName(clazz));
         query.append(formatCondition(request.getCondition()));
         query.append(formatOrder(request.getOrder()));
+        query.append(formatPagination(request.getPagination()));
         try {
             QueryBuilder builder = QueryBuilder.create(config, dataSource, objectMapper, query.toString());
             for (Map.Entry<String, Object> variable : getConditionVariables(request.getCondition()).entrySet()) {
@@ -307,16 +309,31 @@ public class DatabaseStorage extends Storage {
             if (order.getDescending()) {
                 result.append(" DESC");
             }
-            if (order.getLimit() > 0) {
-                if (databaseType.equals("Microsoft SQL Server")) {
-                    result.append(" OFFSET 0 ROWS FETCH FIRST ");
-                    result.append(order.getLimit());
-                    result.append(" ROWS ONLY");
-                } else {
-                    result.append(" LIMIT ");
-                    result.append(order.getLimit());
-                }
+        }
+        return result.toString();
+    }
+    
+    private String formatPagination(Pagination pagination) {
+        StringBuilder result = new StringBuilder();
+        if (pagination != null) {
+        	if (databaseType.equals("Microsoft SQL Server")) {
+        		result.append(" OFFSET ");
+        		result.append(pagination.getSkip());
+        		result.append(" ROWS FETCH FIRST ");
+                result.append(pagination.getLimit());
+                result.append(" ROWS ONLY");
+                return result.toString();
+        	}
+        	
+            if (pagination.getLimit() > 0) {
+            	result.append(" LIMIT ");
+                result.append(pagination.getLimit());
             }
+
+            if(pagination.getSkip() > 0) {
+        		result.append(" OFFSET ");
+                result.append(pagination.getSkip());
+        	}
         }
         return result.toString();
     }

--- a/src/main/java/org/traccar/storage/query/Pagination.java
+++ b/src/main/java/org/traccar/storage/query/Pagination.java
@@ -15,26 +15,22 @@
  */
 package org.traccar.storage.query;
 
-public class Order {
+public class Pagination {
 
-    private final String column;
-    private final boolean descending;
+    private final int limit;
+    private final int skip;
 
-    public Order(String column) {
-        this(column, false);
+    public Pagination(int skip, int limit) {
+        this.skip = skip;
+        this.limit = limit;
     }
 
-    public Order(String column, boolean descending) {
-        this.column = column;
-        this.descending = descending;
-    }
-        
-    public String getColumn() {
-        return column;
+    public int getSkip() {
+        return skip;
     }
 
-    public boolean getDescending() {
-        return descending;
+    public int getLimit() {
+        return limit;
     }
 
 }

--- a/src/main/java/org/traccar/storage/query/Request.java
+++ b/src/main/java/org/traccar/storage/query/Request.java
@@ -20,27 +20,45 @@ public class Request {
     private final Columns columns;
     private final Condition condition;
     private final Order order;
+    private final Pagination pagination;
 
     public Request(Columns columns) {
-        this(columns, null, null);
+        this(columns, null, null, null);
     }
 
     public Request(Condition condition) {
-        this(null, condition, null);
+        this(null, condition, null, null);
     }
 
     public Request(Columns columns, Condition condition) {
-        this(columns, condition, null);
+        this(columns, condition, null, null);
     }
 
     public Request(Columns columns, Order order) {
-        this(columns, null, order);
+        this(columns, null, order, null);
+    }
+    
+    public Request(Columns columns, Pagination pagination) {
+        this(columns, null, null, pagination);
+    }
+    
+    public Request(Columns columns, Order order, Pagination pagination) {
+        this(columns, null, order, pagination);
+    }
+    
+    public Request(Columns columns, Condition condition, Order order) {
+    	this(columns, condition, order, null);
     }
 
-    public Request(Columns columns, Condition condition, Order order) {
+    public Request(Columns columns, Condition condition, Pagination pagination) {
+    	this(columns, condition, null, pagination);
+    }
+
+    public Request(Columns columns, Condition condition, Order order, Pagination pagination) {
         this.columns = columns;
         this.condition = condition;
         this.order = order;
+        this.pagination = pagination;
     }
 
     public Columns getColumns() {
@@ -53,6 +71,10 @@ public class Request {
 
     public Order getOrder() {
         return order;
+    }
+    
+    public Pagination getPagination() {
+    	return pagination;
     }
 
 }


### PR DESCRIPTION
This PR adds pagination capability on the `DatabaseStorage` and the correct handlers on the `Request` class.
Also removes the `Order.limit` in favor of the new `Pagination.limit` and fix the usage of the class throughout the app.