### PR TITLE
Add missing Device, Position, Server and User API endpoints to openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -415,6 +415,11 @@ paths:
             `uniqueId=333331&uniqieId=44442`
           schema:
             type: string
+        - name: excludeAttributes
+          in: query
+          description: Exclude attributes field from device payload
+          schema:
+            type: boolean
       responses:
         '200':
           description: OK
@@ -506,6 +511,69 @@ paths:
           description: No Content
           content: {}
       x-codegen-request-body-name: body
+  /devices/{id}/image:
+    post:
+      summary: Upload/Update Device image
+      tags:
+        - Devices
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          image/*:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: device.png
+        '400':
+          description: Invalid image type or size
+          content: {}
+        '404':
+          description: Device not found
+          content: {}
+  /devices/share:
+    post:
+      summary: Share device location
+      tags:
+        - Devices
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - deviceId
+                - expiration
+              properties:
+                deviceId:
+                  type: integer
+                expiration:
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: eyJhbGciOi...
+        '403':
+          description: Sharing is disabled or temporary user
+          content: {}
   /groups:
     get:
       summary: Fetch a list of Groups
@@ -734,6 +802,103 @@ paths:
         '404':
           description: Not Found
           content: {}
+  /positions/kml:
+    get:
+      summary: Export Positions as KML
+      tags:
+        - Positions
+      parameters:
+        - name: deviceId
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.google-earth.kml+xml:
+              schema:
+                type: string
+                format: binary
+  /positions/csv:
+    get:
+      summary: Export Positions as CSV
+      tags:
+        - Positions
+      parameters:
+        - name: deviceId
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: geofenceId
+          in: query
+          schema:
+            type: integer
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: OK
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+  /positions/gpx:
+    get:
+      summary: Export Positions as GPX
+      tags:
+        - Positions
+      parameters:
+        - name: deviceId
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: OK
+          content:
+            application/gpx+xml:
+              schema:
+                type: string
+                format: binary
   /server:
     get:
       summary: Fetch Server information
@@ -765,6 +930,103 @@ paths:
               schema:
                 $ref: '#/components/schemas/Server'
       x-codegen-request-body-name: body
+  /server/geocode:
+    get:
+      summary: Reverse geocode coordinates
+      tags:
+        - Server
+      parameters:
+        - name: latitude
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+        - name: longitude
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Reverse geocoding is not enabled
+          content: {}
+  /server/timezones:
+    get:
+      summary: Fetch available timezones
+      tags:
+        - Server
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /server/file/{path}:
+    post:
+      summary: Upload a server file
+      tags:
+        - Server
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '200':
+          description: OK
+          content: {}
+        '400':
+          description: Bad Request
+          content: {}
+  /server/gc:
+    get:
+      summary: Trigger garbage collection
+      tags:
+        - Server
+      responses:
+        '200':
+          description: OK
+          content: {}
+  /server/cache:
+    get:
+      summary: Fetch cache diagnostics
+      tags:
+        - Server
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+  /server/reboot:
+    post:
+      summary: Reboot the server process
+      tags:
+        - Server
+      responses:
+        '200':
+          description: OK
+          content: {}
   /session:
     get:
       summary: Fetch Session information
@@ -925,6 +1187,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
       x-codegen-request-body-name: body
+  /users/totp:
+    post:
+      summary: Generate TOTP secret
+      tags:
+        - Users
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
   /users/{id}:
     put:
       summary: Update a User


### PR DESCRIPTION
While working on a [Laravel PHP Traccae API integration](https://traccar.thingstelemetry.com/introduction/getting-started.html) I noted that some endpoints were missing on `openapi.yaml` file. 

This PR expand `openapi.yaml` by adding several new endpoints that are in the source code.

###  Missing 'excludeAttributes' spec 

- Added a query parameter `excludeAttributes` that that lets clients omit the attributes map from responses.

### Device-related endpoints:

- Added `/devices/{id}/image` endpoint used for uploading or updating a device image.
- Added `/devices/share` endpoint that enable sharing a device's location.

### Position export endpoints: 

- Added `/positions/kml`, `/positions/csv`, and `/positions/gpx` endpoints that wllows exporting device positions in KML, CSV, and GPX formats, respectively.
- See [PositionResource](https://github.com/traccar/traccar/blob/0436abf3bafbfa3bb7f7b489bdf47302124a6398/src/main/java/org/traccar/api/resource/PositionResource.java)

### Server utility endpoints:

- Added several missing server endpoints:
  - `/server/geocode` for reverse geocoding coordinates.
  - `/server/timezones` to fetch available timezones.
  - `/server/file/{path}` for uploading files to the server.
  - `/server/gc` to trigger garbage collection.
  - `/server/cache` to fetch cache diagnostics.
  - `/server/reboot` to reboot the server process.
- See [ServerResource](https://github.com/traccar/traccar/blob/0436abf3bafbfa3bb7f7b489bdf47302124a6398/src/main/java/org/traccar/api/resource/ServerResource.java)

### User authentication:

- Added `/users/totp` endpoint to generate a TOTP secret
-  See [UserResource](https://github.com/traccar/traccar/blob/0436abf3bafbfa3bb7f7b489bdf47302124a6398/src/main/java/org/traccar/api/resource/UserResource.java)

The goal is to ensure that the `openapi.yaml` API documentation reflects all available endpoints in the source code. 

I am assuming the the missing endpoints were not a deliberate omissions. 