### PR TITLE
Optimize Docker images

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,14 +1,16 @@
-FROM alpine:3.22
-
+FROM alpine AS package
 ARG VERSION
 COPY installers/traccar-other-$VERSION.zip /tmp/traccar.zip
+RUN unzip -qo /tmp/traccar.zip -d /traccar
 
+FROM eclipse-temurin:21-alpine AS jdk
+RUN jlink --module-path $JAVA_HOME/jmods \
+    --add-modules java.se,jdk.charsets,jdk.crypto.ec,jdk.unsupported \
+    --strip-debug --no-header-files --no-man-pages --compress=2 --output /jre
+
+FROM alpine:3.22
+COPY --from=package /traccar /opt/traccar
+COPY --from=jdk /jre /opt/traccar/jre
 WORKDIR /opt/traccar
-
-RUN set -ex; \
-    apk add --no-cache --no-progress openjdk17-jre-headless; \
-    unzip -qo /tmp/traccar.zip -d .; \
-    rm /tmp/traccar.zip
-
-ENTRYPOINT ["java"]
+ENTRYPOINT ["/opt/traccar/jre/bin/java"]
 CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,19 +1,16 @@
-FROM debian:12-slim
-
+FROM alpine AS package
 ARG VERSION
 COPY installers/traccar-other-$VERSION.zip /tmp/traccar.zip
+RUN unzip -qo /tmp/traccar.zip -d /traccar
 
+FROM eclipse-temurin:21 AS jdk
+RUN jlink --module-path $JAVA_HOME/jmods \
+    --add-modules java.se,jdk.charsets,jdk.crypto.ec,jdk.unsupported \
+    --strip-debug --no-header-files --no-man-pages --compress=2 --output /jre
+
+FROM debian:12-slim
+COPY --from=package /traccar /opt/traccar
+COPY --from=jdk /jre /opt/traccar/jre
 WORKDIR /opt/traccar
-
-RUN set -ex; \
-    apt-get update; \
-    TERM=xterm DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-      openjdk-17-jre-headless \
-      unzip; \
-    unzip -qo /tmp/traccar.zip -d .; \
-    apt-get autoremove --yes unzip; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/* /tmp/*
-
-ENTRYPOINT ["java"]
+ENTRYPOINT ["/opt/traccar/jre/bin/java"]
 CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,19 +1,16 @@
-FROM ubuntu:24.04
-
+FROM alpine AS package
 ARG VERSION
 COPY installers/traccar-other-$VERSION.zip /tmp/traccar.zip
+RUN unzip -qo /tmp/traccar.zip -d /traccar
 
+FROM eclipse-temurin:21 AS jdk
+RUN jlink --module-path $JAVA_HOME/jmods \
+    --add-modules java.se,jdk.charsets,jdk.crypto.ec,jdk.unsupported \
+    --strip-debug --no-header-files --no-man-pages --compress=2 --output /jre
+
+FROM ubuntu:24.04
+COPY --from=package /traccar /opt/traccar
+COPY --from=jdk /jre /opt/traccar/jre
 WORKDIR /opt/traccar
-
-RUN set -ex; \
-    apt-get update; \
-    TERM=xterm DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-      openjdk-17-jre-headless \
-      unzip; \
-    unzip -qo /tmp/traccar.zip -d .; \
-    apt-get autoremove --yes unzip; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/* /tmp/*
-
-ENTRYPOINT ["java"]
+ENTRYPOINT ["/opt/traccar/jre/bin/java"]
 CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]


### PR DESCRIPTION
@magna-z what do you think about doing images like this?

Basically 3 stages:
1. Unzip Traccar package. Separate stage means that we can reuse this code between all images and don't need to worry about installing and cleaning up unzip.
2. Package minimal version of JRE. This is what we do for official installers. Makes sense to do it for docker as well. It can save us quite a bit in size. It's also reusable. The only difference is that alpine needs a different base package.
3. Final docker image. It's basically the same across all with different base.

In my local testing it saved about 100MB on alpine image size.