### PR TITLE
Update gradle to 8.5 for support building with java 21

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi @tananaev 

- In the current configuration of the release build, java 21 is used to build the traccar distribution.
- In the gradle properties, we are still using the `gradle-7.5.1-bin.zip` as the gradle distribution.
- According to [1] and [2] gradle 7.5.1 only supports java 18 and this may result in failed builds for java 21.
- Therefore this PR updates the gradle to 8.5 which is the java 21 supported gradle distribution as per [1] and [3].

[1] https://docs.gradle.org/current/userguide/compatibility.html
[2] https://docs.gradle.org/7.5.1/release-notes.html?_gl=1*1jz7vqz*_ga*MTYwMjA0Mjg3LjE3MTI2MDU4NDc.*_ga_7W7NC6YNPT*MTcxMjYzNDY4OC4zLjEuMTcxMjYzNDc3Mi40Ny4wLjA.
[3] https://docs.gradle.org/8.5/release-notes.html?_gl=1*14d4mdc*_ga*MTYwMjA0Mjg3LjE3MTI2MDU4NDc.*_ga_7W7NC6YNPT*MTcxMjYzNDY4OC4zLjEuMTcxMjYzNDk1OC42MC4wLjA.

Thanks,
Dinith