### PR TITLE
(Tlt2h) Fix for engine hours not being tracked when a packet has a null location

### DIFF
--- a/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -28,6 +28,7 @@ import org.traccar.model.Position;
 import org.traccar.model.WifiAccessPoint;
 
 import java.net.SocketAddress;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -211,6 +212,7 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
 
                     } else {
                         getLastLocation(position, null);
+                        position.setTime(new Date());
                     }
 
                 } else {


### PR DESCRIPTION
This is a workaround for the issue where a device's ignition status may change while the device has no GPS signal.

An example of when this would be a problem is when a vehicle drives into a covered building and then turns the vehicle off. Traccar will stop logging positions because the device isn't sending any valid gps data. The issue occurs when looking at the summary report for engine hours, as Traccar will still be counting up even if the device is constantly sending AUTOLOW statuses. We can solve this problem by setting the fix time as the time when the packet is received.