### PR TITLE
Add ACK response for Sinotrack ST-901L binary packets [protocol H02]

### DIFF
--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -155,10 +155,8 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
         processStatus(position, buf.readUnsignedInt());
 
-        if (channel != null) {
-            sendResponse(channel, remoteAddress, id, "R12");
-        }
-        
+        sendResponse(channel, remoteAddress, id, "R12");
+
         return position;
     }
 

--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -155,6 +155,10 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
         processStatus(position, buf.readUnsignedInt());
 
+        if (channel != null) {
+            sendResponse(channel, remoteAddress, id, "R12");
+        }
+        
         return position;
     }
 


### PR DESCRIPTION
Based on the analysis of servers from pro.sinotrack.com and their responses, we added the same response that is required for binary queries. In the end, the solution works for Sinotrack ST-901L and no more repeating old queries accumulate.

I am attaching screenshots of requests and responses to my Traccar server for processing 2 different types of requests from Sinotrack ST-901L:
![packet_sniffer](https://github.com/user-attachments/assets/53083fbf-da25-413d-a4fe-988b790a805b)

Related old pull request https://github.com/traccar/traccar/pull/5596
