### PR TITLE
Add data compression to PositionForwarderWialon

### DIFF
--- a/src/main/java/org/traccar/MainModule.java
+++ b/src/main/java/org/traccar/MainModule.java
@@ -371,7 +371,7 @@ public class MainModule extends AbstractModule {
                 case "kafka" -> new PositionForwarderKafka(config, objectMapper);
                 case "mqtt" -> new PositionForwarderMqtt(config, objectMapper);
                 case "redis" -> new PositionForwarderRedis(config, objectMapper);
-                case "wialon" -> new PositionForwarderWialon(config, executorService, "1.0");
+                case "wialon" -> new PositionForwarderWialon(config, executorService, "1.0", false);
                 default -> new PositionForwarderUrl(config, client, objectMapper);
             };
         }


### PR DESCRIPTION
If data is bigger then MTU, UDP won't allow to send this. I try to change UDP to TCP, chunk data, but compression do it's best.
Compression is described at the end of this docs: https://extapi.wialon.com/hw/cfg/Wialon%20IPS_en_v_2_0.pdf
Tested on Wialon and build looks fine.