### PR TITLE
Allow managers to send announcements

### DIFF
--- a/src/main/java/org/traccar/api/resource/NotificationResource.java
+++ b/src/main/java/org/traccar/api/resource/NotificationResource.java
@@ -129,7 +129,8 @@ public class NotificationResource extends ExtendedObjectResource<Notification> {
                 var conditions = new LinkedList<Condition>();
                 conditions.add(new Condition.Equals("id", userId));
                 if (permissionsService.notAdmin(getUserId())) {
-                    conditions.add(new Condition.Permission(User.class, getUserId(), ManagedUser.class).excludeGroups());
+                    conditions.add(new Condition.Permission(
+                            User.class, getUserId(), ManagedUser.class).excludeGroups());
                 }
                 users.add(storage.getObject(
                         User.class, new Request(new Columns.All(), Condition.merge(conditions))));

--- a/src/main/java/org/traccar/api/resource/NotificationResource.java
+++ b/src/main/java/org/traccar/api/resource/NotificationResource.java
@@ -28,7 +28,11 @@ import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traccar.api.ExtendedObjectResource;
-import org.traccar.model.*;
+import org.traccar.model.Event;
+import org.traccar.model.ManagedUser;
+import org.traccar.model.Notification;
+import org.traccar.model.Typed;
+import org.traccar.model.User;
 import org.traccar.notification.MessageException;
 import org.traccar.notification.NotificationMessage;
 import org.traccar.notification.NotificatorManager;
@@ -39,7 +43,11 @@ import org.traccar.storage.query.Request;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Path("notifications")

--- a/src/main/java/org/traccar/api/resource/NotificationResource.java
+++ b/src/main/java/org/traccar/api/resource/NotificationResource.java
@@ -113,7 +113,7 @@ public class NotificationResource extends ExtendedObjectResource<Notification> {
     public Response sendMessage(
             @PathParam("notificator") String notificator, @QueryParam("userId") List<Long> userIds,
             NotificationMessage message) throws MessageException, StorageException {
-        permissionsService.checkAdmin(getUserId());
+        permissionsService.checkManager(getUserId());
         List<User> users;
         if (userIds.isEmpty()) {
             users = storage.getObjects(User.class, new Request(new Columns.All()));

--- a/src/main/java/org/traccar/api/resource/NotificationResource.java
+++ b/src/main/java/org/traccar/api/resource/NotificationResource.java
@@ -130,12 +130,9 @@ public class NotificationResource extends ExtendedObjectResource<Notification> {
                 conditions.add(new Condition.Equals("id", userId));
                 if (permissionsService.notAdmin(getUserId())) {
                     conditions.add(new Condition.Permission(User.class, getUserId(), ManagedUser.class).excludeGroups());
-                    users.add(storage.getObject(
-                            User.class, new Request(new Columns.All(), Condition.merge(conditions))));
-                } else {
-                    users.add(storage.getObject(
-                            User.class, new Request(new Columns.All(), Condition.merge(conditions))));
                 }
+                users.add(storage.getObject(
+                        User.class, new Request(new Columns.All(), Condition.merge(conditions))));
             }
         }
         for (User user : users) {


### PR DESCRIPTION
Managers should also be allowed to send announcements, since they can have many users bellow them to manage.

Plus, this would enhance the announcements feature to cover scenarios of Traccar servers where managers want to send information to their managed users.