### PR TITLE
Add extended CAN/OBD parameters for Teltonika FMB devices

### DIFF
--- a/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -294,6 +294,38 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
         register(10833, fmbXXX, (p, b) -> p.set("eyeRoll2", b.readShort()));
         register(10834, fmbXXX, (p, b) -> p.set("eyeRoll3", b.readShort()));
         register(10835, fmbXXX, (p, b) -> p.set("eyeRoll4", b.readShort()));
+
+        // CAN/OBD Engine and Oil parameters
+        register(58, fmbXXX, (p, b) -> p.set("oilTemperature", b.readUnsignedByte()));
+        register(102, fmbXXX, (p, b) -> p.set(Position.KEY_HOURS, b.readUnsignedInt() * 60000L));
+        register(103, fmbXXX, (p, b) -> p.set(Position.KEY_HOURS, b.readUnsignedInt() * 60000L));
+        register(1158, fmbXXX, (p, b) -> p.set("oilPressure", b.readUnsignedShort()));
+        register(1159, fmbXXX, (p, b) -> p.set("oilLevel", b.readUnsignedByte()));
+        register(1270, fmbXXX, (p, b) -> p.set("oilTemperature", b.readByte()));
+
+        // CAN Axle load parameters (kg)
+        register(118, fmbXXX, (p, b) -> p.set("axle1Load", b.readUnsignedShort()));
+        register(119, fmbXXX, (p, b) -> p.set("axle2Load", b.readUnsignedShort()));
+        register(120, fmbXXX, (p, b) -> p.set("axle3Load", b.readUnsignedShort()));
+        register(121, fmbXXX, (p, b) -> p.set("axle4Load", b.readUnsignedShort()));
+        register(122, fmbXXX, (p, b) -> p.set("axle5Load", b.readUnsignedShort()));
+        register(1342, fmbXXX, (p, b) -> p.set("axle6Load", b.readUnsignedShort()));
+
+        // AdBlue / DEF fluid level (%)
+        register(1335, fmbXXX, (p, b) -> p.set("adBlueLevel", b.readUnsignedByte()));
+
+        // CAN Air suspension bellow pressures (kPa)
+        register(1336, fmbXXX, (p, b) -> p.set("bellowPressureFR", b.readUnsignedShort() * 0.1));
+        register(1337, fmbXXX, (p, b) -> p.set("bellowPressureFL", b.readUnsignedShort() * 0.1));
+        register(1338, fmbXXX, (p, b) -> p.set("bellowPressureRR", b.readUnsignedShort() * 0.1));
+        register(1339, fmbXXX, (p, b) -> p.set("bellowPressureRL", b.readUnsignedShort() * 0.1));
+
+        // LLS / Escort fuel sensor temperatures (°C, signed)
+        register(202, fmbXXX, (p, b) -> p.set("lls1FuelTemp", b.readByte()));
+        register(204, fmbXXX, (p, b) -> p.set("lls2FuelTemp", b.readByte()));
+        register(211, fmbXXX, (p, b) -> p.set("lls3FuelTemp", b.readByte()));
+        register(213, fmbXXX, (p, b) -> p.set("lls4FuelTemp", b.readByte()));
+        register(215, fmbXXX, (p, b) -> p.set("lls5FuelTemp", b.readByte()));
     }
 
     private void decodeGh3000Parameter(Position position, int id, ByteBuf buf, int length) {


### PR DESCRIPTION
Added support for additional Teltonika CAN/OBD parameters commonly used with LV-CAN and ALL-CAN adapters:

### Engine & Oil Parameters
- Engine hours (IDs 102, 103) - converted from minutes to milliseconds
- Oil temperature (IDs 58, 1270) - OBD and CAN extended
- Oil pressure (ID 1158) in kPa
- Oil level (ID 1159) in percentage

### Vehicle Load Parameters  
- Axle loads 1-6 (IDs 118-122, 1342) in kg

### Fluid Levels
- AdBlue/DEF level (ID 1335) in percentage

### Suspension
- Air suspension bellow pressures FR/FL/RR/RL (IDs 1336-1339) in kPa

### Fuel Sensors
- LLS/Escort fuel sensor temperatures 1-5 (IDs 202, 204, 211, 213, 215) in °C

Reference: https://wiki.teltonika-gps.com/view/FMC150_Teltonika_Data_Sending_Parameters_ID