### PR TITLE
Easier to run locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "checkstyle"
     id "com.google.protobuf" version "0.9.4"
     id "org.kordamp.gradle.project-enforcer" version "0.13.0"
+    id "application"
 }
 
 repositories {
@@ -116,4 +117,8 @@ jar {
                 "Implementation-Version": "6.2",
                 "Class-Path": configurations.runtimeClasspath.files.collect { "lib/$it.name" }.join(" "))
     }
+}
+
+application {
+    mainClass = 'org.traccar.Main'
 }


### PR DESCRIPTION
This way you can start the server with `./gradlew run`
