### PR TITLE
Add pt_BR Language on Template Folder

### DIFF
--- a/templates/notifications/pt_BR/alarm.vm
+++ b/templates/notifications/pt_BR/alarm.vm
@@ -1,0 +1,15 @@
+#set($subject = "$device.name: Alarme")
+#set($alarmKey = $event.getString('alarm'))
+#set($alarmName = $translations.get("alarm${alarmKey.substring(0, 1).toUpperCase()}${alarmKey.substring(1)}"))
+#set($digest = "Alarme de $device.name: $alarmName às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Alarme: $alarmName<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/commandResult.vm
+++ b/templates/notifications/pt_BR/commandResult.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: resultado de comando recebido")
+#set($digest = "Resultado de comando de $device.name recebido: $position.getString('result') às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Resultado: $position.getString('result')<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Url: <a href="$webUrl?eventId=$event.id">$webUrl?eventId=$event.id</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceExpiration.vm
+++ b/templates/notifications/pt_BR/deviceExpiration.vm
@@ -1,0 +1,8 @@
+#set($subject = "Expiração de dispositivo")
+#set($digest = "O dispositivo $device.name está expirado")
+<!DOCTYPE html>
+<html>
+<body>
+O dispositivo $device.name está expirado.
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceExpirationReminder.vm
+++ b/templates/notifications/pt_BR/deviceExpirationReminder.vm
@@ -1,0 +1,8 @@
+#set($subject = "Lembrete de expiração de dispositivo")
+#set($digest = "O dispositivo $device.name expira em $dateTool.format('yyyy-MM-dd', $expiration, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+O dispositivo $device.name vai expirar em $dateTool.format('yyyy-MM-dd', $expiration, $locale, $timezone).
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceFuelDrop.vm
+++ b/templates/notifications/pt_BR/deviceFuelDrop.vm
@@ -1,0 +1,14 @@
+#set($subject = "$device.name: queda de combustível")
+#set($digest = "Queda do combustível de $device.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Quantidade antes: $event.attributes.before<br>
+Quantidade depois: $event.attributes.after<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceFuelIncrease.vm
+++ b/templates/notifications/pt_BR/deviceFuelIncrease.vm
@@ -1,0 +1,14 @@
+#set($subject = "$device.name: aumento de combustível")
+#set($digest = "Aumento de combustível de $device.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Quantidade antes: $event.attributes.before<br>
+Quantidade depois: $event.attributes.after<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceInactive.vm
+++ b/templates/notifications/pt_BR/deviceInactive.vm
@@ -1,0 +1,15 @@
+#set($subject = "$device.name: inativo")
+#set($lastUpdate = $dateTool.getDate())
+#set($ignore = $lastUpdate.setTime($event.getLong('lastUpdate')))
+#set($digest = "$device.name inativo desde $dateTool.format('yyyy-MM-dd HH:mm:ss', $lastUpdate, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Inativo<br>
+Última atualização: $dateTool.format('yyyy-MM-dd HH:mm:ss', $lastUpdate, $locale, $timezone)<br>
+Url: <a href="$webUrl?eventId=$event.id">$webUrl?eventId=$event.id</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceMoving.vm
+++ b/templates/notifications/pt_BR/deviceMoving.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: em movimento")
+#set($digest = "$device.name em movimento às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Em movimento<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceOffline.vm
+++ b/templates/notifications/pt_BR/deviceOffline.vm
@@ -1,0 +1,12 @@
+#set($subject = "$device.name: desconectado")
+#set($digest = "$device.name desconectado às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Desconectado<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceOnline.vm
+++ b/templates/notifications/pt_BR/deviceOnline.vm
@@ -1,0 +1,12 @@
+#set($subject = "$device.name: conectado")
+#set($digest = "$device.name conectado às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Conectado<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceOverspeed.vm
+++ b/templates/notifications/pt_BR/deviceOverspeed.vm
@@ -1,0 +1,22 @@
+#set($subject = "$device.name: excedeu a velocidade")
+#if($speedUnit == "kmh")
+#set($speedValue = $position.speed * 1.852)
+#set($speedString = $numberTool.format('0.0 km/h', $speedValue))
+#elseif($speedUnit == "mph")
+#set($speedValue = $position.speed * 1.15078)
+#set($speedString = $numberTool.format('0.0 mph', $speedValue))
+#else
+#set($speedString = $numberTool.format('0.0 kn', $position.speed))
+#end
+#set($digest = "$device.name excedeu a velocidade $speedString#{if}($geofence) em $geofence.name#{else}#{end} às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Excedeu a velocidade: $speedString#{if}($geofence) en $geofence.name#{else}#{end}<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceStopped.vm
+++ b/templates/notifications/pt_BR/deviceStopped.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: parou")
+#set($digest = "$device.name parou às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Parou<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/deviceUnknown.vm
+++ b/templates/notifications/pt_BR/deviceUnknown.vm
@@ -1,0 +1,12 @@
+#set($subject = "$device.name: estado desconhecido")
+#set($digest = "$device.name estado desconhecido às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Estado desconhecido<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/driverChanged.vm
+++ b/templates/notifications/pt_BR/driverChanged.vm
@@ -1,0 +1,18 @@
+#set($subject = "$device.name: troca de Condutor")
+#if($driver)
+#set($driverName = $driver.name)
+#else
+#set($driverName = $event.getString('driverUniqueId'))
+#end
+#set($digest = "o condutor $driverName foi trocado em $device.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+Condutor: $driverName<br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/geofenceEnter.vm
+++ b/templates/notifications/pt_BR/geofenceEnter.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: entrou na geocerca")
+#set($digest = "$device.name entrou na geocerca $geofence.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Entrou na geocerca: $geofence.name<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/geofenceExit.vm
+++ b/templates/notifications/pt_BR/geofenceExit.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: saiu da geocerca")
+#set($digest = "$device.name saiu da geocerca $geofence.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Saiu da geocerca: $geofence.name<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/ignitionOff.vm
+++ b/templates/notifications/pt_BR/ignitionOff.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: DESLIGOU a ignição")
+#set($digest = "$device.name DESLIGOU a ignição às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+DESLIGOU a ignição<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/ignitionOn.vm
+++ b/templates/notifications/pt_BR/ignitionOn.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: LIGOU a ignição")
+#set($digest = "$device.name LIGOU a ignição às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+LIGOU a ignição<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/maintenance.vm
+++ b/templates/notifications/pt_BR/maintenance.vm
@@ -1,0 +1,13 @@
+#set($subject = "$device.name: manutenção requerida")
+#set($digest = "Manutenção requerida $maintenance.name em $device.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Manutenção requerida: $maintenance.name<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Local: <a href="$webUrl?eventId=$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/media.vm
+++ b/templates/notifications/pt_BR/media.vm
@@ -1,0 +1,14 @@
+#set($subject = "$device.name: arquivo de mídia recebido")
+#set($digest = "$device.name $event.getString('media') recebido: $event.getString('file') às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Tipo: $event.getString('media')<br>
+Arquivo: <a href="$webUrl/api/media/$device.uniqueId/$event.getString('file')">$event.getString('file')</a><br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Url: <a href="$webUrl?eventId=$event.id">$webUrl?eventId=$event.id</a><br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/passwordReset.vm
+++ b/templates/notifications/pt_BR/passwordReset.vm
@@ -1,0 +1,9 @@
+#set($subject = "Redefinição de senha")
+#set($digest = "Link para redefinir a senha: $webUrl/reset-password?passwordReset=$token")
+<!DOCTYPE html>
+<html>
+<body>
+  Para redefinir sua senha, clique no link abaixo:<br>
+<a href="$webUrl/reset-password?passwordReset=$token">$webUrl/reset-password?passwordReset=$token</a><br>
+</body>
+</html>

