### PR TITLE
Convert Teltonika ASCII VIN to string

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -549,7 +549,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
             for (int j = 0; j < cnt; j++) {
                 int id = buf.readUnsignedShort();
                 int length = buf.readUnsignedShort();
-                if (id == 256) {
+                if (id == 256 || id == 325) {
                     position.set(Position.KEY_VIN,
                             buf.readSlice(length).toString(StandardCharsets.US_ASCII));
                 } else if (id == 281) {


### PR DESCRIPTION
When using Teltonika CAN Devices the VIN is not converted from ASCII to a string as the ID is different, 325 instead of 256, than from ODB Devices.

https://wiki.teltonika-gps.com/view/FMC250_Teltonika_Data_Sending_Parameters_ID