### PR TITLE
Security: Session cookie is not HttpOnly

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -843,6 +843,14 @@ public final class Keys {
             List.of(KeyType.CONFIG),
             "max-age=3600,public");
 
+     /**
+     * Set HttpOnly attribut to the session cookie.
+     */
+    public static final ConfigKey<Boolean> WEB_COOKIE_HTTP_ONLY = new BooleanConfigKey(
+        "web.cookieHttpOnly",
+        List.of(KeyType.CONFIG),
+        false);
+
     /**
      * Enable TOTP authentication on the server.
      */

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -843,14 +843,6 @@ public final class Keys {
             List.of(KeyType.CONFIG),
             "max-age=3600,public");
 
-     /**
-     * Set HttpOnly attribut to the session cookie.
-     */
-    public static final ConfigKey<Boolean> WEB_COOKIE_HTTP_ONLY = new BooleanConfigKey(
-        "web.cookieHttpOnly",
-        List.of(KeyType.CONFIG),
-        false);
-
     /**
      * Enable TOTP authentication on the server.
      */

--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -218,7 +218,7 @@ public class WebServer implements LifecycleObject {
             }
         }
 
-        sessionCookieConfig.setHttpOnly(config.getBoolean(Keys.WEB_COOKIE_HTTP_ONLY));
+        sessionCookieConfig.setHttpOnly(true);
     }
 
     @Override

--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -217,6 +217,8 @@ public class WebServer implements LifecycleObject {
                     break;
             }
         }
+
+        sessionCookieConfig.setHttpOnly(config.getBoolean(Keys.WEB_COOKIE_HTTP_ONLY));
     }
 
     @Override


### PR DESCRIPTION
### Problem
The session cookie does not have the HttpOnly attribute. This parameter tells the browser that the cookie can only be accessed by the server and not by client-side scripts.

See: [OWASP Testing for Cookies Attributes](https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes)

### Recommendation
This pull request adds a parameter to set the HttpOnly attribute to the session cookie. Personally, I would set this attribute to “true” by default, but I don't know the system-wide implications.