### PR TITLE
Updated NMEA protocol

### DIFF
--- a/src/main/java/org/traccar/helper/PositionLogger.java
+++ b/src/main/java/org/traccar/helper/PositionLogger.java
@@ -65,6 +65,11 @@ public class PositionLogger {
                 case "course":
                     builder.append(", course: ").append(String.format("%.1f", position.getCourse()));
                     break;
+                case "altitude":
+                    if (position.getAltitude() > 0) {
+                        builder.append(", altitude: ").append(String.format("%.1f", position.getAltitude()));
+                    }
+                    break;
                 case "accuracy":
                     if (position.getAccuracy() > 0) {
                         builder.append(", accuracy: ").append(String.format("%.1f", position.getAccuracy()));

--- a/src/main/java/org/traccar/helper/PositionLogger.java
+++ b/src/main/java/org/traccar/helper/PositionLogger.java
@@ -66,9 +66,7 @@ public class PositionLogger {
                     builder.append(", course: ").append(String.format("%.1f", position.getCourse()));
                     break;
                 case "altitude":
-                    if (position.getAltitude() > 0) {
-                        builder.append(", altitude: ").append(String.format("%.1f", position.getAltitude()));
-                    }
+                    builder.append(", altitude: ").append(String.format("%.1f", position.getAltitude()));
                     break;
                 case "accuracy":
                     if (position.getAccuracy() > 0) {

--- a/src/main/java/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/T55ProtocolDecoder.java
@@ -76,7 +76,6 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // sat used 00..99
             .number("(d+.?d*),")                 // HDOP
             .number("(-?d+.?d*),")               // altitude
-            .expression("([M]),")                // altitude unit M
             .any()
             .compile();
 
@@ -263,7 +262,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());
-        position.setValid(parser.nextInt(0) >= 1);
+        position.setValid(parser.nextInt(0) > 0);
         position.set(Position.KEY_SATELLITES, parser.nextInt());
         position.set(Position.KEY_HDOP, parser.nextDouble());
         position.setAltitude(parser.nextDouble());

--- a/src/test/java/org/traccar/protocol/T55ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/T55ProtocolDecoderTest.java
@@ -23,7 +23,7 @@ public class T55ProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, text(
                 "$GNGGA,164414.90,4650.5156500,N,01246.1059604,E,1,12,0.84,740.729,M,44.804,M,,*4E"));
 
-        verifyNull(decoder, text(
+        verifyPosition(decoder, text(
                 "$GNGLL,4650.5156500,N,01246.1059604,E,164414.90,A,A*77"));
 
         verifyPosition(decoder, text(


### PR DESCRIPTION
Updated NMEA (T55) protocol:
- Added the altitude and number of sats to GGA message
- Added GLL message parser

Updated PositionLogger to be able to show the altitude if it is configured in `logger.attributes`.

But the speed, course, altitude any many other parameters in the `Position` structure are not optional and may contain invalid values. For example Ebyte E108-GN03G reports the following
```
$GNGGA,193526.000,5332.16315,N,04921.33849,E,1,15,1.5,141.0,M,0.6,M,,*76\r\n
$GNGLL,5332.16315,N,04921.33849,E,193526.000,A,A*41\r\n
$GNGSA,A,3,03,06,12,24,25,32,195,,,,,,2.7,1.5,2.2,1*0B\r\n
$GNGSA,A,3,14,27,40,42,45,,,,,,,,2.7,1.5,2.2,4*36\r\n
$GNGSA,A,3,76,75,67,,,,,,,,,,2.7,1.5,2.2,2*31\r\n
$GPGSV,3,1,11,03,12,034,37,06,50,110,13,11,31,159,,12,57,286,38,0*6C\r\n
$GPGSV,3,2,11,17,24,062,35,19,49,065,35,22,16,105,35,24,49,214,19,0*67\r\n
$GPGSV,3,3,11,25,25,288,30,32,17,312,21,195,24,065,22,0*68\r\n
$BDGSV,2,1,07,14,07,359,29,27,36,056,23,33,,,37,36,79,223,30,0*4B\r\n
$BDGSV,2,2,07,40,30,062,25,42,07,334,16,45,44,297,33,0*48\r\n
$GLGSV,3,1,09,74,37,125,,66,15,299,,86,06,198,,76,25,310,35,0*7F\r\n
$GLGSV,3,2,09,75,85,357,32,84,55,052,,83,05,029,,85,59,170,,0*77\r\n
$GLGSV,3,3,09,67,15,354,25,0*40\r\n
$GNRMC,193526.000,A,5332.16315,N,04921.33849,E,1.91,0.00,110925,,,A,V*02\r\n
$GNVTG,0.00,T,,M,0.00,N,0.00,K,A*23\r\n
$GNZDA,193526.000,11,09,2025,00,00*4E\r\n
$GPTXT,01,01,01,ANTENNA OPEN*25\r\n
$GNDHV,193526.000,0.00,0.000,0.000,0.000,0.00,,,,,M*08\r\n
$GNGST,193526.000,23.4,,,,8.3,2.6,12.2*56\r\n
```
Now GGA contains the altitude. RMC contains the speed. GLL contains coordinates but the speed and altitude are missing. The datetime of all messages is the same.
The log shows:
```
id: 192.168.1.11, time: 2025-09-11 23:35:26, lat: 53.53605, lon: 49.35564, course: 0.0, altitude: 141.0, sat: 15, hdop: 1.5
id: 192.168.1.11, time: 2025-09-11 23:35:26, lat: 53.53605, lon: 49.35564, course: 0.0
id: 192.168.1.11, time: 2025-09-11 23:35:26, lat: 53.53605, lon: 49.35564, speed: 1.9, course: 0.0
```
It would be great to update records with the same time and missing data instead of adding new records. Now the diagram for the speed or altitude looks like a comb. And the device properties always shows the altitude 0.0 because the last message RMC does not contains the altitude.