### PR TITLE
tlt2h protocol: Add `SHAKE` event

### DIFF
--- a/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -112,6 +112,9 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
             case "TOWED":
                 position.set(Position.KEY_ALARM, Position.ALARM_TOW);
                 break;
+            case "SHAKE":
+                position.set(Position.KEY_ALARM, Position.ALARM_VIBRATION);
+                break;
             case "SOS":
                 position.set(Position.KEY_ALARM, Position.ALARM_SOS);
                 break;


### PR DESCRIPTION
This contribution introduces the `SHAKE` event. It has been verified with the Mictrack MT700. MT700 emits this event when configured in Mode 4, 7 or 0. It is the first event sent after wake-up due to a detected vibration.