### PR TITLE
Add Amap geocoder and coordinate util

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -69,6 +69,7 @@ import org.traccar.geocoder.PositionStackGeocoder;
 import org.traccar.geocoder.PlusCodesGeocoder;
 import org.traccar.geocoder.TomTomGeocoder;
 import org.traccar.geocoder.GeocodeJsonGeocoder;
+import org.traccar.geocoder.AmapGeocoder;
 import org.traccar.geolocation.GeolocationProvider;
 import org.traccar.geolocation.GoogleGeolocationProvider;
 import org.traccar.geolocation.OpenCellIdGeolocationProvider;
@@ -264,6 +265,9 @@ public class MainModule extends AbstractModule {
                     break;
                 case "geocodejson":
                     geocoder = new GeocodeJsonGeocoder(client, url, key, language, cacheSize, addressFormat);
+                    break;
+                case "amap":
+                    geocoder = new AmapGeocoder(client, key, cacheSize, addressFormat);
                     break;
                 default:
                     geocoder = new GoogleGeocoder(client, key, language, cacheSize, addressFormat);

--- a/src/main/java/org/traccar/geocoder/AmapGeocoder.java
+++ b/src/main/java/org/traccar/geocoder/AmapGeocoder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012 - 2017 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.geocoder;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.client.Client;
+import org.traccar.helper.CoordinateUtil;
+
+
+public class AmapGeocoder extends JsonGeocoder {
+
+    private static String formatUrl(String key) {
+        String url = "https://restapi.amap.com/v3/geocode/regeo?output=json&location=%2$f,%1$f&extensions=all";
+        if (key != null) {
+            url += "&key=" + key;
+        }
+        return url;
+    }
+
+    public AmapGeocoder(Client client, String key, int cacheSize, AddressFormat addressFormat) {
+        super(client, formatUrl(key), cacheSize, addressFormat);
+    }
+
+    public Address parseAddress(JsonObject json) {
+        JsonObject regeocode = json.getJsonObject("regeocode");
+        if (regeocode != null) {
+            Address address = new Address();
+
+            address.setFormattedAddress(getJsonNode(regeocode, "formatted_address"));
+
+            JsonObject addressComponent = regeocode.getJsonObject("addressComponent");
+            if (addressComponent != null) {
+                JsonObject building = addressComponent.getJsonObject("building");
+                String houseName = getJsonNode(building, "name");
+                if (houseName == null) {
+                    JsonArray aois = regeocode.getJsonArray("aois");
+                    if (!aois.isEmpty()) {
+                        JsonObject aoi = aois.getJsonObject(0);
+                        houseName = getJsonNode(aoi, "name");
+                    }
+                }
+                address.setHouse(houseName);
+
+                JsonObject street = addressComponent.getJsonObject("streetNumber");
+                address.setStreet(getJsonNode(street, "street"));
+
+                address.setSuburb(getJsonNode(addressComponent, "township"));
+                address.setSettlement(getJsonNode(addressComponent, "district"));
+                address.setDistrict(getJsonNode(addressComponent, "city"));
+                address.setState(getJsonNode(addressComponent, "province"));
+                address.setCountry(getJsonNode(addressComponent, "country"));
+            }
+            return address;
+        }
+        return null;
+    }
+
+    private String getJsonNode(JsonObject json, String key) {
+        if (json != null && json.containsKey(key)) {
+            JsonValue value = json.get(key);
+            if (value.getValueType() == JsonValue.ValueType.STRING) {
+                return ((JsonString)value).getString();
+            }
+        }
+        return null;
+    }
+
+    protected String parseError(JsonObject json) {
+        return json.getString("info");
+    }
+
+    @Override
+    public String getAddress(
+            final double latitude, final double longitude, final ReverseGeocoderCallback callback) {
+        if (CoordinateUtil.outOfChina(longitude, latitude)) {
+            return null;
+        }
+        CoordinateUtil.Coordinate coordinate = CoordinateUtil.wgs84ToGcj02(longitude, latitude);
+
+        return super.getAddress(coordinate.getLatitude(), coordinate.getLongitude(), callback);
+    }
+}

--- a/src/main/java/org/traccar/helper/CoordinateUtil.java
+++ b/src/main/java/org/traccar/helper/CoordinateUtil.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2012 - 2017 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.helper;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Coordinate system conversion related toolkits, mainstream coordinate systems include:
+ * WGS84 coordinate system: colloquially Earth coordinate system, used by Maps outside China.
+ * GCJ02 coordinate system: colloquially Mars coordinate system, used by Gaode, Tencent, Ali and so on.
+ * <p>
+ * Reference：<a href="https://en.wikipedia.org/wiki/Restrictions_on_geographic_data_in_China">...</a>
+ * Reference: <a href="https://github.com/dromara/hutool/blob/v5-master/hutool-core/src/main/java/cn/hutool/core/util/CoordinateUtil.java">...</a>
+ */
+public class CoordinateUtil {
+
+    /**
+     * Coordinate conversion parameters：π（Pi)
+     */
+    public static final double PI = 3.1415926535897932384626433832795D;
+
+    /**
+     * Earth radius（Krasovsky 1940）
+     */
+    public static final double RADIUS = 6378245.0D;
+
+    /**
+     * Correction parameter (bias ee)
+     */
+    public static final double CORRECTION_PARAM = 0.00669342162296594323D;
+
+    /**
+     * Determine whether the coordinates are in non-China range
+     * GCJ-02 coordinate system is only valid for China, no conversion is needed for non-Chinese areas.
+     *
+     * @param longitude Longitude
+     * @param latitude Latitude
+     * @return Whether the coordinates are in non-China area
+     */
+    public static boolean outOfChina(double longitude, double latitude) {
+        return (longitude < 72.004 || longitude > 137.8347) || (latitude < 0.8293 || latitude > 55.8271);
+    }
+
+    /**
+     * Convert WGS84 to GCJ-02
+     *
+     * @param longitude Longitude
+     * @param latitude Latitude
+     * @return GCJ-02 coordinate
+     */
+    public static Coordinate wgs84ToGcj02(double longitude, double latitude) {
+        return new Coordinate(longitude, latitude).offset(offset(longitude, latitude, true));
+    }
+
+    /**
+     * Convert GCJ-02 to WGS84
+     *
+     * @param longitude Longitude
+     * @param latitude Latitude
+     * @return WGS84 coordinate
+     */
+    public static Coordinate gcj02ToWgs84(double longitude, double latitude) {
+        return new Coordinate(longitude, latitude).offset(offset(longitude, latitude, false));
+    }
+
+    /**
+     * Offset algorithm for WGS84 to GCJ-02 conversion (not exact)
+     *
+     * @param longitude Longitude
+     * @param latitude Latitude
+     * @param isPlus Forward offset or not: WGS84 to GCJ-02 use forward, otherwise use reverse.
+     * @return Offset coordinates
+     */
+    private static Coordinate offset(double longitude, double latitude, boolean isPlus) {
+        double dlng = transLng(longitude - 105.0, latitude - 35.0);
+        double dlat = transLat(longitude - 105.0, latitude - 35.0);
+
+        double magic = Math.sin(latitude / 180.0 * PI);
+        magic = 1 - CORRECTION_PARAM * magic * magic;
+        final double sqrtMagic = Math.sqrt(magic);
+
+        dlng = (dlng * 180.0) / (RADIUS / sqrtMagic * Math.cos(latitude / 180.0 * PI) * PI);
+        dlat = (dlat * 180.0) / ((RADIUS * (1 - CORRECTION_PARAM)) / (magic * sqrtMagic) * PI);
+
+        if(false == isPlus){
+            dlng = - dlng;
+            dlat = - dlat;
+        }
+
+        return new Coordinate(dlng, dlat);
+    }
+
+    /**
+     * Calculate longitude coordinates
+     *
+     * @param longitude Longitude
+     * @param latitude Latitude
+     * @return ret Calculated
+     */
+    private static double transLng(double longitude, double latitude) {
+        double ret = 300.0 + longitude + 2.0 * latitude + 0.1 * longitude * longitude + 0.1 * longitude * latitude + 0.1 * Math.sqrt(Math.abs(longitude));
+        ret += (20.0 * Math.sin(6.0 * longitude * PI) + 20.0 * Math.sin(2.0 * longitude * PI)) * 2.0 / 3.0;
+        ret += (20.0 * Math.sin(longitude * PI) + 40.0 * Math.sin(longitude / 3.0 * PI)) * 2.0 / 3.0;
+        ret += (150.0 * Math.sin(longitude / 12.0 * PI) + 300.0 * Math.sin(longitude / 30.0 * PI)) * 2.0 / 3.0;
+        return ret;
+    }
+
+    /**
+     * Calculate latitude coordinates
+     *
+     * @param longitude Longitude
+     * @param latitude Latitude
+     * @return ret Calculated
+     */
+    private static double transLat(double longitude, double latitude) {
+        double ret = -100.0 + 2.0 * longitude + 3.0 * latitude + 0.2 * latitude * latitude + 0.1 * longitude * latitude
+                + 0.2 * Math.sqrt(Math.abs(longitude));
+        ret += (20.0 * Math.sin(6.0 * longitude * PI) + 20.0 * Math.sin(2.0 * longitude * PI)) * 2.0 / 3.0;
+        ret += (20.0 * Math.sin(latitude * PI) + 40.0 * Math.sin(latitude / 3.0 * PI)) * 2.0 / 3.0;
+        ret += (160.0 * Math.sin(latitude / 12.0 * PI) + 320 * Math.sin(latitude * PI / 30.0)) * 2.0 / 3.0;
+        return ret;
+    }
+
+
+    /**
+     * Coordinate latitude and longitude
+     */
+    public static class Coordinate implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Longitude
+         */
+        private double longitude;
+        /**
+         * Latitude
+         */
+        private double latitude;
+
+        /**
+         * Constructor
+         *
+         * @param longitude Longitude
+         * @param latitude Latitude
+         */
+        public Coordinate(double longitude, double latitude) {
+            this.longitude = longitude;
+            this.latitude = latitude;
+        }
+
+        /**
+         * Get longitude
+         *
+         * @return Longitude
+         */
+        public double getLongitude() {
+            return longitude;
+        }
+
+        /**
+         * Set longitude
+         *
+         * @param longitude Longitude
+         * @return this
+         */
+        public Coordinate setLongitude(double longitude) {
+            this.longitude = longitude;
+            return this;
+        }
+
+        /**
+         * Get latitude
+         *
+         * @return Latitude
+         */
+        public double getLatitude() {
+            return latitude;
+        }
+
+        /**
+         * Set latitude
+         *
+         * @param latitude Latitude
+         * @return this
+         */
+        public Coordinate setLatitude(double latitude) {
+            this.latitude = latitude;
+            return this;
+        }
+
+        /**
+         * Offset the current coordinates by the specified coordinates.
+         *
+         * @param offset offset
+         * @return this
+         */
+        public Coordinate offset(Coordinate offset){
+            this.longitude += offset.longitude;
+            this.latitude += offset.latitude;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Coordinate that = (Coordinate) o;
+            return Double.compare(that.longitude, longitude) == 0 && Double.compare(that.latitude, latitude) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(longitude, latitude);
+        }
+
+        @Override
+        public String toString() {
+            return "Coordinate{" +
+                    "longitude=" + longitude +
+                    ", latitude=" + latitude +
+                    '}';
+        }
+    }
+}

