### PR TITLE
Fix missing openapi.yaml endpoints and params

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -434,7 +434,6 @@ paths:
           content: {}
     post:
       summary: Create a Device
-      description: Create a new device and link it to the current user
       tags:
         - Devices
       requestBody:
@@ -454,7 +453,6 @@ paths:
   /devices/{id}:
     put:
       summary: Update a Device
-      description: Update the specified device
       tags:
         - Devices
       parameters:
@@ -479,7 +477,6 @@ paths:
       x-codegen-request-body-name: body
     delete:
       summary: Delete a Device
-      description: Delete the specified device
       tags:
         - Devices
       parameters:
@@ -495,7 +492,6 @@ paths:
   /devices/{id}/accumulators:
     put:
       summary: Update total distance and hours of the Device
-      description: Update computed distance and hours for the latest position
       tags:
         - Devices
       parameters:
@@ -518,7 +514,6 @@ paths:
   /devices/{id}/image:
     post:
       summary: Upload/Update Device image
-      description: Upload a device image and return the stored filename
       tags:
         - Devices
       parameters:
@@ -551,7 +546,6 @@ paths:
   /devices/share:
     post:
       summary: Share device location
-      description: Generate a temporary access token for a device share link
       tags:
         - Devices
       requestBody:
@@ -914,7 +908,6 @@ paths:
   /server:
     get:
       summary: Fetch Server information
-      description: Retrieve public server settings and capabilities
       tags:
         - Server
       security: []
@@ -927,7 +920,6 @@ paths:
                 $ref: '#/components/schemas/Server'
     put:
       summary: Update Server information
-      description: Update server settings (admin only)
       tags:
         - Server
       requestBody:
@@ -947,7 +939,6 @@ paths:
   /server/geocode:
     get:
       summary: Reverse geocode coordinates
-      description: Return an readable address for the given latitude and longitude
       tags:
         - Server
       parameters:
@@ -976,7 +967,6 @@ paths:
   /server/timezones:
     get:
       summary: Fetch available timezones
-      description: Return supported timezone identifiers
       tags:
         - Server
       responses:
@@ -991,7 +981,6 @@ paths:
   /server/file/{path}:
     post:
       summary: Upload a server file
-      description: Upload or overwrite a file under the web root (admin only)
       tags:
         - Server
       parameters:
@@ -1017,7 +1006,6 @@ paths:
   /server/gc:
     get:
       summary: Trigger garbage collection
-      description: Request a JVM garbage collection run (admin only)
       tags:
         - Server
       responses:
@@ -1027,7 +1015,6 @@ paths:
   /server/cache:
     get:
       summary: Fetch cache diagnostics
-      description: Return cache status and diagnostics (admin only)
       tags:
         - Server
       responses:
@@ -1040,7 +1027,6 @@ paths:
   /server/reboot:
     post:
       summary: Reboot the server process
-      description: Terminate the process to trigger a restart (admin only)
       tags:
         - Server
       responses:
@@ -1169,7 +1155,6 @@ paths:
   /users:
     get:
       summary: Fetch a list of Users
-      description: Return users visible to the current user. Admin can list all users.
       tags:
         - Users
       parameters:
@@ -1202,7 +1187,6 @@ paths:
           content: {}
     post:
       summary: Create a User
-      description: Register a new user account
       tags:
         - Users
       security: []
@@ -1223,7 +1207,6 @@ paths:
   /users/totp:
     post:
       summary: Generate TOTP secret
-      description: Generate a new TOTP secret key for enrollment
       tags:
         - Users
       security: []
@@ -1237,7 +1220,6 @@ paths:
   /users/{id}:
     put:
       summary: Update a User
-      description: Update the specified user
       tags:
         - Users
       parameters:
@@ -1262,9 +1244,6 @@ paths:
       x-codegen-request-body-name: body
     delete:
       summary: Delete a User
-      description: >- 
-        Completely delete the specified user. Use with caution, 
-        as this action is irreversible.
       tags:
         - Users
       parameters:


### PR DESCRIPTION
This PR improves `openapi.yaml` API documentation for several endpoints.

### Positions endpoint improvements:

- Current `openapi.yaml` state that `deviceId is optional, but requires the from and to parameters when use`, this is not correct as per the latest source code.
https://github.com/traccar/traccar/blob/91a33caf4b28391045607c7b1c1249c5d109fc77/src/main/java/org/traccar/api/resource/PositionResource.java#L81-L92 Clarified that providing `deviceId` without `from` and `to` parameters returns the latest position.
- Added the missing  `geofenceId` query parameters to positions endpoint
https://github.com/traccar/traccar/blob/91a33caf4b28391045607c7b1c1249c5d109fc77/src/main/java/org/traccar/api/resource/PositionResource.java#L66-L68


###  Users endpoint enhancements

- Changed the `/users` `userId` query parameter type from `string` to `integer`, 
- Added  missing `deviceId` and `excludeAttributes` to filter params.
https://github.com/traccar/traccar/blob/91a33caf4b28391045607c7b1c1249c5d109fc77/src/main/java/org/traccar/api/resource/UserResource.java#L72-L74
- Added an empty `security` array to the "Create a User" endpoint  (I saw the @PermitAll).

### Events endpoint update

* Added a missing `404 Not Found` response to the event retrieval endpoint.