### PR TITLE
Add filter.zeroAccuracy filter option.

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1457,6 +1457,13 @@ public final class Keys {
             List.of(KeyType.CONFIG));
 
     /**
+     * Filter positions with a zero accuracy.
+     */
+    public static final ConfigKey<Boolean> FILTER_ZERO_ACCURACY = new BooleanConfigKey(
+            "filter.zeroAccuracy",
+            List.of(KeyType.CONFIG));
+
+    /**
      * Filter cell and wifi locations that are coming from geolocation provider.
      */
     public static final ConfigKey<Boolean> FILTER_APPROXIMATE = new BooleanConfigKey(

--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -48,6 +48,7 @@ public class FilterHandler extends BasePositionHandler {
     private final long filterPast;
     private final boolean filterApproximate;
     private final int filterAccuracy;
+    private final boolean filterZeroAccuracy;
     private final boolean filterStatic;
     private final int filterDistance;
     private final int filterMaxSpeed;
@@ -72,6 +73,7 @@ public class FilterHandler extends BasePositionHandler {
         filterFuture = config.getLong(Keys.FILTER_FUTURE) * 1000;
         filterPast = config.getLong(Keys.FILTER_PAST) * 1000;
         filterAccuracy = config.getInteger(Keys.FILTER_ACCURACY);
+        filterZeroAccuracy = config.getBoolean(Keys.FILTER_ZERO_ACCURACY);
         filterApproximate = config.getBoolean(Keys.FILTER_APPROXIMATE);
         filterStatic = config.getBoolean(Keys.FILTER_STATIC);
         filterDistance = config.getInteger(Keys.FILTER_DISTANCE);
@@ -131,7 +133,7 @@ public class FilterHandler extends BasePositionHandler {
     }
 
     private boolean filterAccuracy(Position position) {
-        return filterAccuracy != 0 && position.getAccuracy() > filterAccuracy;
+        return (filterAccuracy != 0 && position.getAccuracy() > filterAccuracy) || (filterZeroAccuracy && position.getAccuracy() == 0);
     }
 
     private boolean filterApproximate(Position position) {


### PR DESCRIPTION
One of my friends has the issue that some coordinates are completely wrong but all wrong ones have an accuracy that is 0 while all valid ones have an accuracy that is bigger than 0.

I know that there is the "filter.accuracy" key but that only filters out points with an accuracy higher than a threshold.

This PR adds a new filter with the "filter.zeroAccuracy" key that filters out all points with an accuracy of 0.

This is probably a niche use case but I know at least one user who needs this.