### PR TITLE
JMAK - Fix hourmeter conversion from hours to milliseconds

### DIFF
--- a/src/main/java/org/traccar/protocol/JmakProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/JmakProtocolDecoder.java
@@ -148,7 +148,7 @@ public class JmakProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (BitUtil.check(mask, 16)) {
-            position.set(Position.KEY_HOURS, Double.parseDouble(values[index++]));
+            position.set(Position.KEY_HOURS, Double.parseDouble(values[index++]) * 3600000);
         }
 
         if (BitUtil.check(mask, 17)) {
@@ -253,7 +253,7 @@ public class JmakProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (BitUtil.check(mask, 1)) {
-            position.set(Position.KEY_HOURS, Double.parseDouble(values[index++]));
+            position.set(Position.KEY_HOURS, Double.parseDouble(values[index++]) * 3600000);
         }
 
         if (BitUtil.check(mask, 2)) {


### PR DESCRIPTION
Traccar was receiving the hourmeter value in hours—even though it expected milliseconds. This change converts the incoming hours to milliseconds (hours × 3 600 000) before processing, ensuring that the hourmeter readings display correctly in Traccar.