### PR TITLE
Add feature to include id in position forwarding

### DIFF
--- a/src/main/java/org/traccar/model/Position.java
+++ b/src/main/java/org/traccar/model/Position.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.traccar.storage.QueryIgnore;
 import org.traccar.storage.StorageName;
 
@@ -349,6 +351,12 @@ public class Position extends Message {
     @Override
     public void setType(String type) {
         super.setType(type);
+    }
+
+    @Override
+    @JsonProperty("id")
+    public long getId() {
+        return super.getId();
     }
 
 }


### PR DESCRIPTION
Addesses #5592 
- Added JsonProperty("id") in Position to include 'id' in JSON serialization for forwarding

I reviewed the full hierarchy for Position class (baseModel -> ExtendedModel -> Message -> Position) 
I checked Position Forward Implementations to ensure it correctly handles the updated JSON with the new id field