### PR TITLE
Add endpoints for retrieving historical actions related to users and objects

### DIFF
--- a/src/main/java/org/traccar/api/BaseObjectResource.java
+++ b/src/main/java/org/traccar/api/BaseObjectResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 - 2022 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 - 2025 Anton Tananaev (anton@traccar.org)
  * Copyright 2017 - 2018 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This pull request introduces functionality for retrieving historical actions associated with objects and users, as well as updates to copyright information. The key changes include adding new endpoints for fetching historical data.

### New functionality for retrieving historical actions:

* **Added `getHistory` method in `BaseObjectResource`:** This new endpoint allows fetching historical actions for a specific object within an optional date range. 

* **Added `getActions` method in `UserResource`:** This endpoint enables retrieving actions performed by a specific user within an optional date range, similar to the `getHistory` method. 


These changes enhance the API by providing endpoints for querying historical data, which can be useful for auditing and tracking purposes.