### PR TITLE
Prevent creation of unnecessary sessions for unauthenticated requests…

### DIFF
--- a/src/main/java/org/traccar/api/security/SecurityRequestFilter.java
+++ b/src/main/java/org/traccar/api/security/SecurityRequestFilter.java
@@ -26,6 +26,7 @@ import org.traccar.storage.StorageException;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -84,16 +85,21 @@ public class SecurityRequestFilter implements ContainerRequestFilter {
                     throw new WebApplicationException(e);
                 }
 
-            } else if (request.getSession() != null) {
+            } else {
 
-                Long userId = (Long) request.getSession().getAttribute(SessionHelper.USER_ID_KEY);
-                Date expiration = (Date) request.getSession().getAttribute(SessionHelper.EXPIRATION_KEY);
-                if (userId != null) {
-                    User user = injector.getInstance(PermissionsService.class).getUser(userId);
-                    if (user != null) {
-                        user.checkDisabled();
-                        statisticsManager.registerRequest(userId);
-                        securityContext = new UserSecurityContext(new UserPrincipal(userId, expiration));
+                HttpSession session = request.getSession(false);
+                if (session != null) {
+                    Long userId = (Long) session.getAttribute(SessionHelper.USER_ID_KEY);
+                    Date expiration = (Date) session.getAttribute(SessionHelper.EXPIRATION_KEY);
+                    if (expiration != null && expiration.before(new Date())) {
+                        session.invalidate();
+                    } else if (userId != null) {
+                        User user = injector.getInstance(PermissionsService.class).getUser(userId);
+                        if (user != null) {
+                            user.checkDisabled();
+                            statisticsManager.registerRequest(userId);
+                            securityContext = new UserSecurityContext(new UserPrincipal(userId, expiration));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Prevent creation of unnecessary sessions for unauthenticated requests and invalidate expired sessions before establishing the security context, ensuring expired logins cannot continue using the API.