### PR TITLE
Add release delivery to Docker Hub and GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,24 @@
-name: Build Installers
+name: Build Release
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version'
+        description: Version
         required: true
-        default: 'preview'
+        default: preview
 
 jobs:
-  release:
-    runs-on: ubuntu-22.04
+  build:
+    name: Build installers
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
-      - run: git checkout ${{ github.ref_name }}
-        working-directory: ./traccar-web
+      - working-directory: ./traccar-web
+        run: git checkout ${{ github.ref_name }}
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -29,24 +30,115 @@ jobs:
           node-version: 21
           cache: npm
           cache-dependency-path: traccar-web/package-lock.json
-      - run: npm ci && npm run build
-        working-directory: ./traccar-web
+      - working-directory: ./traccar-web
+        run: npm ci && npm run build
       - run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
           sudo apt-get install libgcc-s1:i386 libstdc++6:i386
-          sudo apt-get install innoextract makeself wine32 s3cmd
-      - name: Build installers
-        working-directory: ./setup
+          sudo apt-get install innoextract makeself wine32
+      - working-directory: ./setup
         run: |
           wget -q http://files.jrsoftware.org/is/5/isetup-5.5.6.exe
           wget -q https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.4_7.zip
           wget -q https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz
           wget -q https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.4_7.tar.gz
           ./package.sh ${{ github.event.inputs.version }}
-      - name: Upload installers
-        working-directory: ./setup
-        env:
+      - uses: actions/upload-artifact@v4
+        with:
+          name: installers
+          path: setup/traccar-*.zip
+          compression-level: 0
+          retention-days: 1
+  upload:
+    name: Upload installers
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+      - env:
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-        run: s3cmd --acl-public put traccar-*.zip s3://traccar/builds/ --host=nyc3.digitaloceanspaces.com --host-bucket=traccar --access_key="$S3_ACCESS_KEY" --secret_key="$S3_SECRET_KEY"
+        run: |
+          sudo apt-get install s3cmd
+          s3cmd --acl-public put installers/traccar-*.zip s3://traccar/builds/ --host=nyc3.digitaloceanspaces.com --host-bucket=traccar --access_key="$S3_ACCESS_KEY" --secret_key="$S3_SECRET_KEY"
+  release:
+    name: Create release with installers
+    needs: build
+    if: ${{ github.event.inputs.version != 'preview' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/v${{ github.event.inputs.version }}',
+                sha: context.sha
+            })
+      - uses: actions/download-artifact@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          files: installers/traccar-*.zip
+  docker:
+    name: Build and push docker images
+    needs: build
+    if: ${{ github.event.inputs.version != 'preview' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [alpine, debian, ubuntu]
+        include:
+          - os: alpine
+            platforms: linux/amd64,linux/arm64
+          - platforms: linux/amd64,linux/arm64,linux/arm/v7
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          path: docker
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: latest=false
+          images: |
+            traccar/traccar
+            ghcr.io/traccar/traccar
+          tags: |
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},suffix=-${{ matrix.os }},value=v${{ github.event.inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.os }},value=v${{ github.event.inputs.version }}
+            type=semver,pattern={{major}},suffix=-${{ matrix.os }},value=v${{ github.event.inputs.version }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=v${{ github.event.inputs.version }},enable=${{ matrix.os == 'alpine' }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ github.event.inputs.version }},enable=${{ matrix.os == 'alpine' }}
+            type=semver,pattern={{major}},value=v${{ github.event.inputs.version }},enable=${{ matrix.os == 'alpine' }}
+            type=raw,value=latest,enable=${{ matrix.os == 'alpine' }}
+            type=raw,value=${{ matrix.os }}
+          labels: |
+            org.opencontainers.image.version=${{ github.event.inputs.version }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile.${{ matrix.os }}
+          build-args: VERSION=${{ github.event.inputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platforms }}
+          push: true

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,14 @@
+FROM alpine:3.22
+
+ARG VERSION
+COPY installers/traccar-other-$VERSION.zip /tmp/traccar.zip
+
+WORKDIR /opt/traccar
+
+RUN set -ex; \
+    apk add --no-cache --no-progress openjdk17-jre-headless; \
+    unzip -qo /tmp/traccar.zip -d .; \
+    rm /tmp/traccar.zip
+
+ENTRYPOINT ["java"]
+CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,19 @@
+FROM debian:12-slim
+
+ARG VERSION
+COPY installers/traccar-other-$VERSION.zip /tmp/traccar.zip
+
+WORKDIR /opt/traccar
+
+RUN set -ex; \
+    apt-get update; \
+    TERM=xterm DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+      openjdk-17-jre-headless \
+      unzip; \
+    unzip -qo /tmp/traccar.zip -d .; \
+    apt-get autoremove --yes unzip; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENTRYPOINT ["java"]
+CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04
+
+ARG VERSION
+COPY installers/traccar-other-$VERSION.zip /tmp/traccar.zip
+
+WORKDIR /opt/traccar
+
+RUN set -ex; \
+    apt-get update; \
+    TERM=xterm DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+      openjdk-17-jre-headless \
+      unzip; \
+    unzip -qo /tmp/traccar.zip -d .; \
+    apt-get autoremove --yes unzip; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENTRYPOINT ["java"]
+CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]


### PR DESCRIPTION
@tananaev,
I have migrated and refactored the build and publication of Docker traccar/tracker images from the [traccar/traccar-docker repository](https://github.com/traccar/traccar-docker). Along with the creation of the new release, Docker images will be published on the Docker Hub and GitHub Container Registry.

To parallelize the publication, I split the submission into S3 and the Docker build. In the future can add another task to create a release on GitHub.

Before the first launch, you need to add the secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.