### PR TITLE
Redis cache implementation - Similar to InMemory Cache

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -27,4 +27,13 @@
     <entry key='atrack.custom'>true</entry>
     <entry key='intellitrac.port'>6037</entry>
 
+    <!--<entry key='forward.type'>redis</entry>
+    <entry key='forward.url'>redis://localhost:6379</entry>
+
+    <entry key='cache.type'>redis</entry>
+    <entry key='cache.host'>localhost</entry>
+    <entry key='cache.port'>6379</entry>
+    <entry key='cache.user'></entry>
+    <entry key='cache.password'></entry>-->
+
 </properties>

--- a/src/main/java/org/traccar/broadcast/BroadcastInterface.java
+++ b/src/main/java/org/traccar/broadcast/BroadcastInterface.java
@@ -21,7 +21,9 @@ import org.traccar.model.Event;
 import org.traccar.model.ObjectOperation;
 import org.traccar.model.Position;
 
-public interface BroadcastInterface {
+import java.io.Serializable;
+
+public interface BroadcastInterface extends Serializable {
 
     default void updateDevice(boolean local, Device device) {
     }

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1979,4 +1979,20 @@ public final class Keys {
             "broadcast.secondary",
             List.of(KeyType.CONFIG));
 
+    /** Cache type. **/
+    public static final ConfigKey<String> CACHE_TYPE = new StringConfigKey(
+            "cache.type",
+            List.of(KeyType.CONFIG));
+    /** Cache host. **/
+    public static final ConfigKey<String> CACHE_HOST = new StringConfigKey(
+            "cache.host",
+            List.of(KeyType.CONFIG));
+
+    public static final ConfigKey<Integer> CACHE_PORT = new IntegerConfigKey(
+            "cache.port",
+            List.of(KeyType.CONFIG));
+
+    public static final ConfigKey<String> CACHE_PASSWORD = new StringConfigKey(
+            "cache.password",
+            List.of(KeyType.CONFIG));
 }

--- a/src/main/java/org/traccar/model/BaseModel.java
+++ b/src/main/java/org/traccar/model/BaseModel.java
@@ -16,7 +16,9 @@
  */
 package org.traccar.model;
 
-public class BaseModel {
+import java.io.Serializable;
+
+public class BaseModel implements Serializable {
 
     private long id;
 

--- a/src/main/java/org/traccar/session/ConnectionKey.java
+++ b/src/main/java/org/traccar/session/ConnectionKey.java
@@ -17,9 +17,10 @@ package org.traccar.session;
 
 import io.netty.channel.Channel;
 
+import java.io.Serializable;
 import java.net.SocketAddress;
 
-public record ConnectionKey(SocketAddress localAddress, SocketAddress remoteAddress) {
+public record ConnectionKey(SocketAddress localAddress, SocketAddress remoteAddress) implements Serializable {
     public ConnectionKey(Channel channel, SocketAddress remoteAddress) {
         this(channel.localAddress(), remoteAddress);
     }

--- a/src/main/java/org/traccar/session/cache/CacheGraph.java
+++ b/src/main/java/org/traccar/session/cache/CacheGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Anton Tananaev (anton@traccar.org)
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,123 +17,26 @@ package org.traccar.session.cache;
 
 import org.traccar.model.BaseModel;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.Serializable;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class CacheGraph {
+public interface CacheGraph extends Serializable {
+    void addObject(BaseModel value);
 
-    private final Map<CacheKey, CacheNode> roots = new HashMap<>();
-    private final WeakValueMap<CacheKey, CacheNode> nodes = new WeakValueMap<>();
+    void removeObject(Class<? extends BaseModel> clazz, long id);
 
-    void addObject(BaseModel value) {
-        CacheKey key = new CacheKey(value);
-        CacheNode node = new CacheNode(value);
-        roots.put(key, node);
-        nodes.put(key, node);
-    }
-
-    void removeObject(Class<? extends BaseModel> clazz, long id) {
-        CacheKey key = new CacheKey(clazz, id);
-        CacheNode node = nodes.remove(key);
-        if (node != null) {
-            node.getAllLinks(false).forEach(child -> child.getLinks(key.clazz(), true).remove(node));
-        }
-        roots.remove(key);
-    }
-
-    @SuppressWarnings("unchecked")
-    <T extends BaseModel> T getObject(Class<T> clazz, long id) {
-        CacheNode node = nodes.get(new CacheKey(clazz, id));
-        return node != null ? (T) node.getValue() : null;
-    }
+    <T extends BaseModel> T getObject(Class<T> clazz, long id);
 
     <T extends BaseModel> Stream<T> getObjects(
             Class<? extends BaseModel> fromClass, long fromId,
-            Class<T> clazz, Set<Class<? extends BaseModel>> proxies, boolean forward) {
+            Class<T> clazz, Set<Class<? extends BaseModel>> proxies, boolean forward);
 
-        CacheNode rootNode = nodes.get(new CacheKey(fromClass, fromId));
-        if (rootNode != null) {
-            return getObjectStream(rootNode, clazz, proxies, forward);
-        } else {
-            return Stream.empty();
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T extends BaseModel> Stream<T> getObjectStream(
-            CacheNode rootNode, Class<T> clazz, Set<Class<? extends BaseModel>> proxies, boolean forward) {
-
-        if (proxies.contains(clazz)) {
-            return Stream.empty();
-        }
-
-        var directSteam = rootNode.getLinks(clazz, forward).stream()
-                .map(node -> (T) node.getValue());
-
-        var proxyStream = proxies.stream()
-                .flatMap(proxyClass -> rootNode.getLinks(proxyClass, forward).stream()
-                        .flatMap(node -> getObjectStream(node, clazz, proxies, forward)));
-
-        return Stream.concat(directSteam, proxyStream);
-    }
-
-    void updateObject(BaseModel value) {
-        CacheNode node = nodes.get(new CacheKey(value));
-        if (node != null) {
-            node.setValue(value);
-        }
-    }
+    void updateObject(BaseModel value);
 
     boolean addLink(
             Class<? extends BaseModel> fromClazz, long fromId,
-            BaseModel toValue) {
-        boolean stop = true;
-        CacheNode fromNode = nodes.get(new CacheKey(fromClazz, fromId));
-        if (fromNode != null) {
-            CacheKey toKey = new CacheKey(toValue);
-            CacheNode toNode = nodes.get(toKey);
-            if (toNode == null) {
-                stop = false;
-                toNode = new CacheNode(toValue);
-                nodes.put(toKey, toNode);
-            }
-            fromNode.getLinks(toValue.getClass(), true).add(toNode);
-            toNode.getLinks(fromClazz, false).add(fromNode);
-        }
-        return stop;
-    }
+            BaseModel toValue);
 
-    void removeLink(
-            Class<? extends BaseModel> fromClazz, long fromId,
-            Class<? extends BaseModel> toClazz, long toId) {
-        CacheNode fromNode = nodes.get(new CacheKey(fromClazz, fromId));
-        if (fromNode != null) {
-            CacheNode toNode = nodes.get(new CacheKey(toClazz, toId));
-            if (toNode != null) {
-                fromNode.getLinks(toClazz, true).remove(toNode);
-                toNode.getLinks(fromClazz, false).remove(fromNode);
-            }
-        }
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (CacheNode node : roots.values()) {
-            printNode(stringBuilder, node, "");
-        }
-        return stringBuilder.toString().trim();
-    }
-
-    private void printNode(StringBuilder stringBuilder, CacheNode node, String indentation) {
-        stringBuilder
-                .append('\n')
-                .append(indentation)
-                .append(node.getValue().getClass().getSimpleName())
-                .append('(').append(node.getValue().getId()).append(')');
-        node.getAllLinks(true).forEach(child -> printNode(stringBuilder, child, indentation + "  "));
-    }
-
+    void removeLink(Class<? extends BaseModel> fromClass, long fromId, Class<? extends BaseModel> toClass, long toId);
 }

--- a/src/main/java/org/traccar/session/cache/CacheKey.java
+++ b/src/main/java/org/traccar/session/cache/CacheKey.java
@@ -17,8 +17,8 @@ package org.traccar.session.cache;
 
 import org.traccar.model.BaseModel;
 
-record CacheKey(Class<? extends BaseModel> clazz, long id) {
-    CacheKey(BaseModel object) {
+public record CacheKey(Class<? extends BaseModel> clazz, long id) {
+    public CacheKey(BaseModel object) {
         this(object.getClass(), object.getId());
     }
 }

--- a/src/main/java/org/traccar/session/cache/CacheManager.java
+++ b/src/main/java/org/traccar/session/cache/CacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 - 2024 Anton Tananaev (anton@traccar.org)
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,327 +15,40 @@
  */
 package org.traccar.session.cache;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.traccar.broadcast.BroadcastInterface;
-import org.traccar.broadcast.BroadcastService;
 import org.traccar.config.Config;
-import org.traccar.model.Attribute;
 import org.traccar.model.BaseModel;
-import org.traccar.model.Calendar;
-import org.traccar.model.Device;
-import org.traccar.model.Driver;
-import org.traccar.model.Geofence;
-import org.traccar.model.Group;
-import org.traccar.model.GroupedModel;
-import org.traccar.model.Maintenance;
-import org.traccar.model.Notification;
 import org.traccar.model.ObjectOperation;
-import org.traccar.model.Permission;
 import org.traccar.model.Position;
-import org.traccar.model.Schedulable;
 import org.traccar.model.Server;
 import org.traccar.model.User;
-import org.traccar.storage.Storage;
-import org.traccar.storage.StorageException;
-import org.traccar.storage.query.Columns;
-import org.traccar.storage.query.Condition;
-import org.traccar.storage.query.Request;
+import org.traccar.model.Notification;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
-@Singleton
-public class CacheManager implements BroadcastInterface {
+public interface CacheManager {
+    <T extends BaseModel> T getObject(Class<T> clazz, long id);
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CacheManager.class);
+    <T extends BaseModel> Set<T> getDeviceObjects(long deviceId, Class<T> clazz);
 
-    private static final Set<Class<? extends BaseModel>> GROUPED_CLASSES =
-            Set.of(Attribute.class, Driver.class, Geofence.class, Maintenance.class, Notification.class);
+    Position getPosition(long deviceId);
 
-    private final Config config;
-    private final Storage storage;
-    private final BroadcastService broadcastService;
+    void updatePosition(Position position);
 
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    void addDevice(long deviceId, Object key) throws Exception;
 
-    private final CacheGraph graph = new CacheGraph();
+    void removeDevice(long deviceId, Object key);
 
-    private Server server;
-    private final Map<Long, Position> devicePositions = new HashMap<>();
-    private final Map<Long, HashSet<Object>> deviceReferences = new HashMap<>();
+    <T extends BaseModel> void invalidateObject(boolean local, Class<T> clazz, long id, ObjectOperation operation)
+            throws Exception;
 
-    @Inject
-    public CacheManager(Config config, Storage storage, BroadcastService broadcastService) throws StorageException {
-        this.config = config;
-        this.storage = storage;
-        this.broadcastService = broadcastService;
-        server = storage.getObject(Server.class, new Request(new Columns.All()));
-        broadcastService.registerListener(this);
-    }
+    <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
+            boolean local, Class<T1> clazz1, long id1, Class<T2> clazz2, long id2, boolean link) throws Exception;
 
-    @Override
-    public String toString() {
-        return graph.toString();
-    }
+    Server getServer();
 
-    public Config getConfig() {
-        return config;
-    }
+    Set<User> getNotificationUsers(long notificationId, long deviceId);
 
-    public <T extends BaseModel> T getObject(Class<T> clazz, long id) {
-        try {
-            lock.readLock().lock();
-            return graph.getObject(clazz, id);
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
+    Set<Notification> getDeviceNotifications(long deviceId);
 
-    public <T extends BaseModel> Set<T> getDeviceObjects(long deviceId, Class<T> clazz) {
-        try {
-            lock.readLock().lock();
-            return graph.getObjects(Device.class, deviceId, clazz, Set.of(Group.class), true)
-                    .collect(Collectors.toUnmodifiableSet());
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public Position getPosition(long deviceId) {
-        try {
-            lock.readLock().lock();
-            return devicePositions.get(deviceId);
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public Server getServer() {
-        try {
-            lock.readLock().lock();
-            return server;
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public Set<User> getNotificationUsers(long notificationId, long deviceId) {
-        try {
-            lock.readLock().lock();
-            Set<User> deviceUsers = getDeviceObjects(deviceId, User.class);
-            return graph.getObjects(Notification.class, notificationId, User.class, Set.of(), false)
-                    .filter(deviceUsers::contains)
-                    .collect(Collectors.toUnmodifiableSet());
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public Set<Notification> getDeviceNotifications(long deviceId) {
-        try {
-            lock.readLock().lock();
-            var direct = graph.getObjects(Device.class, deviceId, Notification.class, Set.of(Group.class), true)
-                    .map(BaseModel::getId)
-                    .collect(Collectors.toUnmodifiableSet());
-            return graph.getObjects(Device.class, deviceId, Notification.class, Set.of(Group.class, User.class), true)
-                    .filter(notification -> notification.getAlways() || direct.contains(notification.getId()))
-                    .collect(Collectors.toUnmodifiableSet());
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public void addDevice(long deviceId, Object key) throws Exception {
-        try {
-            lock.writeLock().lock();
-            var references = deviceReferences.computeIfAbsent(deviceId, k -> new HashSet<>());
-            if (references.isEmpty()) {
-                Device device = storage.getObject(Device.class, new Request(
-                        new Columns.All(), new Condition.Equals("id", deviceId)));
-                graph.addObject(device);
-                initializeCache(device);
-                if (device.getPositionId() > 0) {
-                    devicePositions.put(deviceId, storage.getObject(Position.class, new Request(
-                            new Columns.All(), new Condition.Equals("id", device.getPositionId()))));
-                }
-            }
-            references.add(key);
-            LOGGER.debug("Cache add device {} references {} key {}", deviceId, references.size(), key);
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    public void removeDevice(long deviceId, Object key) {
-        try {
-            lock.writeLock().lock();
-            var references = deviceReferences.computeIfAbsent(deviceId, k -> new HashSet<>());
-            references.remove(key);
-            if (references.isEmpty()) {
-                graph.removeObject(Device.class, deviceId);
-                devicePositions.remove(deviceId);
-                deviceReferences.remove(deviceId);
-            }
-            LOGGER.debug("Cache remove device {} references {} key {}", deviceId, references.size(), key);
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    public void updatePosition(Position position) {
-        try {
-            lock.writeLock().lock();
-            if (deviceReferences.containsKey(position.getDeviceId())) {
-                devicePositions.put(position.getDeviceId(), position);
-            }
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    @Override
-    public <T extends BaseModel> void invalidateObject(
-            boolean local, Class<T> clazz, long id, ObjectOperation operation) throws Exception {
-        if (local) {
-            broadcastService.invalidateObject(true, clazz, id, operation);
-        }
-
-        if (operation == ObjectOperation.DELETE) {
-            graph.removeObject(clazz, id);
-        }
-        if (operation != ObjectOperation.UPDATE) {
-            return;
-        }
-
-        if (clazz.equals(Server.class)) {
-            server = storage.getObject(Server.class, new Request(new Columns.All()));
-            return;
-        }
-
-        var after = storage.getObject(clazz, new Request(new Columns.All(), new Condition.Equals("id", id)));
-        if (after == null) {
-            return;
-        }
-        var before = getObject(after.getClass(), after.getId());
-        if (before == null) {
-            return;
-        }
-
-        if (after instanceof GroupedModel) {
-            long beforeGroupId = ((GroupedModel) before).getGroupId();
-            long afterGroupId = ((GroupedModel) after).getGroupId();
-            if (beforeGroupId != afterGroupId) {
-                if (beforeGroupId > 0) {
-                    invalidatePermission(clazz, id, Group.class, beforeGroupId, false);
-                }
-                if (afterGroupId > 0) {
-                    invalidatePermission(clazz, id, Group.class, afterGroupId, true);
-                }
-            }
-        } else if (after instanceof Schedulable) {
-            long beforeCalendarId = ((Schedulable) before).getCalendarId();
-            long afterCalendarId = ((Schedulable) after).getCalendarId();
-            if (beforeCalendarId != afterCalendarId) {
-                if (beforeCalendarId > 0) {
-                    invalidatePermission(clazz, id, Calendar.class, beforeCalendarId, false);
-                }
-                if (afterCalendarId > 0) {
-                    invalidatePermission(clazz, id, Calendar.class, afterCalendarId, true);
-                }
-            }
-            // TODO handle notification always change
-        }
-
-        graph.updateObject(after);
-    }
-
-    @Override
-    public <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
-            boolean local, Class<T1> clazz1, long id1, Class<T2> clazz2, long id2, boolean link) throws Exception {
-        if (local) {
-            broadcastService.invalidatePermission(true, clazz1, id1, clazz2, id2, link);
-        }
-
-        if (clazz1.equals(User.class) && GroupedModel.class.isAssignableFrom(clazz2)) {
-            invalidatePermission(clazz2, id2, clazz1, id1, link);
-        } else {
-            invalidatePermission(clazz1, id1, clazz2, id2, link);
-        }
-    }
-
-    private <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
-            Class<T1> fromClass, long fromId, Class<T2> toClass, long toId, boolean link) throws Exception {
-
-        boolean groupLink = GroupedModel.class.isAssignableFrom(fromClass) && toClass.equals(Group.class);
-        boolean calendarLink = Schedulable.class.isAssignableFrom(fromClass) && toClass.equals(Calendar.class);
-        boolean userLink = fromClass.equals(User.class) && toClass.equals(Notification.class);
-
-        boolean groupedLinks = GroupedModel.class.isAssignableFrom(fromClass)
-                && (GROUPED_CLASSES.contains(toClass) || toClass.equals(User.class));
-
-        if (!groupLink && !calendarLink && !userLink && !groupedLinks) {
-            return;
-        }
-
-        if (link) {
-            BaseModel object = storage.getObject(toClass, new Request(
-                    new Columns.All(), new Condition.Equals("id", toId)));
-            if (!graph.addLink(fromClass, fromId, object)) {
-                initializeCache(object);
-            }
-        } else {
-            graph.removeLink(fromClass, fromId, toClass, toId);
-        }
-    }
-
-    private void initializeCache(BaseModel object) throws Exception {
-        if (object instanceof User) {
-            for (Permission permission : storage.getPermissions(User.class, Notification.class)) {
-                if (permission.getOwnerId() == object.getId()) {
-                    invalidatePermission(
-                            permission.getOwnerClass(), permission.getOwnerId(),
-                            permission.getPropertyClass(), permission.getPropertyId(), true);
-                }
-            }
-        } else {
-            if (object instanceof GroupedModel groupedModel) {
-                long groupId = groupedModel.getGroupId();
-                if (groupId > 0) {
-                    invalidatePermission(object.getClass(), object.getId(), Group.class, groupId, true);
-                }
-
-                for (Permission permission : storage.getPermissions(User.class, object.getClass())) {
-                    if (permission.getPropertyId() == object.getId()) {
-                        invalidatePermission(
-                                object.getClass(), object.getId(), User.class, permission.getOwnerId(), true);
-                    }
-                }
-
-                for (Class<? extends BaseModel> clazz : GROUPED_CLASSES) {
-                    for (Permission permission : storage.getPermissions(object.getClass(), clazz)) {
-                        if (permission.getOwnerId() == object.getId()) {
-                            invalidatePermission(
-                                    object.getClass(), object.getId(), clazz, permission.getPropertyId(), true);
-                        }
-                    }
-                }
-            }
-
-            if (object instanceof Schedulable schedulable) {
-                long calendarId = schedulable.getCalendarId();
-                if (calendarId > 0) {
-                    invalidatePermission(object.getClass(), object.getId(), Calendar.class, calendarId, true);
-                }
-            }
-        }
-    }
-
+    Config getConfig();
 }

--- a/src/main/java/org/traccar/session/cache/CacheType.java
+++ b/src/main/java/org/traccar/session/cache/CacheType.java
@@ -1,0 +1,6 @@
+package org.traccar.session.cache;
+
+public enum CacheType {
+    IN_MEMORY,
+    REDIS
+}

--- a/src/main/java/org/traccar/session/cache/InMemoryCacheGraph.java
+++ b/src/main/java/org/traccar/session/cache/InMemoryCacheGraph.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.session.cache;
+
+import org.traccar.model.BaseModel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+public class InMemoryCacheGraph implements CacheGraph {
+
+    private final Map<CacheKey, CacheNode> roots = new HashMap<>();
+    private final WeakValueMap<CacheKey, CacheNode> nodes = new WeakValueMap<>();
+
+    @Override
+    public void addObject(BaseModel value) {
+        CacheKey key = new CacheKey(value);
+        CacheNode node = new CacheNode(value);
+        roots.put(key, node);
+        nodes.put(key, node);
+    }
+
+    @Override
+    public void removeObject(Class<? extends BaseModel> clazz, long id) {
+        CacheKey key = new CacheKey(clazz, id);
+        CacheNode node = nodes.remove(key);
+        if (node != null) {
+            node.getAllLinks(false).forEach(child -> child.getLinks(key.clazz(), true).remove(node));
+        }
+        roots.remove(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T extends BaseModel> T getObject(Class<T> clazz, long id) {
+        CacheNode node = nodes.get(new CacheKey(clazz, id));
+        return node != null ? (T) node.getValue() : null;
+    }
+
+    @Override
+    public <T extends BaseModel> Stream<T> getObjects(
+            Class<? extends BaseModel> fromClass, long fromId,
+            Class<T> clazz, Set<Class<? extends BaseModel>> proxies, boolean forward) {
+
+        CacheNode rootNode = nodes.get(new CacheKey(fromClass, fromId));
+        if (rootNode != null) {
+            return getObjectStream(rootNode, clazz, proxies, forward);
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends BaseModel> Stream<T> getObjectStream(
+            CacheNode rootNode, Class<T> clazz, Set<Class<? extends BaseModel>> proxies, boolean forward) {
+
+        if (proxies.contains(clazz)) {
+            return Stream.empty();
+        }
+
+        var directSteam = rootNode.getLinks(clazz, forward).stream()
+                .map(node -> (T) node.getValue());
+
+        var proxyStream = proxies.stream()
+                .flatMap(proxyClass -> rootNode.getLinks(proxyClass, forward).stream()
+                        .flatMap(node -> getObjectStream(node, clazz, proxies, forward)));
+
+        return Stream.concat(directSteam, proxyStream);
+    }
+
+    @Override
+    public void updateObject(BaseModel value) {
+        CacheNode node = nodes.get(new CacheKey(value));
+        if (node != null) {
+            node.setValue(value);
+        }
+    }
+
+    @Override
+    public boolean addLink(
+            Class<? extends BaseModel> fromClazz, long fromId,
+            BaseModel toValue) {
+        boolean stop = true;
+        CacheNode fromNode = nodes.get(new CacheKey(fromClazz, fromId));
+        if (fromNode != null) {
+            CacheKey toKey = new CacheKey(toValue);
+            CacheNode toNode = nodes.get(toKey);
+            if (toNode == null) {
+                stop = false;
+                toNode = new CacheNode(toValue);
+                nodes.put(toKey, toNode);
+            }
+            fromNode.getLinks(toValue.getClass(), true).add(toNode);
+            toNode.getLinks(fromClazz, false).add(fromNode);
+        }
+        return stop;
+    }
+
+    @Override
+    public void removeLink(
+            Class<? extends BaseModel> fromClazz, long fromId,
+            Class<? extends BaseModel> toClazz, long toId) {
+        CacheNode fromNode = nodes.get(new CacheKey(fromClazz, fromId));
+        if (fromNode != null) {
+            CacheNode toNode = nodes.get(new CacheKey(toClazz, toId));
+            if (toNode != null) {
+                fromNode.getLinks(toClazz, true).remove(toNode);
+                toNode.getLinks(fromClazz, false).remove(fromNode);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (CacheNode node : roots.values()) {
+            printNode(stringBuilder, node, "");
+        }
+        return stringBuilder.toString().trim();
+    }
+
+    private void printNode(StringBuilder stringBuilder, CacheNode node, String indentation) {
+        stringBuilder
+                .append('\n')
+                .append(indentation)
+                .append(node.getValue().getClass().getSimpleName())
+                .append('(').append(node.getValue().getId()).append(')');
+        node.getAllLinks(true).forEach(child -> printNode(stringBuilder, child, indentation + "  "));
+    }
+
+}

--- a/src/main/java/org/traccar/session/cache/InMemoryCacheManager.java
+++ b/src/main/java/org/traccar/session/cache/InMemoryCacheManager.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.session.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traccar.broadcast.BroadcastInterface;
+import org.traccar.broadcast.BroadcastService;
+import org.traccar.config.Config;
+import org.traccar.model.Attribute;
+import org.traccar.model.BaseModel;
+import org.traccar.model.Calendar;
+import org.traccar.model.Device;
+import org.traccar.model.Driver;
+import org.traccar.model.Geofence;
+import org.traccar.model.Group;
+import org.traccar.model.GroupedModel;
+import org.traccar.model.Maintenance;
+import org.traccar.model.Notification;
+import org.traccar.model.ObjectOperation;
+import org.traccar.model.Permission;
+import org.traccar.model.Position;
+import org.traccar.model.Schedulable;
+import org.traccar.model.Server;
+import org.traccar.model.User;
+import org.traccar.storage.Storage;
+import org.traccar.storage.StorageException;
+import org.traccar.storage.query.Columns;
+import org.traccar.storage.query.Condition;
+import org.traccar.storage.query.Request;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+public class InMemoryCacheManager implements BroadcastInterface, CacheManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryCacheManager.class);
+
+    private static final Set<Class<? extends BaseModel>> GROUPED_CLASSES =
+            Set.of(Attribute.class, Driver.class, Geofence.class, Maintenance.class, Notification.class);
+
+    private final Config config;
+    protected final Storage storage;
+    protected final BroadcastService broadcastService;
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private final CacheGraph graph = new InMemoryCacheGraph();
+
+    private Server server;
+    private final Map<Long, Position> devicePositions = new HashMap<>();
+    private final Map<Long, HashSet<Object>> deviceReferences = new HashMap<>();
+
+    public InMemoryCacheManager(Config config, Storage storage, BroadcastService broadcastService)
+            throws StorageException {
+        this.config = config;
+        this.storage = storage;
+        this.broadcastService = broadcastService;
+        server = storage.getObject(Server.class, new Request(new Columns.All()));
+        broadcastService.registerListener(this);
+    }
+
+    @Override
+    public String toString() {
+        return graph.toString();
+    }
+
+    public Config getConfig() {
+        return config;
+    }
+
+    public <T extends BaseModel> T getObject(Class<T> clazz, long id) {
+        try {
+            lock.readLock().lock();
+            return graph.getObject(clazz, id);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public <T extends BaseModel> Set<T> getDeviceObjects(long deviceId, Class<T> clazz) {
+        try {
+            lock.readLock().lock();
+            return graph.getObjects(Device.class, deviceId, clazz, Set.of(Group.class), true)
+                    .collect(Collectors.toUnmodifiableSet());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public Position getPosition(long deviceId) {
+        try {
+            lock.readLock().lock();
+            return devicePositions.get(deviceId);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public Server getServer() {
+        try {
+            lock.readLock().lock();
+            return server;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public Set<User> getNotificationUsers(long notificationId, long deviceId) {
+        try {
+            lock.readLock().lock();
+            Set<User> deviceUsers = getDeviceObjects(deviceId, User.class);
+            return graph.getObjects(Notification.class, notificationId, User.class, Set.of(), false)
+                    .filter(deviceUsers::contains)
+                    .collect(Collectors.toUnmodifiableSet());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public Set<Notification> getDeviceNotifications(long deviceId) {
+        try {
+            lock.readLock().lock();
+            var direct = graph.getObjects(Device.class, deviceId, Notification.class, Set.of(Group.class), true)
+                    .map(BaseModel::getId)
+                    .collect(Collectors.toUnmodifiableSet());
+            return graph.getObjects(Device.class, deviceId, Notification.class,
+                            Set.of(Group.class, User.class), true)
+                    .filter(notification -> notification.getAlways() || direct.contains(notification.getId()))
+                    .collect(Collectors.toUnmodifiableSet());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void addDevice(long deviceId, Object key) throws Exception {
+        try {
+            lock.writeLock().lock();
+            var references = deviceReferences.computeIfAbsent(deviceId, k -> new HashSet<>());
+            if (references.isEmpty()) {
+                Device device = storage.getObject(Device.class, new Request(
+                        new Columns.All(), new Condition.Equals("id", deviceId)));
+                graph.addObject(device);
+                initializeCache(device);
+                if (device.getPositionId() > 0) {
+                    devicePositions.put(deviceId, storage.getObject(Position.class, new Request(
+                            new Columns.All(), new Condition.Equals("id", device.getPositionId()))));
+                }
+            }
+            references.add(key);
+            LOGGER.debug("Cache add device {} references {} key {}", deviceId, references.size(), key);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void removeDevice(long deviceId, Object key) {
+        try {
+            lock.writeLock().lock();
+            var references = deviceReferences.computeIfAbsent(deviceId, k -> new HashSet<>());
+            references.remove(key);
+            if (references.isEmpty()) {
+                graph.removeObject(Device.class, deviceId);
+                devicePositions.remove(deviceId);
+                deviceReferences.remove(deviceId);
+            }
+            LOGGER.debug("Cache remove device {} references {} key {}", deviceId, references.size(), key);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void updatePosition(Position position) {
+        try {
+            lock.writeLock().lock();
+            if (deviceReferences.containsKey(position.getDeviceId())) {
+                devicePositions.put(position.getDeviceId(), position);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public <T extends BaseModel> void invalidateObject(
+            boolean local, Class<T> clazz, long id, ObjectOperation operation) throws Exception {
+        if (local) {
+            broadcastService.invalidateObject(true, clazz, id, operation);
+        }
+
+        if (operation == ObjectOperation.DELETE) {
+            graph.removeObject(clazz, id);
+        }
+        if (operation != ObjectOperation.UPDATE) {
+            return;
+        }
+
+        if (clazz.equals(Server.class)) {
+            server = storage.getObject(Server.class, new Request(new Columns.All()));
+            return;
+        }
+
+        var after = storage.getObject(clazz, new Request(new Columns.All(), new Condition.Equals("id", id)));
+        if (after == null) {
+            return;
+        }
+        var before = getObject(after.getClass(), after.getId());
+        if (before == null) {
+            return;
+        }
+
+        if (after instanceof GroupedModel) {
+            long beforeGroupId = ((GroupedModel) before).getGroupId();
+            long afterGroupId = ((GroupedModel) after).getGroupId();
+            if (beforeGroupId != afterGroupId) {
+                if (beforeGroupId > 0) {
+                    invalidatePermission(clazz, id, Group.class, beforeGroupId, false);
+                }
+                if (afterGroupId > 0) {
+                    invalidatePermission(clazz, id, Group.class, afterGroupId, true);
+                }
+            }
+        } else if (after instanceof Schedulable) {
+            long beforeCalendarId = ((Schedulable) before).getCalendarId();
+            long afterCalendarId = ((Schedulable) after).getCalendarId();
+            if (beforeCalendarId != afterCalendarId) {
+                if (beforeCalendarId > 0) {
+                    invalidatePermission(clazz, id, Calendar.class, beforeCalendarId, false);
+                }
+                if (afterCalendarId > 0) {
+                    invalidatePermission(clazz, id, Calendar.class, afterCalendarId, true);
+                }
+            }
+            // TODO handle notification always change
+        }
+
+        graph.updateObject(after);
+    }
+
+    @Override
+    public <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
+            boolean local, Class<T1> clazz1, long id1, Class<T2> clazz2, long id2, boolean link) throws Exception {
+        if (local) {
+            broadcastService.invalidatePermission(true, clazz1, id1, clazz2, id2, link);
+        }
+
+        if (clazz1.equals(User.class) && GroupedModel.class.isAssignableFrom(clazz2)) {
+            invalidatePermission(clazz2, id2, clazz1, id1, link);
+        } else {
+            invalidatePermission(clazz1, id1, clazz2, id2, link);
+        }
+    }
+
+    private <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
+            Class<T1> fromClass, long fromId, Class<T2> toClass, long toId, boolean link) throws Exception {
+
+        boolean groupLink = GroupedModel.class.isAssignableFrom(fromClass) && toClass.equals(Group.class);
+        boolean calendarLink = Schedulable.class.isAssignableFrom(fromClass) && toClass.equals(Calendar.class);
+        boolean userLink = fromClass.equals(User.class) && toClass.equals(Notification.class);
+
+        boolean groupedLinks = GroupedModel.class.isAssignableFrom(fromClass)
+                && (GROUPED_CLASSES.contains(toClass) || toClass.equals(User.class));
+
+        if (!groupLink && !calendarLink && !userLink && !groupedLinks) {
+            return;
+        }
+
+        if (link) {
+            BaseModel object = storage.getObject(toClass, new Request(
+                    new Columns.All(), new Condition.Equals("id", toId)));
+            if (!graph.addLink(fromClass, fromId, object)) {
+                initializeCache(object);
+            }
+        } else {
+            graph.removeLink(fromClass, fromId, toClass, toId);
+        }
+    }
+
+    private void initializeCache(BaseModel object) throws Exception {
+        if (object instanceof User) {
+            for (Permission permission : storage.getPermissions(User.class, Notification.class)) {
+                if (permission.getOwnerId() == object.getId()) {
+                    invalidatePermission(
+                            permission.getOwnerClass(), permission.getOwnerId(),
+                            permission.getPropertyClass(), permission.getPropertyId(), true);
+                }
+            }
+        } else {
+            if (object instanceof GroupedModel groupedModel) {
+                long groupId = groupedModel.getGroupId();
+                if (groupId > 0) {
+                    invalidatePermission(object.getClass(), object.getId(), Group.class, groupId, true);
+                }
+
+                for (Permission permission : storage.getPermissions(User.class, object.getClass())) {
+                    if (permission.getPropertyId() == object.getId()) {
+                        invalidatePermission(
+                                object.getClass(), object.getId(), User.class, permission.getOwnerId(), true);
+                    }
+                }
+
+                for (Class<? extends BaseModel> clazz : GROUPED_CLASSES) {
+                    for (Permission permission : storage.getPermissions(object.getClass(), clazz)) {
+                        if (permission.getOwnerId() == object.getId()) {
+                            invalidatePermission(
+                                    object.getClass(), object.getId(), clazz, permission.getPropertyId(), true);
+                        }
+                    }
+                }
+            }
+
+            if (object instanceof Schedulable schedulable) {
+                long calendarId = schedulable.getCalendarId();
+                if (calendarId > 0) {
+                    invalidatePermission(object.getClass(), object.getId(), Calendar.class, calendarId, true);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/traccar/session/cache/redis/RedisCacheGraph.java
+++ b/src/main/java/org/traccar/session/cache/redis/RedisCacheGraph.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.session.cache.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traccar.model.BaseModel;
+import org.traccar.session.cache.CacheGraph;
+import org.traccar.session.cache.CacheKey;
+import org.traccar.session.cache.CacheNode;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class RedisCacheGraph implements CacheGraph {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisCacheGraph.class);
+
+    private static final String ROOTS = "roots";
+    private static final String LINKS_SUFFIX = ":links";
+    private static final String BACKLINKS_SUFFIX = ":backlinks";
+    private static final String NODES = "nodes";
+    private final JedisPool jedisPool;
+    private final ObjectMapper objectMapper;
+
+    public RedisCacheGraph(JedisPool jedisPool, ObjectMapper objectMapper) {
+        this.jedisPool = jedisPool;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void addObject(BaseModel value) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String key = new CacheKey(value).toString();
+            String className = value.getClass().getName();
+            String val = className + ":" + objectMapper.writeValueAsString(value);
+            jedis.hset(ROOTS, key, val);
+            jedis.hset(NODES, key, val);
+            //log key
+            LOGGER.info("Added object to cache: {} in class {}", key, this.getClass().getSimpleName());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void removeObject(Class<? extends BaseModel> clazz, long id) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String key = new CacheKey(clazz, id).toString();
+
+            // Remove forward links
+            Set<String> forwardLinks = jedis.smembers(key + LINKS_SUFFIX);
+            for (String link : forwardLinks) {
+                jedis.srem(link + BACKLINKS_SUFFIX, key);
+            }
+            jedis.del(key + LINKS_SUFFIX);
+
+            // Remove backward links
+            Set<String> backwardLinks = jedis.smembers(key + BACKLINKS_SUFFIX);
+            for (String link : backwardLinks) {
+                jedis.srem(link + LINKS_SUFFIX, key);
+            }
+            jedis.del(key + BACKLINKS_SUFFIX);
+
+            jedis.hdel(ROOTS, key);
+            jedis.hdel(NODES, key);
+
+            // Log key
+            LOGGER.info("Removed object and its links from cache: {} in class {}", key,
+                    this.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public <T extends BaseModel> T getObject(Class<T> clazz, long id) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String key = new CacheKey(clazz, id).toString();
+            String data = jedis.hget(NODES, key);
+            if (data != null) {
+                String[] parts = data.split(":", 2);
+                String className = parts[0];
+                String serializedData = parts[1];
+                if (clazz.isAssignableFrom(Class.forName(className))) {
+                    //log serializedData
+                    LOGGER.info("Deserialized object from cache: {} in class {}", serializedData,
+                            this.getClass().getSimpleName());
+                    return objectMapper.readValue(serializedData, clazz);
+                } else {
+                    throw new RuntimeException("Deserialized object is not of expected type: " + clazz.getName());
+                }
+            }
+        } catch (ClassNotFoundException | JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    @Override
+    public <T extends BaseModel> Stream<T> getObjects(Class<? extends BaseModel> fromClass, long fromId, Class<T> clazz,
+                                                      Set<Class<? extends BaseModel>> proxies, boolean forward) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String fromKey = new CacheKey(fromClass, fromId).toString();
+            Set<String> linkedKeys = jedis.smembers(fromKey + (forward ? LINKS_SUFFIX : BACKLINKS_SUFFIX));
+
+
+            return linkedKeys.stream()
+                    .map(linkedKey -> {
+                        String data = jedis.hget(NODES, linkedKey);
+                        if (data != null) {
+                            String[] parts = data.split(":", 2);
+                            String className = parts[0];
+                            try {
+                                if (clazz.isAssignableFrom(Class.forName(className))) {
+                                    return objectMapper.readValue(parts[1], clazz);
+                                }
+                            } catch (ClassNotFoundException | JsonProcessingException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .map(clazz::cast);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private <T extends BaseModel> Stream<T> getObjectStream(
+            CacheNode rootNode, Class<T> clazz, Set<Class<? extends BaseModel>> proxies, boolean forward) {
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            String rootKey = new CacheKey(rootNode.getValue()).toString();
+            String linkSuffix = forward ? LINKS_SUFFIX : BACKLINKS_SUFFIX;
+
+            // Direct links
+            Set<String> directLinks = jedis.smembers(rootKey + linkSuffix);
+            Stream<T> directStream = directLinks.stream()
+                    .map(link -> jedis.hget(NODES, link))
+                    .filter(Objects::nonNull)
+                    .map(json -> {
+                        try {
+                            String[] parts = json.split(":", 2);
+                            String className = parts[0];
+                                if (clazz.isAssignableFrom(Class.forName(className))) {
+                                    return objectMapper.readValue(parts[1], clazz);
+                                }
+                            return null;
+                        } catch (JsonProcessingException e) {
+                            LOGGER.error("Error deserializing object", e);
+                            return null;
+                        } catch (ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .filter(Objects::nonNull);
+
+            // Proxy links
+            var proxyStream = proxies.stream()
+                    .flatMap(proxyClass -> {
+                        Set<String> proxyLinks = jedis.smembers(rootKey + linkSuffix);
+                        return proxyLinks.stream()
+                                .flatMap(link -> {
+                                    try {
+                                        CacheNode proxyNode = new CacheNode(objectMapper.readValue(
+                                                jedis.hget(NODES, link).split(":", 2)[1], proxyClass));
+                                        return getObjectStream(proxyNode, clazz, proxies, forward);
+                                    } catch (JsonProcessingException e) {
+                                        LOGGER.error("Error deserializing proxy object", e);
+                                        return Stream.empty();
+                                    }
+                                });
+                    });
+
+            return Stream.concat(directStream, proxyStream);
+        }
+    }
+
+    @Override
+    public void updateObject(BaseModel value) {
+        addObject(value);
+    }
+
+    @Override
+    public boolean addLink(Class<? extends BaseModel> fromClazz, long fromId, BaseModel toValue) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            boolean stop = true;
+
+            String fromKey = new CacheKey(fromClazz, fromId).toString();
+            String toKey = new CacheKey(toValue).toString();
+
+            if (!jedis.hexists(NODES, toKey)) {
+                String className = toValue.getClass().getName();
+                String valueCache;
+                try {
+                    valueCache = className + ":" + objectMapper.writeValueAsString(toValue);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+                jedis.hset(NODES, toKey, valueCache);
+                stop = false;
+            }
+            // Add the forward and backward links
+            jedis.sadd(fromKey + LINKS_SUFFIX, toKey);
+            jedis.sadd(toKey + BACKLINKS_SUFFIX, fromKey);
+
+            // Log the addition of the link
+            LOGGER.info("Added link from {} to {} in class {}", fromKey, toKey, this.getClass().getSimpleName());
+            return stop;
+        }
+    }
+
+    @Override
+    public void removeLink(Class<? extends BaseModel> fromClazz, long fromId, Class<? extends BaseModel> toClazz,
+                           long toId) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String fromKey = new CacheKey(fromClazz, fromId).toString();
+            String toKey = new CacheKey(toClazz, toId).toString();
+            jedis.srem(fromKey + LINKS_SUFFIX, toKey);
+            jedis.srem(toKey + BACKLINKS_SUFFIX, fromKey);
+            //log fromKey, toKey
+            LOGGER.info("Removed link from {} to {} in class {}", fromKey, toKey, this.getClass().getSimpleName());
+        }
+    }
+}

--- a/src/main/java/org/traccar/session/cache/redis/RedisCacheManager.java
+++ b/src/main/java/org/traccar/session/cache/redis/RedisCacheManager.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2024 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.session.cache.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.traccar.broadcast.BroadcastInterface;
+import org.traccar.broadcast.BroadcastService;
+import org.traccar.config.Config;
+import org.traccar.model.BaseModel;
+import org.traccar.model.Driver;
+import org.traccar.model.Geofence;
+import org.traccar.model.Maintenance;
+import org.traccar.model.Notification;
+import org.traccar.model.Position;
+import org.traccar.model.Server;
+import org.traccar.model.User;
+import org.traccar.model.Group;
+import org.traccar.model.Calendar;
+import org.traccar.model.Attribute;
+import org.traccar.model.Device;
+import org.traccar.model.GroupedModel;
+import org.traccar.model.Permission;
+import org.traccar.model.Schedulable;
+import org.traccar.model.ObjectOperation;
+import org.traccar.session.cache.CacheManager;
+import org.traccar.storage.Storage;
+import org.traccar.storage.StorageException;
+import org.traccar.storage.query.Columns;
+import org.traccar.storage.query.Condition;
+import org.traccar.storage.query.Request;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RedisCacheManager implements BroadcastInterface, CacheManager {
+
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(RedisCacheManager.class);
+
+    private final transient JedisPool jedisPool;
+    private final transient RedisCacheGraph graph;
+    protected final transient Storage storage;
+
+    private static final Set<Class<? extends BaseModel>> GROUPED_CLASSES =
+            Set.of(Attribute.class, Driver.class, Geofence.class, Maintenance.class, Notification.class);
+    private final ObjectMapper objectMapper;
+    private final BroadcastService broadcastService;
+    private Server server;
+    private final transient Config config;
+    private static final String DEVICE_POSITIONS_KEY = "devicePositions";
+    private static final String REFERENCES_SUFFIX = ":references";
+    private static final String DEVICE_KEY_PREFIX = "device:";
+
+    public RedisCacheManager(Config config, Storage storage, BroadcastService broadcastService,
+                             ObjectMapper objectMapper, RedisCacheGraph graph, JedisPool jedisPool)
+            throws StorageException {
+        this.objectMapper = objectMapper;
+        this.jedisPool = jedisPool;
+        this.graph = graph;
+        this.storage = storage;
+        this.broadcastService = broadcastService;
+        server = storage.getObject(Server.class, new Request(new Columns.All()));
+        broadcastService.registerListener(this);
+        this.config = config;
+    }
+
+    @Override
+    public <T extends BaseModel> T getObject(Class<T> clazz, long id) {
+        return graph.getObject(clazz, id);
+    }
+
+    @Override
+    public <T extends BaseModel> Set<T> getDeviceObjects(long deviceId, Class<T> clazz) {
+        return graph.getObjects(Device.class, deviceId, clazz, Set.of(Group.class), true)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public Position getPosition(long deviceId) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String data = jedis.hget(DEVICE_POSITIONS_KEY, String.valueOf(deviceId));
+            if (data != null) {
+                return objectMapper.readValue(data, Position.class);
+            } else {
+                Position position = storage.getObject(Position.class, new Request(
+                        new Columns.All(), new Condition.Equals("deviceId", deviceId)));
+                if (position != null) {
+                    jedis.hset(DEVICE_POSITIONS_KEY, String.valueOf(deviceId),
+                            objectMapper.writeValueAsString(position));
+                }
+                return position;
+            }
+        } catch (StorageException e) {
+            throw new RuntimeException("Storage error", e);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void updatePosition(Position position) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.hset(DEVICE_POSITIONS_KEY,
+                    String.valueOf(position.getDeviceId()), objectMapper.writeValueAsString(position));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void addDevice(long deviceId, Object key) throws Exception {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String deviceKey = DEVICE_KEY_PREFIX + deviceId;
+            String referencesKey = deviceKey + REFERENCES_SUFFIX;
+
+            // Check if the device is already in the cache
+            if (!jedis.exists(deviceKey)) {
+                Device device = storage.getObject(Device.class, new Request(
+                        new Columns.All(), new Condition.Equals("id", deviceId)));
+                graph.addObject(device);
+                initializeCache(device);
+                if (device.getPositionId() > 0) {
+                    Position position = storage.getObject(Position.class, new Request(
+                            new Columns.All(), new Condition.Equals("id", device.getPositionId())));
+                    jedis.hset(deviceKey, "position", objectMapper.writeValueAsString(position));
+                }
+            }
+            // Add the reference key to the Redis set
+            jedis.sadd(referencesKey, key.toString());
+            Long referencesSize = jedis.scard(referencesKey);
+            LOGGER.debug("Cache add device {} references {} key {}", deviceId, referencesSize, key);
+        }
+    }
+
+    @Override
+    public void removeDevice(long deviceId, Object key) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String deviceKey = DEVICE_KEY_PREFIX + deviceId;
+            String referencesKey = deviceKey + REFERENCES_SUFFIX;
+
+            // Remove the reference key from the Redis set
+            jedis.srem(referencesKey, key.toString());
+            long referencesSize = jedis.scard(referencesKey);
+
+            if (referencesSize == 0) {
+                graph.removeObject(Device.class, deviceId);
+                jedis.del(deviceKey);
+                jedis.del(referencesKey);
+            }
+            LOGGER.debug("Cache remove device {} references {} key {}", deviceId, referencesSize, key);
+        }
+    }
+
+    private void initializeCache(BaseModel object) throws Exception {
+        if (object instanceof User) {
+            for (Permission permission : storage.getPermissions(User.class, Notification.class)) {
+                if (permission.getOwnerId() == object.getId()) {
+                    invalidatePermission(
+                            permission.getOwnerClass(), permission.getOwnerId(),
+                            permission.getPropertyClass(), permission.getPropertyId(), true);
+                }
+            }
+        } else {
+            if (object instanceof GroupedModel groupedModel) {
+                long groupId = groupedModel.getGroupId();
+                if (groupId > 0) {
+                    invalidatePermission(object.getClass(), object.getId(), Group.class, groupId, true);
+                }
+
+                for (Permission permission : storage.getPermissions(User.class, object.getClass())) {
+                    if (permission.getPropertyId() == object.getId()) {
+                        invalidatePermission(
+                                object.getClass(), object.getId(), User.class, permission.getOwnerId(), true);
+                    }
+                }
+
+                for (Class<? extends BaseModel> clazz : GROUPED_CLASSES) {
+                    for (Permission permission : storage.getPermissions(object.getClass(), clazz)) {
+                        if (permission.getOwnerId() == object.getId()) {
+                            invalidatePermission(
+                                    object.getClass(), object.getId(), clazz, permission.getPropertyId(), true);
+                        }
+                    }
+                }
+            }
+
+            if (object instanceof Schedulable schedulable) {
+                long calendarId = schedulable.getCalendarId();
+                if (calendarId > 0) {
+                    invalidatePermission(object.getClass(), object.getId(), Calendar.class, calendarId, true);
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public <T extends BaseModel> void invalidateObject(
+            boolean local, Class<T> clazz, long id, ObjectOperation operation) throws Exception {
+        if (local) {
+            broadcastService.invalidateObject(true, clazz, id, operation);
+        }
+        if (operation == ObjectOperation.DELETE) {
+            graph.removeObject(clazz, id);
+            return;
+        }
+        if (operation != ObjectOperation.UPDATE) {
+            return;
+        }
+        if (clazz.equals(Server.class)) {
+            server = storage.getObject(Server.class, new Request(new Columns.All()));
+            graph.updateObject(server);
+            return;
+        }
+        var after = storage.getObject(clazz, new Request(new Columns.All(), new Condition.Equals("id", id)));
+        if (after == null) {
+            return;
+        }
+        var before = getObject(after.getClass(), after.getId());
+        if (before == null) {
+            return;
+        }
+        if (after instanceof GroupedModel) {
+            long beforeGroupId = ((GroupedModel) before).getGroupId();
+            long afterGroupId = ((GroupedModel) after).getGroupId();
+            if (beforeGroupId != afterGroupId) {
+                if (beforeGroupId > 0) {
+                    invalidatePermission(clazz, id, Group.class, beforeGroupId, false);
+                }
+                if (afterGroupId > 0) {
+                    invalidatePermission(clazz, id, Group.class, afterGroupId, true);
+                }
+            }
+        } else if (after instanceof Schedulable) {
+            long beforeCalendarId = ((Schedulable) before).getCalendarId();
+            long afterCalendarId = ((Schedulable) after).getCalendarId();
+            if (beforeCalendarId != afterCalendarId) {
+                if (beforeCalendarId > 0) {
+                    invalidatePermission(clazz, id, Calendar.class, beforeCalendarId, false);
+                }
+                if (afterCalendarId > 0) {
+                    invalidatePermission(clazz, id, Calendar.class, afterCalendarId, true);
+                }
+            }
+        }
+        graph.updateObject(after);
+    }
+
+    @Override
+    public <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
+            boolean local, Class<T1> clazz1, long id1, Class<T2> clazz2, long id2, boolean link) throws Exception {
+        if (local) {
+            broadcastService.invalidatePermission(true, clazz1, id1, clazz2, id2, link);
+        }
+
+        if (clazz1.equals(User.class) && GroupedModel.class.isAssignableFrom(clazz2)) {
+            invalidatePermission(clazz2, id2, clazz1, id1, link);
+        } else {
+            invalidatePermission(clazz1, id1, clazz2, id2, link);
+        }
+    }
+
+    @Override
+    public Config getConfig() {
+        return config;
+    }
+
+    @Override
+    public Server getServer() {
+        return server;
+    }
+
+    private <T1 extends BaseModel, T2 extends BaseModel> void invalidatePermission(
+            Class<T1> fromClass, long fromId, Class<T2> toClass, long toId, boolean link) throws Exception {
+
+        boolean groupLink = GroupedModel.class.isAssignableFrom(fromClass) && toClass.equals(Group.class);
+        boolean calendarLink = Schedulable.class.isAssignableFrom(fromClass) && toClass.equals(Calendar.class);
+        boolean userLink = fromClass.equals(User.class) && toClass.equals(Notification.class);
+
+        boolean groupedLinks = GroupedModel.class.isAssignableFrom(fromClass)
+                && (GROUPED_CLASSES.contains(toClass) || toClass.equals(User.class));
+
+        if (!groupLink && !calendarLink && !userLink && !groupedLinks) {
+            return;
+        }
+        if (link) {
+            BaseModel object = storage.getObject(toClass, new Request(
+                    new Columns.All(), new Condition.Equals("id", toId)));
+            if (!graph.addLink(fromClass, fromId, object)) {
+                initializeCache(object);
+            }
+        } else {
+            graph.removeLink(fromClass, fromId, toClass, toId);
+        }
+    }
+
+    @Override
+    public Set<User> getNotificationUsers(long notificationId, long deviceId) {
+        try {
+            Set<User> deviceUsers = getDeviceObjects(deviceId, User.class);
+            return graph.getObjects(Notification.class, notificationId, User.class, Set.of(), false)
+                    .filter(user -> deviceUsers.stream().anyMatch(deviceUser -> deviceUser.compare(user)))
+                    .collect(Collectors.toUnmodifiableSet());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Set<Notification> getDeviceNotifications(long deviceId) {
+        try {
+            var direct = graph.getObjects(Device.class, deviceId, Notification.class, Set.of(Group.class), true)
+                    .map(BaseModel::getId)
+                    .collect(Collectors.toUnmodifiableSet());
+            return graph.getObjects(Device.class, deviceId, Notification.class,
+                            Set.of(Group.class, User.class), true)
+                    .filter(notification -> notification.getAlways() || direct.contains(notification.getId()))
+                    .collect(Collectors.toUnmodifiableSet());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
The idea of having a distributed cache (like Redis) is to make traccar more scalable. 
I am not very much familiar with core structure of traccar, so there may be a better way to achieve it. But here is what I changed:

debug.xml: Added entries for redis server
MainModule.java: Add capability to initialize custom cache manager (In future, any type of cache can be initialized there). For this, I removed @Singleton from original Cache class.
CacheManager.java and CacheGraph.java are now interfaces. The implementation type of cache need to implement them in order to bring a new type of cache.

CacheManager and CacheGraph have two implementations; InMemory (existing one) and Redis (new one) with names InMemoryCacheManager, InMemoryCacheGraph and RedisCacheManager, RedisCacheGraph respectively.

