### PR TITLE
Fix: Set UTF-8 Encoding for Proper Rendering of Chinese Characters in Server Title

### DIFF
--- a/src/main/java/org/traccar/web/OverrideFilter.java
+++ b/src/main/java/org/traccar/web/OverrideFilter.java
@@ -49,7 +49,7 @@ public class OverrideFilter implements Filter {
             chain.doFilter(request, response);
             return;
         }
-        response.setCharacterEncoding("UTF-8");
+
         ResponseWrapper wrappedResponse = new ResponseWrapper((HttpServletResponse) response);
 
         chain.doFilter(request, wrappedResponse);

--- a/src/main/java/org/traccar/web/OverrideFilter.java
+++ b/src/main/java/org/traccar/web/OverrideFilter.java
@@ -30,6 +30,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Singleton
 public class OverrideFilter implements Filter {
@@ -70,12 +71,12 @@ public class OverrideFilter implements Filter {
                 String description = server.getString("description", "Traccar GPS Tracking System");
                 String colorPrimary = server.getString("colorPrimary", "#1a237e");
 
-                String alteredContent = new String(wrappedResponse.getCapture(), "UTF-8")
+                String alteredContent = new String(wrappedResponse.getCapture(), StandardCharsets.UTF_8)
                         .replace("${title}", title)
                         .replace("${description}", description)
                         .replace("${colorPrimary}", colorPrimary);
 
-                byte[] data = alteredContent.getBytes("UTF-8");
+                byte[] data = alteredContent.getBytes(StandardCharsets.UTF_8);
                 response.setContentLength(data.length);
                 response.getOutputStream().write(data);
 

--- a/src/main/java/org/traccar/web/OverrideFilter.java
+++ b/src/main/java/org/traccar/web/OverrideFilter.java
@@ -49,7 +49,7 @@ public class OverrideFilter implements Filter {
             chain.doFilter(request, response);
             return;
         }
-
+        response.setCharacterEncoding("UTF-8");
         ResponseWrapper wrappedResponse = new ResponseWrapper((HttpServletResponse) response);
 
         chain.doFilter(request, wrappedResponse);
@@ -70,12 +70,12 @@ public class OverrideFilter implements Filter {
                 String description = server.getString("description", "Traccar GPS Tracking System");
                 String colorPrimary = server.getString("colorPrimary", "#1a237e");
 
-                String alteredContent = new String(wrappedResponse.getCapture())
+                String alteredContent = new String(wrappedResponse.getCapture(), "UTF-8")
                         .replace("${title}", title)
                         .replace("${description}", description)
                         .replace("${colorPrimary}", colorPrimary);
 
-                byte[] data = alteredContent.getBytes();
+                byte[] data = alteredContent.getBytes("UTF-8");
                 response.setContentLength(data.length);
                 response.getOutputStream().write(data);
 


### PR DESCRIPTION
The server title in the Traccar web interface was displaying as garbled characters when set to Chinese strings due to a missing charset=utf-8 in the response Content-Type header. This change ensures that the server title is rendered correctly by explicitly setting the response's character encoding to UTF-8.

Changes:
- Modified the OverrideFilter class to set response.setCharacterEncoding("UTF-8").
- Ensured proper rendering of the title/description in the web interface.

Closes #5465 
