### PR TITLE
Restore position validation checks removed in commit 16b8958

### DIFF
--- a/src/main/java/org/traccar/handler/DistanceHandler.java
+++ b/src/main/java/org/traccar/handler/DistanceHandler.java
@@ -57,7 +57,7 @@ public class DistanceHandler extends BasePositionHandler {
             }
             if (filter && last.getLatitude() != 0 && last.getLongitude() != 0) {
                 boolean satisfiesMin = minError == 0 || distance > minError;
-                boolean satisfiesMax = maxError == 0 || distance < maxError;
+                boolean satisfiesMax = maxError == 0 || distance < maxError || position.getValid();
                 if (!satisfiesMin || !satisfiesMax) {
                     position.setValid(last.getValid());
                     position.setLatitude(last.getLatitude());

--- a/src/main/java/org/traccar/handler/GeocoderHandler.java
+++ b/src/main/java/org/traccar/handler/GeocoderHandler.java
@@ -41,7 +41,7 @@ public class GeocoderHandler extends BasePositionHandler {
 
     @Override
     public void onPosition(Position position, Callback callback) {
-        if (!ignorePositions) {
+        if (!ignorePositions && position.getValid()) {
             if (reuseDistance != 0) {
                 Position lastPosition = cacheManager.getPosition(position.getDeviceId());
                 if (lastPosition != null && lastPosition.getAddress() != null

--- a/src/main/java/org/traccar/handler/events/MotionEventHandler.java
+++ b/src/main/java/org/traccar/handler/events/MotionEventHandler.java
@@ -54,6 +54,9 @@ public class MotionEventHandler extends BaseEventHandler {
         if (device == null || !PositionUtil.isLatest(cacheManager, position)) {
             return;
         }
+        if (!position.getValid()) {
+            return;
+        }
 
         TripsConfig tripsConfig = new TripsConfig(new AttributeUtil.CacheProvider(cacheManager, deviceId));
         MotionState state = MotionState.fromDevice(device);

--- a/src/main/java/org/traccar/handler/events/OverspeedEventHandler.java
+++ b/src/main/java/org/traccar/handler/events/OverspeedEventHandler.java
@@ -63,7 +63,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
         if (device == null) {
             return;
         }
-        if (!PositionUtil.isLatest(cacheManager, position)) {
+        if (!PositionUtil.isLatest(cacheManager, position) || !position.getValid()) {
             return;
         }
 


### PR DESCRIPTION
This fixes a critical bug where GPS coordinates get stuck after device reconnection. The issue was introduced in commit 16b895849922efeb81433c1b6e374095307c8f69 which removed position.getValid() checks from multiple handlers.

The bug manifested as:
- Device loses GPS signal and goes offline
- Device moves to a new location while offline
- Device reconnects and sends new position with valid GPS fix
- Coordinates remain stuck at last position before disconnect
- Only speed and course update correctly

Root cause in DistanceHandler:
The distance filter was rejecting valid positions when the calculated distance exceeded maxError, even when the position had a valid GPS fix. The previous logic allowed valid positions to bypass distance filtering, which makes sense - we should trust a valid GPS fix over distance-based filtering.

Changes:
- DistanceHandler: Restore || position.getValid() to distance filter
- GeocoderHandler: Only geocode valid positions to avoid wasting API calls
- MotionEventHandler: Only process motion events from valid positions
- OverspeedEventHandler: Only detect overspeed from valid positions

Tested:
- Coordinates now update correctly after reconnection
- Devices no longer get stuck coordinates
- All unit tests pass