### PR TITLE
Fix Notification schema in OpenAPI docs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2019,14 +2019,15 @@ components:
           type: integer
         type:
           type: string
+        description:
+          type: string
+          nullable: true
         always:
           type: boolean
-        web:
-          type: boolean
-        mail:
-          type: boolean
-        sms:
-          type: boolean
+        commandId:
+          type: integer
+        notificators:
+          type: string
         calendarId:
           type: integer
         attributes:


### PR DESCRIPTION
## Summary
- correct Notification fields in `openapi.yaml` to match the Java model

## Testing
- `./gradlew test --no-daemon -q` *(fails: No route to host)*