### PR TITLE
Update TrvProtocolDecoder.java

### DIFF
--- a/src/main/java/org/traccar/protocol/TrvProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TrvProtocolDecoder.java
@@ -181,7 +181,7 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
                 channel.writeAndFlush(new NetworkMessage(responseHeader + "," + time + ",0#", remoteAddress));
             } else if (type.equals("AP14") && !id.equals("IW")) {
                 channel.writeAndFlush(new NetworkMessage(responseHeader + ",0.000,0.000#", remoteAddress));
-            } else if (!Set.of("AP12", "AP14", "AP33", "AP34", "AP84", "AP85").contains(type)
+            } else if (!Set.of("AP12", "AP14", "AP33", "AP34", "AP76", "AP77", "AP84", "AP85").contains(type)
                     && !sentence.substring(responseHeader.length() + 1).matches("^\\d{6}$")) {
                 channel.writeAndFlush(new NetworkMessage(responseHeader + "#", remoteAddress));
             }


### PR DESCRIPTION

[Gps Watch protocol_2023.pdf](https://github.com/user-attachments/files/17291876/Gps.Watch.protocol_2023.pdf)
No response for following IWAP Commands:
AP76
AP77
Attached is the protocol where the changes are visible. On page 22 you can see AP76/AP77.