### PR TITLE
Add performance improvements for opening websocket with SQL backed storage

### DIFF
--- a/src/main/java/org/traccar/api/resource/PositionResource.java
+++ b/src/main/java/org/traccar/api/resource/PositionResource.java
@@ -84,7 +84,7 @@ public class PositionResource extends BaseResource {
                         new Columns.All(), new Condition.LatestPositions(deviceId)));
             }
         } else {
-            return PositionUtil.getLatestPositions(storage, getUserId());
+            return PositionUtil.getLatestPositions(storage, getUserId(), null);
         }
     }
 

--- a/src/main/java/org/traccar/helper/model/PositionUtil.java
+++ b/src/main/java/org/traccar/helper/model/PositionUtil.java
@@ -64,14 +64,17 @@ public final class PositionUtil {
                 new Order("fixTime")));
     }
 
-    public static List<Position> getLatestPositions(Storage storage, long userId) throws StorageException {
-        var devices = storage.getObjects(Device.class, new Request(
-                new Columns.Include("id"),
-                new Condition.Permission(User.class, userId, Device.class)));
+    public static List<Position> getLatestPositions(Storage storage, long userId, List<Device> devices)
+            throws StorageException {
+        if (devices == null) {
+            devices = storage.getObjects(Device.class, new Request(
+                    new Columns.Include("id"),
+                    new Condition.Permission(User.class, userId, Device.class)));
+        }
         var deviceIds = devices.stream().map(BaseModel::getId).collect(Collectors.toUnmodifiableSet());
 
         var positions = storage.getObjects(Position.class, new Request(
-                new Columns.All(), new Condition.LatestPositions()));
+                new Columns.All(), new Condition.LatestPositions(deviceIds)));
         return positions.stream()
                 .filter(position -> deviceIds.contains(position.getDeviceId()))
                 .collect(Collectors.toList());

