### PR TITLE
Fix for failing docker compose healthchecks failing

### DIFF
--- a/docker/compose/traccar-mysql.yaml
+++ b/docker/compose/traccar-mysql.yaml
@@ -33,7 +33,7 @@ services:
       DATABASE_USER: traccar
       DATABASE_PASSWORD: traccar
     healthcheck:
-      test: [ "CMD", "wget", "-q", "-s", "http://localhost:8082/api/health" ]
+      test: [ "CMD", "wget", "-q", "-S", "http://localhost:8082/api/health" ]
       interval: 2m
       timeout: 5s
       start_period: 1h

--- a/docker/compose/traccar-mysql.yaml
+++ b/docker/compose/traccar-mysql.yaml
@@ -33,7 +33,7 @@ services:
       DATABASE_USER: traccar
       DATABASE_PASSWORD: traccar
     healthcheck:
-      test: [ "CMD", "wget", "-q", "-S", "http://localhost:8082/api/health" ]
+      test: [ "CMD", "wget", "--spider", "-q", "-S", "http://localhost:8082/api/health" ]
       interval: 2m
       timeout: 5s
       start_period: 1h

--- a/docker/compose/traccar-timescaledb.yaml
+++ b/docker/compose/traccar-timescaledb.yaml
@@ -23,7 +23,7 @@ services:
       DATABASE_USER: traccar
       DATABASE_PASSWORD: traccar
     healthcheck:
-      test: [ "CMD", "wget", "-q", "-s", "http://localhost:8082/api/health" ]
+      test: [ "CMD", "wget", "-q", "-S", "http://localhost:8082/api/health" ]
       interval: 2m
       timeout: 5s
       start_period: 1h

--- a/docker/compose/traccar-timescaledb.yaml
+++ b/docker/compose/traccar-timescaledb.yaml
@@ -23,7 +23,7 @@ services:
       DATABASE_USER: traccar
       DATABASE_PASSWORD: traccar
     healthcheck:
-      test: [ "CMD", "wget", "-q", "-S", "http://localhost:8082/api/health" ]
+      test: [ "CMD", "wget", "--spider", "-q", "-S", "http://localhost:8082/api/health" ]
       interval: 2m
       timeout: 5s
       start_period: 1h


### PR DESCRIPTION
In reference to #5615 and commit e5c8a22, the `wget` command in the Docker healthcheck used an invalid `-s` option (not supported in BusyBox wget). This caused the healthcheck to fail silently.

This update:

- Replaces `-s` with the correct `-S` to show server response
- Adds `--spider` to prevent wget from attempting to download and save the /api/health response as a file named `health,` which can lead to file conflicts and failing healthchecks