### PR TITLE
Fix stack overflow, flatten various recursive paths

### DIFF
--- a/src/main/java/org/traccar/ProcessingHandler.java
+++ b/src/main/java/org/traccar/ProcessingHandler.java
@@ -211,7 +211,7 @@ public class ProcessingHandler extends ChannelInboundHandlerAdapter implements B
             nextPosition = queue.peek();
         }
         if (nextPosition != null) {
-            processPositionHandlers(ctx, nextPosition);
+            ctx.executor().execute(() -> processPositionHandlers(ctx, nextPosition));
         }
     }
 


### PR DESCRIPTION
This fixes two recursive paths. One of them fixes #5684 and the other fixes potential recursion issues when there are many handlers.

I have tested both setups under my own deployment and the first patch fixes the issue I described in #5684.

---

The call path for processing new points is recursive, with recursion depth
controlled by the depth of the point queue. This results in a stack overflow
under heavy load. Fix it by eliminating the problematic recursive path.

The previous path was:
```
  processNextPosition()
    -> processPositionHandlers()
       -> finishedProcessing()
          -> processNextPosition()
```
The base case was "no more positions to process"; so with a large queue this
could easily exceed the stack limit.

It is now:
```
  processNextPosition()
    -> schedule(processPositionHandlers())

  processPositionHandlers()
  -> finishedProcessing()
     -> processNextPosition()
```

Points are still processed one at a time in order, but each processing job
happens in a new stack.