### PR TITLE
Add api endpoint to delete a singular position

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -600,6 +600,24 @@ paths:
         '400':
           description: Bad Request
           content: {}
+  /positions/{id}:
+    delete:
+      summary: Delete a Position
+      tags:
+        - Positions
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: No Content
+          content: {}
+        '404':
+          description: Not Found
+          content: {}
   /server:
     get:
       summary: Fetch Server information

--- a/src/main/java/org/traccar/api/resource/PositionResource.java
+++ b/src/main/java/org/traccar/api/resource/PositionResource.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
@@ -86,6 +87,23 @@ public class PositionResource extends BaseResource {
         } else {
             return PositionUtil.getLatestPositions(storage, getUserId());
         }
+    }
+
+    @Path("{id}")
+    @DELETE
+    public Response removeById(@PathParam("id") long positionId) throws StorageException {
+        permissionsService.checkRestriction(getUserId(), UserRestrictions::getReadonly);
+
+        Request request = new Request(new Columns.All(), new Condition.Equals("id", positionId));
+        Position position = storage.getObject(Position.class, request);
+        if (position == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        permissionsService.checkPermission(Device.class, getUserId(), position.getDeviceId());
+
+        storage.removeObject(Position.class, request);
+        return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     @DELETE


### PR DESCRIPTION
I found https://github.com/traccar/traccar/issues/4387 and the coresponding PR for its implementation https://github.com/traccar/traccar/pull/5061 which I based this on.

I already have some ids from the `/api/positions` endpoint which I want to easliy remove without constructing deviceId/from/to parameters.

I hope that request makes sense and the implementation isn't _too_ bad, I'm not often doing Java stuff. Thanks for maintaining this cool project (: