### PR TITLE
Security: Session fixation

### DIFF
--- a/src/main/java/org/traccar/api/AsyncSocketServlet.java
+++ b/src/main/java/org/traccar/api/AsyncSocketServlet.java
@@ -18,10 +18,10 @@ package org.traccar.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
-import org.traccar.api.resource.SessionResource;
 import org.traccar.api.security.LoginService;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
+import org.traccar.helper.SessionHelper;
 import org.traccar.session.ConnectionManager;
 import org.traccar.storage.Storage;
 
@@ -69,7 +69,7 @@ public class AsyncSocketServlet extends JettyWebSocketServlet {
                     throw new RuntimeException(e);
                 }
             } else if (req.getSession() != null) {
-                userId = (Long) ((HttpSession) req.getSession()).getAttribute(SessionResource.USER_ID_KEY);
+                userId = (Long) ((HttpSession) req.getSession()).getAttribute(SessionHelper.USER_ID_KEY);
             }
             if (userId != null) {
                 return new AsyncSocket(objectMapper, connectionManager, storage, userId);

--- a/src/main/java/org/traccar/api/MediaFilter.java
+++ b/src/main/java/org/traccar/api/MediaFilter.java
@@ -17,10 +17,10 @@
 package org.traccar.api;
 
 import com.google.inject.Provider;
-import org.traccar.api.resource.SessionResource;
 import org.traccar.api.security.PermissionsService;
 import org.traccar.database.StatisticsManager;
 import org.traccar.helper.Log;
+import org.traccar.helper.SessionHelper;
 import org.traccar.model.Device;
 import org.traccar.storage.Storage;
 import org.traccar.storage.StorageException;
@@ -65,7 +65,7 @@ public class MediaFilter implements Filter {
             HttpSession session = ((HttpServletRequest) request).getSession(false);
             Long userId = null;
             if (session != null) {
-                userId = (Long) session.getAttribute(SessionResource.USER_ID_KEY);
+                userId = (Long) session.getAttribute(SessionHelper.USER_ID_KEY);
                 if (userId != null) {
                     statisticsManager.registerRequest(userId);
                 }

--- a/src/main/java/org/traccar/api/resource/SessionResource.java
+++ b/src/main/java/org/traccar/api/resource/SessionResource.java
@@ -81,6 +81,7 @@ public class SessionResource extends BaseResource {
             LoginResult loginResult = loginService.login(token);
             if (loginResult != null) {
                 User user = loginResult.getUser();
+                request.getSession().invalidate();
                 request.getSession().setAttribute(USER_ID_KEY, user.getId());
                 request.getSession().setAttribute(EXPIRATION_KEY, loginResult.getExpiration());
                 LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
@@ -128,6 +129,7 @@ public class SessionResource extends BaseResource {
         }
         if (loginResult != null) {
             User user = loginResult.getUser();
+            request.getSession().invalidate();
             request.getSession().setAttribute(USER_ID_KEY, user.getId());
             LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
             return user;

--- a/src/main/java/org/traccar/api/resource/SessionResource.java
+++ b/src/main/java/org/traccar/api/resource/SessionResource.java
@@ -22,6 +22,7 @@ import org.traccar.api.security.LoginService;
 import org.traccar.api.signature.TokenManager;
 import org.traccar.database.OpenIdProvider;
 import org.traccar.helper.LogAction;
+import org.traccar.helper.SessionHelper;
 import org.traccar.helper.WebHelper;
 import org.traccar.model.User;
 import org.traccar.storage.StorageException;
@@ -57,9 +58,6 @@ import java.net.URI;
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 public class SessionResource extends BaseResource {
 
-    public static final String USER_ID_KEY = "userId";
-    public static final String EXPIRATION_KEY = "expiration";
-
     @Inject
     private LoginService loginService;
 
@@ -81,15 +79,12 @@ public class SessionResource extends BaseResource {
             LoginResult loginResult = loginService.login(token);
             if (loginResult != null) {
                 User user = loginResult.getUser();
-                request.getSession().invalidate();
-                request.getSession().setAttribute(USER_ID_KEY, user.getId());
-                request.getSession().setAttribute(EXPIRATION_KEY, loginResult.getExpiration());
-                LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
+                SessionHelper.userLogin(request, user, loginResult.getExpiration());
                 return user;
             }
         }
 
-        Long userId = (Long) request.getSession().getAttribute(USER_ID_KEY);
+        Long userId = (Long) request.getSession().getAttribute(SessionHelper.USER_ID_KEY);
         if (userId != null) {
             User user = permissionsService.getUser(userId);
             if (user != null) {
@@ -106,7 +101,7 @@ public class SessionResource extends BaseResource {
         permissionsService.checkUser(getUserId(), userId);
         User user = storage.getObject(User.class, new Request(
                 new Columns.All(), new Condition.Equals("id", userId)));
-        request.getSession().setAttribute(USER_ID_KEY, user.getId());
+        request.getSession().setAttribute(SessionHelper.USER_ID_KEY, user.getId());
         LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
         return user;
     }
@@ -129,9 +124,7 @@ public class SessionResource extends BaseResource {
         }
         if (loginResult != null) {
             User user = loginResult.getUser();
-            request.getSession().invalidate();
-            request.getSession().setAttribute(USER_ID_KEY, user.getId());
-            LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
+            SessionHelper.userLogin(request, user, null);
             return user;
         } else {
             LogAction.failedLogin(WebHelper.retrieveRemoteAddress(request));
@@ -142,7 +135,7 @@ public class SessionResource extends BaseResource {
     @DELETE
     public Response remove() {
         LogAction.logout(getUserId(), WebHelper.retrieveRemoteAddress(request));
-        request.getSession().removeAttribute(USER_ID_KEY);
+        request.getSession().removeAttribute(SessionHelper.USER_ID_KEY);
         return Response.noContent().build();
     }
 
@@ -150,7 +143,7 @@ public class SessionResource extends BaseResource {
     @POST
     public String requestToken(
             @FormParam("expiration") Date expiration) throws StorageException, GeneralSecurityException, IOException {
-        Date currentExpiration = (Date) request.getSession().getAttribute(EXPIRATION_KEY);
+        Date currentExpiration = (Date) request.getSession().getAttribute(SessionHelper.EXPIRATION_KEY);
         if (currentExpiration != null && currentExpiration.before(expiration)) {
             expiration = currentExpiration;
         }

--- a/src/main/java/org/traccar/api/resource/SessionResource.java
+++ b/src/main/java/org/traccar/api/resource/SessionResource.java
@@ -101,8 +101,7 @@ public class SessionResource extends BaseResource {
         permissionsService.checkUser(getUserId(), userId);
         User user = storage.getObject(User.class, new Request(
                 new Columns.All(), new Condition.Equals("id", userId)));
-        request.getSession().setAttribute(SessionHelper.USER_ID_KEY, user.getId());
-        LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
+        SessionHelper.userLogin(request, user, null);
         return user;
     }
 

--- a/src/main/java/org/traccar/api/resource/UserResource.java
+++ b/src/main/java/org/traccar/api/resource/UserResource.java
@@ -24,6 +24,7 @@ import org.traccar.api.BaseObjectResource;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
 import org.traccar.helper.LogAction;
+import org.traccar.helper.SessionHelper;
 import org.traccar.helper.model.UserUtil;
 import org.traccar.model.Device;
 import org.traccar.model.ManagedUser;
@@ -138,7 +139,7 @@ public class UserResource extends BaseObjectResource<User> {
     public Response remove(@PathParam("id") long id) throws Exception {
         Response response = super.remove(id);
         if (getUserId() == id) {
-            request.getSession().removeAttribute(SessionResource.USER_ID_KEY);
+            request.getSession().removeAttribute(SessionHelper.USER_ID_KEY);
         }
         return response;
     }

--- a/src/main/java/org/traccar/api/security/SecurityRequestFilter.java
+++ b/src/main/java/org/traccar/api/security/SecurityRequestFilter.java
@@ -18,8 +18,8 @@ package org.traccar.api.security;
 import com.google.inject.Injector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.traccar.api.resource.SessionResource;
 import org.traccar.database.StatisticsManager;
+import org.traccar.helper.SessionHelper;
 import org.traccar.model.User;
 import org.traccar.storage.StorageException;
 
@@ -86,8 +86,8 @@ public class SecurityRequestFilter implements ContainerRequestFilter {
 
             } else if (request.getSession() != null) {
 
-                Long userId = (Long) request.getSession().getAttribute(SessionResource.USER_ID_KEY);
-                Date expiration = (Date) request.getSession().getAttribute(SessionResource.EXPIRATION_KEY);
+                Long userId = (Long) request.getSession().getAttribute(SessionHelper.USER_ID_KEY);
+                Date expiration = (Date) request.getSession().getAttribute(SessionHelper.EXPIRATION_KEY);
                 if (userId != null) {
                     User user = injector.getInstance(PermissionsService.class).getUser(userId);
                     if (user != null) {

--- a/src/main/java/org/traccar/database/OpenIdProvider.java
+++ b/src/main/java/org/traccar/database/OpenIdProvider.java
@@ -192,6 +192,7 @@ public class OpenIdProvider {
         User user = loginService.login(
                 userInfo.getEmailAddress(), userInfo.getName(), administrator).getUser();
 
+        request.getSession().invalidate();
         request.getSession().setAttribute(SessionResource.USER_ID_KEY, user.getId());
         LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
 

--- a/src/main/java/org/traccar/database/OpenIdProvider.java
+++ b/src/main/java/org/traccar/database/OpenIdProvider.java
@@ -17,11 +17,10 @@ package org.traccar.database;
 
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
-import org.traccar.api.resource.SessionResource;
 import org.traccar.api.security.LoginService;
 import org.traccar.model.User;
 import org.traccar.storage.StorageException;
-import org.traccar.helper.LogAction;
+import org.traccar.helper.SessionHelper;
 import org.traccar.helper.WebHelper;
 
 import java.net.URI;
@@ -33,6 +32,7 @@ import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
 import java.io.IOException;
+
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -192,9 +192,7 @@ public class OpenIdProvider {
         User user = loginService.login(
                 userInfo.getEmailAddress(), userInfo.getName(), administrator).getUser();
 
-        request.getSession().invalidate();
-        request.getSession().setAttribute(SessionResource.USER_ID_KEY, user.getId());
-        LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
+        SessionHelper.userLogin(request, user, null);
 
         return baseUrl;
     }

--- a/src/main/java/org/traccar/helper/SessionHelper.java
+++ b/src/main/java/org/traccar/helper/SessionHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.helper;
+
+import org.traccar.model.User;
+import java.util.Date;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class SessionHelper {
+
+    public static final String USER_ID_KEY = "userId";
+    public static final String EXPIRATION_KEY = "expiration";
+
+    private SessionHelper() {
+    }
+
+    public static void userLogin(HttpServletRequest request, User user, Date expiration) {
+        request.getSession().invalidate();
+        request.getSession().setAttribute(USER_ID_KEY, user.getId());
+
+        if (expiration != null) {
+            request.getSession().setAttribute(EXPIRATION_KEY, expiration);
+        }
+
+        LogAction.login(user.getId(), WebHelper.retrieveRemoteAddress(request));
+    }
+
+}

--- a/src/main/java/org/traccar/web/WebRequestLog.java
+++ b/src/main/java/org/traccar/web/WebRequestLog.java
@@ -20,7 +20,6 @@ import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.DateCache;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.traccar.api.resource.SessionResource;
 import org.traccar.helper.SessionHelper;
 
 import java.util.Locale;

--- a/src/main/java/org/traccar/web/WebRequestLog.java
+++ b/src/main/java/org/traccar/web/WebRequestLog.java
@@ -21,6 +21,7 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.DateCache;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.traccar.api.resource.SessionResource;
+import org.traccar.helper.SessionHelper;
 
 import java.util.Locale;
 import java.util.TimeZone;
@@ -40,7 +41,7 @@ public class WebRequestLog extends ContainerLifeCycle implements RequestLog {
     @Override
     public void log(Request request, Response response) {
         try {
-            Long userId = (Long) request.getSession().getAttribute(SessionResource.USER_ID_KEY);
+            Long userId = (Long) request.getSession().getAttribute(SessionHelper.USER_ID_KEY);
             writer.write(String.format("%s - %s [%s] \"%s %s %s\" %d %d",
                     request.getRemoteHost(),
                     userId != null ? String.valueOf(userId) : "-",


### PR DESCRIPTION
### Problem
Session fixation is made possible by the unsafe practice of keeping the same value in session cookies before and after authentication.

In the generic exploitation of session-fixing vulnerabilities, an attacker can obtain a set of session cookies from the target website without first authenticating. He can then force these cookies into the victim's browser using various techniques. If the victim subsequently authenticates on the target website and the cookies are not updated at login, the victim will be identified by the session cookies chosen by the chosen by the attacker. The attacker is then able to impersonate the victim using these known cookies.

See: [OWASP Session Fixation](https://owasp.org/www-community/attacks/Session_fixation )

### Recommendation
This pull request refresh the session cookie after a successful login.