### PR TITLE
Add curl to docker images to fix healthcheck failures

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -9,6 +9,7 @@ RUN jlink --module-path $JAVA_HOME/jmods \
     --strip-debug --no-header-files --no-man-pages --compress=2 --output /jre
 
 FROM alpine:3.22
+RUN apk add --no-cache curl
 COPY --from=package /traccar /opt/traccar
 COPY --from=jdk /jre /opt/traccar/jre
 WORKDIR /opt/traccar

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -9,8 +9,14 @@ RUN jlink --module-path $JAVA_HOME/jmods \
     --strip-debug --no-header-files --no-man-pages --compress=2 --output /jre
 
 FROM debian:12-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY --from=package /traccar /opt/traccar
 COPY --from=jdk /jre /opt/traccar/jre
+
 WORKDIR /opt/traccar
 ENTRYPOINT ["/opt/traccar/jre/bin/java"]
 CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -9,8 +9,14 @@ RUN jlink --module-path $JAVA_HOME/jmods \
     --strip-debug --no-header-files --no-man-pages --compress=2 --output /jre
 
 FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY --from=package /traccar /opt/traccar
 COPY --from=jdk /jre /opt/traccar/jre
+
 WORKDIR /opt/traccar
 ENTRYPOINT ["/opt/traccar/jre/bin/java"]
 CMD ["-jar", "tracker-server.jar", "conf/traccar.xml"]


### PR DESCRIPTION
Healthchecks were failing due to missing curl inside the containers. This commit updates the final stages of Dockerfiles (based on Alpine, Debian, and Ubuntu) to include curl, ensuring healthchecks can run properly.