### PR TITLE
Disable unused Jersey WADL

### DIFF
--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -165,6 +165,7 @@ public class WebServer implements LifecycleObject {
         }
 
         ResourceConfig resourceConfig = new ResourceConfig();
+        resourceConfig.property("jersey.config.server.wadl.disableWadl", true);
         resourceConfig.registerClasses(
                 JacksonFeature.class,
                 ObjectMapperContextResolver.class,


### PR DESCRIPTION
Hi,

while combing thorough warnings, I found a low hanging fruit:

> WARN: JAXBContext implementation could not be found. WADL feature is disabled.

As WADL is not used anywhere and disabling it is one line config change, I implemented it for cleaner logs.