### PR TITLE
Add Alarm attribute to Minifinder2ProtocolDecoder.java

### DIFF
--- a/src/main/java/org/traccar/protocol/Minifinder2ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Minifinder2ProtocolDecoder.java
@@ -180,6 +180,9 @@ public class Minifinder2ProtocolDecoder extends BaseProtocolDecoder {
                         if (length == 5) {
                             position.setDeviceTime(new Date(buf.readUnsignedIntLE() * 1000));
                         }
+                        if (alarm > 0) {
+                            position.set(Position.KEY_ALARM, alarm);
+                        }
                         break;
                     case 0x14:
                         position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());


### PR DESCRIPTION
Add Alarm attribute to the Minifinder2 protocol to get the raw alarm data.