### PR TITLE
Security: Hide error details

### DIFF
--- a/src/main/java/org/traccar/api/ResourceErrorHandler.java
+++ b/src/main/java/org/traccar/api/ResourceErrorHandler.java
@@ -15,20 +15,33 @@
  */
 package org.traccar.api;
 
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
 import org.traccar.helper.Log;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
 public class ResourceErrorHandler implements ExceptionMapper<Exception> {
 
+    private static final String HIDDEN_MESSAGE_KEY = "HiddenError";
+    private boolean hideErrorDetail;
+
+    @Inject
+    public ResourceErrorHandler(Config config) {
+        this.hideErrorDetail = config.getBoolean(Keys.WEB_HIDE_ERROR_DETAIL);
+    }
+
     @Override
     public Response toResponse(Exception e) {
         if (e instanceof WebApplicationException webException) {
-            return Response.fromResponse(webException.getResponse()).entity(Log.exceptionStack(webException)).build();
+            String message = hideErrorDetail ? HIDDEN_MESSAGE_KEY : Log.exceptionStack(webException);
+            return Response.fromResponse(webException.getResponse()).entity(message).build();
         } else {
-            return Response.status(Response.Status.BAD_REQUEST).entity(Log.exceptionStack(e)).build();
+            String message = hideErrorDetail ? HIDDEN_MESSAGE_KEY : Log.exceptionStack(e);
+            return Response.status(Response.Status.BAD_REQUEST).entity(message).build();
         }
     }
 

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -844,6 +844,13 @@ public final class Keys {
             "max-age=3600,public");
 
     /**
+     * Show or hide technical details in error messages displayed to users.
+     */
+    public static final ConfigKey<Boolean> WEB_HIDE_ERROR_DETAIL = new BooleanConfigKey(
+        "web.hideErrorDetail",
+        List.of(KeyType.CONFIG));
+
+    /**
      * Enable TOTP authentication on the server.
      */
     public static final ConfigKey<Boolean> WEB_TOTP_ENABLE = new BooleanConfigKey(


### PR DESCRIPTION
### Problem
By default, some pages return technical details on errors, such as the stack trace. While this behavior can be useful for development, it is not user-friendly and may reveal implementation details to an attacker.

See: [OWASP Improper Error Handling](https://owasp.org/www-community/Improper_Error_Handling)

### Recommendation
This pull request add a parameter to hide error details and only show a generic error message.

Linked to pull request : https://github.com/traccar/traccar-web/pull/1283