--- a/src/test/java/org/traccar/geocoder/GeocoderTest.java
+++ b/src/test/java/org/traccar/geocoder/GeocoderTest.java
@@ -129,4 +129,12 @@ public class GeocoderTest {
         String address = geocoder.getAddress(40.7337807, -73.9974401, null);
         assertEquals("35 West 9th Street, New York, New York, US", address);
     }
+
+    @Disabled
+    @Test
+    public void testAmap() {
+        Geocoder geocoder = new AmapGeocoder(client, "", 0, new AddressFormat());
+        String address = geocoder.getAddress(39.991957, 116.310003, null);
+        assertEquals("北京大学物理学院 中关村北大街, 海淀区, 北京市, 中国", address);
+    }
 }


### PR DESCRIPTION
In China, geolocation encoding is commonly dominated by the use of Gaode Maps(Amap) and Baidu Maps. Other internationally used platforms are not as accurate. Moreover, China has a special system of geographic coordinates(GCJ-02). This merge request implements the geolocation encoding implementation of the Gaode map(Amap).

For this merge request I added two class, CoordinateUtil and AmapGeocoder.
CoordinateUtil is mainly used to convert WGS84 to GCJ-02 coordinates, this code reference: https://github.com/dromara/hutool/blob/v5-master/hutool-core/src/main/java/cn/hutool/ core/util/CoordinateUtil.java 
AmapGeocoder implements the interpretation of geographic coordinates of Gaode map(Amap).