### PR TITLE
tlt2h: Fix handling UDP

### DIFF
--- a/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -148,7 +148,10 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
 
         String status = parser.next();
 
-        String[] messages = sentence.substring(sentence.indexOf('\n') + 1).split("\r\n");
+        String[] messages = sentence.substring(
+                sentence.indexOf('\n') + 1,
+                sentence.endsWith("##") ? sentence.length() - 4 : sentence.length())
+                .split("\r\n");
         List<Position> positions = new LinkedList<>();
 
         for (String message : messages) {


### PR DESCRIPTION
Currently, the tlt2h decoder used with UDP does not correctly detect the end of the datagram, leading to a second empty position returned in [positions](https://github.com/frederictobiasc/traccar/blob/da82ef8979c23496bbf3507f34fc410e5f86f8ed/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java#L249) (see example contents of `positions` below.  This results for instance in networks, battery voltage, ... being never shown in the `details` view of a device. This was initially reported in https://github.com/traccar/traccar/pull/5344#issuecomment-2266344264.

I confirm that this fixes the issue.

Is it fine to fix this by introducing the CharacterDelimiterFrameDecoder also used by the TCP handler, or should we rather catch this in the frame decoder itself?

## Further information

Contents of [messages](https://github.com/frederictobiasc/traccar/blob/da82ef8979c23496bbf3507f34fc410e5f86f8ed/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java#L151) when processing a datagram:


```
messages = [
  "#4065#$WIFI,015036.00,A,-79,66C0E2A3AAAA,-68,E4F75BA2AAAA,-77,ACDB48E6AAAA,-79,388B59DCAAAA,-79,56C0E2A3AAAA,030824*7D",
  "##"
];
```

<details>
  <summary>Contents of positions</summary>

See [positions](https://github.com/frederictobiasc/traccar/blob/da82ef8979c23496bbf3507f34fc410e5f86f8ed/src/main/java/org/traccar/protocol/Tlt2hProtocolDecoder.java#L249)

```
LinkedList@75 size=2
0:
  accuracy: 0.000000
  address: null
  altitude: 0.000000
  attributes: LinkedHashMap@141 size=1
    0: LinkedHashMap$Entry@172 "battery":"4.065"
      key: "battery"
      value: "4.065"
  course: 0.000000
  deviceId: 1
  deviceTime: Date@142
  fixTime: null
  geofenceIds: null
  id: 0
  latitude: 0.000000
  longitude: 0.000000
  network:
    carrier: null
    cellTowers: null
    considerIp: Boolean@182
    homeMobileCountryCode: null
    homeMobileNetworkCode: null
    radioType: "gsm"
    wifiAccessPoints: ArrayList@184 size=5
      0: WifiAccessPoint@190
        channel: null
        macAddress: "66:C0:E2:A3:AA:AA"
        signalStrength: Integer@211
      1: WifiAccessPoint@191
      2: WifiAccessPoint@192
      3: WifiAccessPoint@193
      4: WifiAccessPoint@194
  outdated: true
  protocol: "tlt2h"
    coder: 0
    hash: 110458994
    hashIsZero: false
    value: byte[5]@165
    serverTime: Date@145
    speed: 0.000000
    type: null
    valid: false
1:
  accuracy: 0.000000
  address: null
  altitude: 0.000000
  attributes: LinkedHashMap@155 size=0
  course: 0.000000
  deviceId: 1
  deviceTime: null
  fixTime: null
  geofenceIds: null
  id: 0
  latitude: 0.000000
  longitude: 0.000000
  network: null
  outdated: true
  protocol: "tlt2h"
  serverTime: Date@156
  speed: 0.000000
  type: null
  valid: false
```
</details>