### PR TITLE
Add external voltage extraction for h02 protocol (replaces #5703)

### DIFF
--- a/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/H02ProtocolDecoder.java
@@ -155,6 +155,11 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
         processStatus(position, buf.readUnsignedInt());
 
+        if (buf.readableBytes() >= 3) {
+            buf.skipBytes(buf.readableBytes() - 3);
+            position.set(Position.KEY_POWER, buf.readUnsignedShort() / 10.0);
+        }
+
         if (getConfig().getBoolean(Keys.PROTOCOL_ACK.withPrefix(getProtocolName()))) {
             sendResponse(channel, remoteAddress, id, "R12");
         }

--- a/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/H02ProtocolDecoderTest.java
@@ -11,6 +11,10 @@ public class H02ProtocolDecoderTest extends ProtocolTest {
 
         var decoder = inject(new H02ProtocolDecoder(null));
 
+        verifyAttribute(decoder, binary(
+                "24720104244110373303112551337904060000794834000000fffff9ffff001b0a00000ee600ea0f00000000007601"),
+                Position.KEY_POWER, 11.8);
+
         verifyPosition(decoder, buffer(
                 "*HQ,9001000002,V8,213945,A,3542.2043,N,38.6508,W,0.00,170,221025,FBFFF9FF,0,0,0,0,22,31,126,0#"),
                 position("2025-10-22 21:39:45.000", true, 35.70340, -0.64418));


### PR DESCRIPTION
This PR replaces #5703 which was accidentally closed due to a force-push error.

It addresses all maintainer feedback from the previous PR:
- Uses relative `readableBytes()` checks instead of absolute indexes
- Removes duplicate unit tests
- Keeps frame decoder logic configurable via config (no code changes to `H02FrameDecoder`)

Original description below:

---

Following my post in the forum: https://www.traccar.org/forums/topic/automotive-relay-style-cj7320-cj730-lk720-not-displaying-vehicle-battery-voltage/

My code adds support for extracting external/vehicle battery voltage from H02 protocol binary messages with extended format (47 bytes).

The frame decoder now correctly detects and reads extended format messages when configured with `protocol.h02.messageLength=47`.

**Changes**
- **H02ProtocolDecoder.java**: Extract voltage from bytes -3 and -2 (before record number byte) using relative buffer operations
- **H02ProtocolDecoderTest.java**: Add unit test for voltage extraction

**Configuration**
Users with extended format devices should set:
```xml
<entry key='protocol.h02.messageLength'>47</entry>
```
