### PR TITLE
JMAK - Fix bug devicetime jr11

### DIFF
--- a/src/main/java/org/traccar/protocol/JmakProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/JmakProtocolDecoder.java
@@ -100,7 +100,8 @@ public class JmakProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (BitUtil.check(mask, 4)) {
-            position.setFixTime(new Date(Long.parseLong(values[index++])));
+            position.setFixTime(new Date(Long.parseLong(values[index])));
+            position.setDeviceTime(new Date(Long.parseLong(values[index++])));
         }
 
         if (BitUtil.check(mask, 5)) {


### PR DESCRIPTION
Bug Description:
The JR11 protocol can send a position without the "send timestamp" value (checked via `BitUtil.check(mask, 25)`). As a result, `setDeviceTime` is not set, causing the following error:

`org.traccar.storage.StorageException: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: NULL not allowed for column "DEVICETIME"; SQL statement:  `

Solution:
Use `BitUtil.check(mask, 4)` (which is mandatory for setting deviceTime) before checking bit 25. This ensures that if bit 25 is not present in the mask, the deviceTime is still properly configured.