### PR TITLE
Add support to decode car acc status for h02 protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -301,27 +301,12 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
             .compile();
 
     /* reply to CXZT command on ST906 V2 tracker */
-    private static final Pattern PATTERN_SMS_ST906_V2 = new PatternBuilder()
+    private static final Pattern PATTERN_SMS = new PatternBuilder()
             .text("*HQ,")
             .number("(d+),")                     // id
-            .text("SMS,ST906")
-            .expression("[^ ]+ \\d+/\\d+/\\d+")  // firmware/version (e.g. (70SACD)_TQ_V_2.0 2024/06/07)
-            .text("\\nID:")
-            .number("d+")                        // id (again)
-            .text("\\nIP:")
-            .expression("[^ ]+")                 // IP address
-            .number(" d+")                       // port
-            .text("\\nUT:")
-            .number("d+,d+,d+")                  // UT values
-            .text("\\nVOLT:")
-            .number("(d+.d+)V")                  // voltage
-            .text("\\nAPN:")
-            .expression("([^\\n]+)")              // APN
-            .text("\\nGPS:")
-            .expression("([AB])-(\\d+)-(\\d+)")   // GPS validity, lat, lon
-            .text("\\nGSM:")
-            .number("(d+)")                       // GSM value
-            .any()
+            .text("SMS,")
+            .expression("(.+)")
+            .text("#").optional()
             .compile();
 
     private void sendResponse(Channel channel, SocketAddress remoteAddress, String id, String type) {
@@ -551,7 +536,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
     private Position decodeSms(String sentence, Channel channel, SocketAddress remoteAddress) {
 
-        Parser parser = new Parser(PATTERN_SMS_ST906_V2, sentence);
+        Parser parser = new Parser(PATTERN_SMS, sentence);
         if (!parser.matches()) {
             return null;
         }
@@ -563,7 +548,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
         Position position = new Position(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
-        position.set(Position.KEY_POWER, parser.nextDouble());
+        position.set(Position.KEY_RESULT, parser.next());
         getLastLocation(position, null);
         return position;
     }

--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -306,7 +306,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // id
             .text("SMS,")
             .expression("(.+)")
-            .text("#").optional()
+            .text("#")
             .compile();
 
     private void sendResponse(Channel channel, SocketAddress remoteAddress, String id, String type) {

--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -300,29 +300,30 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
             .any()
             .compile();
 
+    /* reply to CXZT command on ST906 V2 tracker */
     private static final Pattern PATTERN_SMS_ST906_V2 = new PatternBuilder()
             .text("*HQ,")
-            .number("(d+),")                // id
+            .number("(d+),")                     // id
             .text("SMS,ST906")
-            .expression("[^ ]+ \\d+/\\d+/\\d+")                 // firmware/version (e.g. (70SACD)_TQ_V_2.0 2024/06/07)
+            .expression("[^ ]+ \\d+/\\d+/\\d+")  // firmware/version (e.g. (70SACD)_TQ_V_2.0 2024/06/07)
             .text("\\nID:")
-            .number("d+")                      // id (again)
-            .text("\\nIP:") 
-            .expression("[^ ]+")                // IP address
-            .number(" d+")                      // port
+            .number("d+")                        // id (again)
+            .text("\\nIP:")
+            .expression("[^ ]+")                 // IP address
+            .number(" d+")                       // port
             .text("\\nUT:")
-            .number("d+,d+,d+")             // UT values
+            .number("d+,d+,d+")                  // UT values
             .text("\\nVOLT:")
-            .number("(d+.d+)V")                   // voltage
+            .number("(d+.d+)V")                  // voltage
             .text("\\nAPN:")
             .expression("([^\\n]+)")              // APN
             .text("\\nGPS:")
-            .expression("([AB])-(\\d+)-(\\d+)")       // GPS validity, lat, lon
+            .expression("([AB])-(\\d+)-(\\d+)")   // GPS validity, lat, lon
             .text("\\nGSM:")
             .number("(d+)")                       // GSM value
             .any()
             .compile();
- 
+
     private void sendResponse(Channel channel, SocketAddress remoteAddress, String id, String type) {
         if (channel != null && id != null) {
             String response;

--- a/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
@@ -267,25 +267,6 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
         
         verifyPosition(decoder, binary(
                 "24971305007205201916101533335008000073206976000000effffbffff000252776566060000000000000000000049"));
-
-        verifyAttribute(decoder, buffer(
-                "*HQ,135790246811220,HTBT,100#"),
-                Position.KEY_BATTERY_LEVEL, 100);                
-    }
-
-    @Test
-    public void testDecodeStatus() throws Exception {
-
-        var decoder = inject(new H02ProtocolDecoder(null));
-
-        verifyAttribute(decoder, buffer(
-                "*HQ,2705171109,V1,213324,A,5002.5849,N,01433.7822,E,0.00,000,140613,FFFFFFFF#"),
-                Position.KEY_STATUS, 0xFFFFFFFFL);
-
-        verifyAttribute(decoder, binary(
-                "2441091144271222470112142233983006114026520E000000FFFFFBFFFF0014060000000001CC00262B0F170A"),
-                Position.KEY_STATUS, 0xFFFFFBFFL);
-
         verifyAttribute(decoder, buffer(
                 "*HQ,5226073533,SMS,ST906(70SACD)_TQ_V_2.0 2024/06/07\\n" + //
                                                 "ID:5226073533\\n" + //
@@ -303,6 +284,24 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
                                                 "APN:internet.example.com\\n" + //
                                                 "GPS:A-24-23\\n" + //
                                                 "GSM:26");
+    }
+
+    @Test
+    public void testDecodeStatus() throws Exception {
+
+        var decoder = inject(new H02ProtocolDecoder(null));
+
+        verifyAttribute(decoder, buffer(
+                "*HQ,2705171109,V1,213324,A,5002.5849,N,01433.7822,E,0.00,000,140613,FFFFFFFF#"),
+                Position.KEY_STATUS, 0xFFFFFFFFL);
+
+        verifyAttribute(decoder, binary(
+                "2441091144271222470112142233983006114026520E000000FFFFFBFFFF0014060000000001CC00262B0F170A"),
+                Position.KEY_STATUS, 0xFFFFFBFFL);
+
+        verifyAttribute(decoder, buffer(
+                "*HQ,4210051415,V1,164549,A,0956.3869,N,08406.7068,W,000.00,000,221215,FFFFFBFF,712,01,0,0,6#"),
+                Position.KEY_STATUS, 0xFFFFFBFFL);
 
     }
 

--- a/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
@@ -268,6 +268,9 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, binary(
                 "24971305007205201916101533335008000073206976000000effffbffff000252776566060000000000000000000049"));
 
+        verifyAttribute(decoder, buffer(
+                "*HQ,135790246811220,HTBT,100#"),
+                Position.KEY_BATTERY_LEVEL, 100);                
     }
 
     @Test
@@ -284,8 +287,22 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
                 Position.KEY_STATUS, 0xFFFFFBFFL);
 
         verifyAttribute(decoder, buffer(
-                "*HQ,4210051415,V1,164549,A,0956.3869,N,08406.7068,W,000.00,000,221215,FFFFFBFF,712,01,0,0,6#"),
-                Position.KEY_STATUS, 0xFFFFFBFFL);
+                "*HQ,5226073533,SMS,ST906(70SACD)_TQ_V_2.0 2024/06/07\\n" + //
+                                                "ID:5226073533\\n" + //
+                                                "IP:1.2.3.4 5013\\n" + //
+                                                "UT:30,30,300\\n" + //
+                                                "VOLT:12.9V\\n" + //
+                                                "APN:internet.example.com\\n" + //
+                                                "GPS:A-24-23\\n" + //
+                                                "GSM:26#"),
+                Position.KEY_RESULT, "ST906(70SACD)_TQ_V_2.0 2024/06/07\\n" + //
+                                                "ID:5226073533\\n" + //
+                                                "IP:1.2.3.4 5013\\n" + //
+                                                "UT:30,30,300\\n" + //
+                                                "VOLT:12.9V\\n" + //
+                                                "APN:internet.example.com\\n" + //
+                                                "GPS:A-24-23\\n" + //
+                                                "GSM:26");
 
     }
 


### PR DESCRIPTION
This PR should add support for the ST906 battery reporting provided as reply to CXZT command:

```
2025-08-09 21:19:15  INFO: [T13cb679d: h02 > 1.2.3.4] CXZT
2025-08-09 21:19:15  INFO: [T13cb679d: h02 < 1.2.3.4] *HQ,11223344,SMS,ST906(70SACD)_TQ_V_2.0 2024/06/07\nID:11223344\nIP:1.2.3.4 5013\nUT:30,30,300\nVOLT:13.1V\nAPN:internet.example.com\nGPS:A-22-20\nGSM:26#
```
My plan is to run CXZT command using API every hour and use computed attributes to have it in the logs and screen. 