### PR TITLE
Add Reboot Delay

### DIFF
--- a/src/main/java/org/traccar/api/resource/ServerResource.java
+++ b/src/main/java/org/traccar/api/resource/ServerResource.java
@@ -56,6 +56,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.TimeZone;
+import java.util.Timer;
+import java.util.TimerTask;
 
 @Path("server")
 @Produces(MediaType.APPLICATION_JSON)
@@ -163,9 +165,16 @@ public class ServerResource extends BaseResource {
 
     @Path("reboot")
     @POST
-    public void reboot() throws StorageException {
+    public Response reboot() throws StorageException {
         permissionsService.checkAdmin(getUserId());
-        System.exit(130);
+        TimerTask rebootTask = new TimerTask() {
+            public void run() {
+                System.exit(130);
+            }
+        };
+        Timer rebootTimer = new Timer();
+        rebootTimer.schedule(rebootTask, 3000);
+        return Response.ok().build();
     }
 
 }


### PR DESCRIPTION
Hey there,

This probably isn't the best way to do this, but I noticed the need for a response isn't fulfilled in [PreferencesPage.jsx#L92](https://github.com/traccar/traccar-web/blob/e4840d26a26dd298dbd97be74373b85607a84add/src/settings/PreferencesPage.jsx#L92)

We use traccar with Cloudflare, so the result for us is seeing the source of the CF 502 page as an error, because the endpoint immediately becomes unavailable and never returns an ok response. Presumably if you don't use CF the promise just doesn't resolve because the server can't return anything, so most wouldn't see an error if the reboot is successful.

The reboot works fine either way. This just provides a response and schedules the reboot to occur 3 seconds later. The response has no body. I suppose later you could return a message like "Rebooting in 3 seconds" and display it to the web user. This is just one way to handle the expectation of an ok response, by providing one and rebooting afterwards.

I would have offered additional feedback but I actually have no idea how to do a PR that includes traccar-web

Just an idea anyway

Cheers