### PR TITLE
Fix H02 protocol bounds checking vulnerabilities

### DIFF
--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -516,7 +516,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
         int count = parser.nextInt();
         Network network = new Network();
         String[] values = parser.next().split(",");
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < count && i * 4 + 1 < values.length; i++) {
             network.addCellTower(CellTower.from(
                     mcc, mnc, Integer.parseInt(values[i * 4]), Integer.parseInt(values[i * 4 + 1])));
         }
@@ -580,8 +580,10 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
             Network network = new Network();
             for (String cell : parser.next().split("Y")) {
                 String[] values = cell.split(",");
-                network.addCellTower(CellTower.from(mcc, mnc,
-                        Integer.parseInt(values[0]), Integer.parseInt(values[1]), Integer.parseInt(values[2])));
+                if (values.length >= 3) {
+                    network.addCellTower(CellTower.from(mcc, mnc,
+                            Integer.parseInt(values[0]), Integer.parseInt(values[1]), Integer.parseInt(values[2])));
+                }
             }
 
             position.setNetwork(network);

--- a/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
@@ -276,6 +276,18 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
                 "*HQ,5226073533,SMS,ST906(70SACD)_TQ_V_2.0 2024/06/07\nID:5226073533\nIP:1.2.3.4 5013\nUT:30,30,300\nVOLT:12.9V\nAPN:internet.example.com\nGPS:A-24-23\nGSM:26#"),
                 Position.KEY_RESULT, "ST906(70SACD)_TQ_V_2.0 2024/06/07\nID:5226073533\nIP:1.2.3.4 5013\nUT:30,30,300\nVOLT:12.9V\nAPN:internet.example.com\nGPS:A-24-23\nGSM:26");
 
+        // Test V3 with count higher than actual values (bounds checking)
+        verifyAttributes(decoder, buffer(
+                "*HQ,353111080001055,V3,044855,28403,10,001450,011473,158,-62,0292,0,X,030817,FFFFFBFF#"));
+
+        // Test VP1 with malformed cell data containing empty segments (bounds checking)
+        verifyNotNull(decoder, buffer(
+                "*hq,356327081001239,VP1,V,470,002,Y92,3565,0Y#"));
+
+        // Test VP1 with cell segment having fewer than 3 values (bounds checking)
+        verifyNotNull(decoder, buffer(
+                "*hq,356327081001239,VP1,V,470,002,92,3565Y92Y#"));
+
     }
 
     @Test


### PR DESCRIPTION
Add bounds validation to prevent denial of service attacks through malformed protocol messages:

- decodeV3: Add bounds check for cell tower parsing loop to handle cases where count field exceeds actual array data
- decodeVp1: Add length validation before accessing cell segment indices to handle empty or malformed segments

These vulnerabilities allow denial of service but not remote code execution due to Java's memory safety.

Added test cases for malformed inputs.