### PR TITLE
tlt2h protocol: Enable UDP

### DIFF
--- a/src/main/java/org/traccar/protocol/Tlt2hProtocol.java
+++ b/src/main/java/org/traccar/protocol/Tlt2hProtocol.java
@@ -38,6 +38,14 @@ public class Tlt2hProtocol extends BaseProtocol {
                 pipeline.addLast(new Tlt2hProtocolDecoder(Tlt2hProtocol.this));
             }
         });
+        addServer(new TrackerServer(config, getName(), true) {
+            @Override
+            protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
+                pipeline.addLast(new StringDecoder());
+                pipeline.addLast(new StringEncoder());
+                pipeline.addLast(new Tlt2hProtocolDecoder(Tlt2hProtocol.this));
+            }
+        });
     }
 
 }


### PR DESCRIPTION
This contribution aims to enable UDP support for the tlt2h protocol. I have a Mictrack MT700 at hand and verified the UDP mode working with this change successfully. The datagrams sent turned out to be identical to those sent in TCP mode.

However, I'm not too familiar with the code base so I don't know if that is enough.

Closes https://github.com/traccar/traccar/issues/5307