### PR TITLE
OpenAPI yaml: User expirationTime nullable: true

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1803,6 +1803,7 @@ components:
           type: string
           description: in IS0 8601 format. eg. `1963-11-22T18:30:00Z`
           format: date-time
+          nullable: true
         deviceLimit:
           type: integer
         userLimit:


### PR DESCRIPTION
This resolves the issue described in the linked forum thread:
[Link to Traccar Forum topic](https://www.traccar.org/forums/topic/traccar-openapi-client-getusers-expirationtime-can-be-null-but-is-not-marked-as-nullable/
)

Tested and confirmed. 