### PR TITLE
Add ACK response for Sinotrack ST-901L binary packets [protocol H02]

### DIFF
--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -155,6 +155,10 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
         processStatus(position, buf.readUnsignedInt());
 
+        if (channel != null) {
+            channel.writeAndFlush(new NetworkMessage("ON", remoteAddress));
+        }
+
         return position;
     }
 


### PR DESCRIPTION
Testing assumptions to solve the problem with Sinotrack ST-901L 
Details: https://www.traccar.org/forums/topic/sinotrack-st-901-config-issues/page/9/#post-112372