--- a/templates/notifications/pt_BR/queuedCommandSent.vm
+++ b/templates/notifications/pt_BR/queuedCommandSent.vm
@@ -1,0 +1,12 @@
+#set($subject = "$device.name: comando enfileirado enviado")
+#set($digest = "comando enfileirado enviado ao veículo $device.name às $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+Dispositivo: $device.name<br>
+Comando enfileirado enviado<br>
+Hora: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+<br>
+<a href="$webUrl/settings/notifications?token=$token">Cancelar subscrição</a>
+</body>
+</html>

--- a/templates/notifications/pt_BR/userExpiration.vm
+++ b/templates/notifications/pt_BR/userExpiration.vm
@@ -1,0 +1,8 @@
+#set($subject = "Expiração da conta")
+#set($digest = "A conta expirou")
+<!DOCTYPE html>
+<html>
+<body>
+Sua conta de usuário expirou.
+</body>
+</html>

--- a/templates/notifications/pt_BR/userExpirationReminder.vm
+++ b/templates/notifications/pt_BR/userExpirationReminder.vm
@@ -1,0 +1,8 @@
+#set($subject = "Lembrete de expiração da conta")
+#set($digest = "A conta expira em $dateTool.format('yyyy-MM-dd', $expiration, $locale, $timezone)")
+<!DOCTYPE html>
+<html>
+<body>
+  Sua conta de usuário irá expirar em $dateTool.format('yyyy-MM-dd', $expiration, $locale, $timezone).
+</body>
+</html>


### PR DESCRIPTION
Add Brazilian Portuguese (pt_BR) notification templates under templates/notifications/pt_BR/.
This follows the new i18n folder layout and enables localized notifications when the user/server language is set to pt_BR.

Motivation

Provide first-class localization for Portuguese (Brazil) users.

Align custom templates with the new templates/notifications/<lang>/ structure introduced in recent releases.

Keep subject/digest + HTML bodies consistent across events.

What’s included

New folder: templates/notifications/pt_BR/

Initial set of templates (this PR):
queuedCommandSent.vm, userExpiration.vm, userExpirationReminder.vm
(More events can be added in follow-ups as needed.)

Template details

Each template sets:

#set($subject = "...")

#set($digest = "...")

HTML body includes:

Device and timestamp (format dd-MM-yyyy HH:mm:ss, using yyyy).

Event link: $webUrl?eventId=$event.id

Unsubscribe link: $webUrl/settings/notifications?token=$token

UTF-8 content (accents/emoji safe).

Behavior / i18n

If user (or server) has language = pt_BR, the engine will pick files from pt_BR.

If a pt_BR file is missing for an event, the engine falls back to en.

How to test

Set language = pt_BR for a user (or globally in config).

Restart the service to reload templates.

Trigger the corresponding events and verify subject/digest and HTML output.

Check links (event details and unsubscribe).

Backwards compatibility

No changes to existing en templates.

Pure additive; safe to merge.