### PR TITLE
Fix case-sensitive email login issue

### DIFF
--- a/src/main/java/org/traccar/api/security/LoginService.java
+++ b/src/main/java/org/traccar/api/security/LoginService.java
@@ -92,7 +92,7 @@ public class LoginService {
             return null;
         }
 
-        email = email.trim();
+        email = email.trim().toLowerCase();
         User user = storage.getObject(User.class, new Request(
                 new Columns.All(),
                 new Condition.Or(

--- a/src/main/java/org/traccar/model/User.java
+++ b/src/main/java/org/traccar/model/User.java
@@ -55,7 +55,7 @@ public class User extends ExtendedModel implements UserRestrictions, Disableable
     }
 
     public void setEmail(String email) {
-        this.email = email.trim();
+        this.email = email.trim().toLowerCase();
     }
 
     private String phone;


### PR DESCRIPTION
## Summary
  - Normalize email addresses to lowercase when storing (`User.setEmail()`)
  - Normalize email addresses to lowercase when querying (`LoginService.login()`)
  - Ensures case-insensitive login regardless of database type

  Fixes #5723

  ## Test plan
  - [x] Register a user with mixed-case email (e.g., `Test@Example.COM`)
  - [x] Verify login works with different case variations (e.g., `test@example.com`)