### PR TITLE
feat: add junixsocket

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ ext {
     nettyVersion = "4.2.6.Final"
     protobufVersion = "4.32.1"
     jxlsVersion = "2.14.0" // version 3 has breaking changes
+    junixsocketVersion = "2.10.1"
 }
 
 def resolveTransitiveVersion = { String root, String group, String name ->
@@ -85,6 +86,8 @@ dependencies {
     implementation "com.mysql:mysql-connector-j:9.4.0"
     implementation "org.mariadb.jdbc:mariadb-java-client:3.5.6"
     implementation "org.postgresql:postgresql:42.7.8"
+    implementation "com.kohlschutter.junixsocket:junixsocket-core:$junixsocketVersion"
+    implementation "com.kohlschutter.junixsocket:junixsocket-mysql:$junixsocketVersion"
     implementation "com.microsoft.sqlserver:mssql-jdbc:13.2.0.jre11"
     implementation "com.zaxxer:HikariCP:7.0.2"
     implementation "io.netty:netty-buffer:$nettyVersion"


### PR DESCRIPTION
Add support for JUnixSocket, allowing database connections via UNIX domain sockets without all the username and password fuzz. For a detailed description on how to configure this, see the following page:

https://kohlschutter.github.io/junixsocket/dependency.html#jdbc

Fixes: https://github.com/traccar/traccar/issues/5687