### PR TITLE
[Chore] Add Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,18 @@
+FROM alpine:3.21
+
+ENV TRACCAR_VERSION=6.6
+
+WORKDIR /opt/traccar
+
+RUN set -ex; \
+    apk add --no-cache --no-progress \
+      openjdk17-jre-headless \
+      wget; \
+    wget -qO /tmp/traccar.zip https://github.com/traccar/traccar/releases/download/v$TRACCAR_VERSION/traccar-other-$TRACCAR_VERSION.zip; \
+    unzip -qo /tmp/traccar.zip -d /opt/traccar; \
+    rm /tmp/traccar.zip; \
+    apk del wget
+
+ENTRYPOINT ["java", "-Xms1g", "-Xmx1g", "-Djava.net.preferIPv4Stack=true"]
+
+CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  traccar:
+    container_name: traccar
+    hostname: traccar
+    image: traccar/traccar:6-alpine
+    restart: unless-stopped
+    ports:
+      - "80:8082"
+      - "5200-5350:5000-5150"
+      - "5200-5350:5000-5150/udp"
+    volumes:
+      - ./logs:/opt/traccar/logs:rw
+      - ./traccar.xml:/opt/traccar/conf/traccar.xml:ro


### PR DESCRIPTION
This pull request introduces a lightweight Dockerized setup for the Traccar GPS tracking platform. It includes a new `Dockerfile` based on Alpine Linux and a `docker-compose.yml` file for easy deployment. The most important changes are grouped below:

### Dockerfile for Traccar:

* Added `Dockerfile.alpine` to build a lightweight Docker image for Traccar using Alpine Linux. The image installs OpenJDK 17, downloads the Traccar release, and sets up the runtime environment.

### Docker Compose Setup:

* Added `docker-compose.yml` to simplify the deployment of the Traccar container. It specifies the container configuration, port mappings, and volume mounts for logs and configuration.