### PR TITLE
Add support for GET method in HTTP SMS client

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1175,6 +1175,15 @@ public final class Keys {
             List.of(KeyType.CONFIG));
 
     /**
+     * SMS HTTP method. Can be 'GET' or 'POST'. Default is 'POST'.
+     * When using GET, the template is appended as query parameters to the URL.
+     */
+    public static final ConfigKey<String> SMS_HTTP_METHOD = new StringConfigKey(
+            "sms.http.method",
+            List.of(KeyType.CONFIG),
+            "POST");
+
+    /**
      * AWS Access Key with SNS permission.
      */
     public static final ConfigKey<String> SMS_AWS_ACCESS = new StringConfigKey(


### PR DESCRIPTION
- Add SMS_HTTP_METHOD configuration key with default value 'POST'
- Update HttpSmsClient to respect the HTTP method configuration
- When method is GET, append template as query parameters to URL
- Maintains backward compatibility with existing POST-based configs

This change allows Traccar to work with SMS APIs that only support GET requests with query parameters (such as voip.ms REST API).