--- a/src/main/java/org/traccar/reports/DevicesReportProvider.java
+++ b/src/main/java/org/traccar/reports/DevicesReportProvider.java
@@ -55,7 +55,7 @@ public class DevicesReportProvider {
 
     public Collection<DeviceReportItem> getObjects(long userId) throws StorageException {
 
-        var positions = PositionUtil.getLatestPositions(storage, userId).stream()
+        var positions = PositionUtil.getLatestPositions(storage, userId, null).stream()
                 .collect(Collectors.toMap(Message::getDeviceId, p -> p));
 
         return storage.getObjects(Device.class, new Request(

--- a/src/main/java/org/traccar/session/ConnectionManager.java
+++ b/src/main/java/org/traccar/session/ConnectionManager.java
@@ -376,14 +376,13 @@ public class ConnectionManager implements BroadcastInterface {
         void onUpdateLog(LogRecord record);
     }
 
-    public synchronized void addListener(long userId, UpdateListener listener) throws StorageException {
+    public synchronized void addListener(long userId, UpdateListener listener, List<Device> devices)
+            throws StorageException {
         var set = listeners.get(userId);
         if (set == null) {
             set = new HashSet<>();
             listeners.put(userId, set);
 
-            var devices = storage.getObjects(Device.class, new Request(
-                    new Columns.Include("id"), new Condition.Permission(User.class, userId, Device.class)));
             userDevices.put(userId, devices.stream().map(BaseModel::getId).collect(Collectors.toSet()));
             devices.forEach(device -> deviceUsers.computeIfAbsent(device.getId(), id -> new HashSet<>()).add(userId));
         }

--- a/src/main/java/org/traccar/storage/DatabaseStorage.java
+++ b/src/main/java/org/traccar/storage/DatabaseStorage.java
@@ -30,6 +30,7 @@ import org.traccar.storage.query.Request;
 import jakarta.inject.Inject;
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -230,6 +231,17 @@ public class DatabaseStorage extends Storage {
             var condition = (Condition.LatestPositions) genericCondition;
             if (condition.getDeviceId() > 0) {
                 results.put("deviceId", condition.getDeviceId());
+            } else if (condition.getDeviceIds() != null) {
+                int paramMultiple = (condition.getDeviceIds().size() / 10) + 1;
+                List<Long> deviceList = new ArrayList<>(condition.getDeviceIds());
+                for (int i = 0; i < paramMultiple * 10; i++) {
+                    String key = String.format("deviceId%s", i);
+                    if (i < deviceList.size()) {
+                        results.put(key, deviceList.get(i));
+                    } else {
+                        results.put(key, 0L);
+                    }
+                }
             }
         }
         return results;
@@ -291,6 +303,18 @@ public class DatabaseStorage extends Storage {
                 result.append(getStorageName(Device.class));
                 if (condition.getDeviceId() > 0) {
                     result.append(" WHERE id = :deviceId");
+                } else if (condition.getDeviceIds() != null) {
+                    result.append(" WHERE id IN ( ");
+                    int paramMultiple = (condition.getDeviceIds().size() / 10) + 1;
+                    for (int i = 0; i < paramMultiple; i++) {
+                        for (int j = 0; j < 10; j++) {
+                            result.append(String.format(":deviceId%s", j + (10 * i)));
+                            if (i != (paramMultiple - 1) || j != 9) {
+                                result.append(", ");
+                            }
+                        }
+                    }
+                    result.append(" )");
                 }
                 result.append(")");
 

--- a/src/main/java/org/traccar/storage/QueryBuilder.java
+++ b/src/main/java/org/traccar/storage/QueryBuilder.java
@@ -182,6 +182,9 @@ public final class QueryBuilder {
     }
 
     public QueryBuilder setLong(String name, long value) throws SQLException {
+        if (name.matches("^deviceId\\d+$")) {
+            return setLong(name, value, true);
+        }
         return setLong(name, value, false);
     }
 

--- a/src/main/java/org/traccar/storage/query/Condition.java
+++ b/src/main/java/org/traccar/storage/query/Condition.java
@@ -18,6 +18,7 @@ package org.traccar.storage.query;
 import org.traccar.model.GroupedModel;
 
 import java.util.List;
+import java.util.Set;
 
 public interface Condition {
 
@@ -194,17 +195,24 @@ public interface Condition {
 
     class LatestPositions implements Condition {
         private final long deviceId;
+        private final Set<Long> deviceIds;
+
+        public LatestPositions(Set<Long> deviceIds) {
+            this.deviceId = 0;
+            this.deviceIds = deviceIds;
+        }
 
         public LatestPositions(long deviceId) {
             this.deviceId = deviceId;
-        }
-
-        public LatestPositions() {
-            this(0);
+            this.deviceIds = null;
         }
 
         public long getDeviceId() {
             return deviceId;
+        }
+
+        public Set<Long> getDeviceIds() {
+            return deviceIds;
         }
     }
 


### PR DESCRIPTION
- Allow querying for multiple deviceIds when getting latest positions
- Perform the (expensive) query for devices belonging to user only once
- Create cacheable PreparedStatement
- Collapse 0L to NULL for query params for more SQL performance

## Background
We found some issues that caused the websocket opening process to bog down the server. The biggest issue was that the original code fetches the latest position for all devices before filtering for the ones belonging to the user. Before filtering, however, it constructs the full-fledged entity object and with a substantial amount of devices, this can cause the JVM to allocate and then garbage collect almost immediately. With enough users opening websockets, this can grind Traccar to a halt. We solve this by passing the deviceIds first to the SQL query.

Before:
![](https://i.imgur.com/p6IDoXK.png)

After:
<img width="1403" alt="image" src="https://github.com/traccar/traccar/assets/5489134/1bc03350-c051-40d9-a80d-97f37a457a2e">

Notice the CPU time per minute has a drastic difference.

There is another expensive query which determines which devices are accessible to a user, and in the current flow this was called twice. We further enhance the websocket opening process by calling this query only once and passing it downstream.

In the end, the performance seems quite stable in load testing so far.