### PR TITLE
Native ntfy notification integration

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1301,6 +1301,20 @@ public final class Keys {
             "notificator.telegram.sendLocation",
             List.of(KeyType.CONFIG));
 
+    public static final ConfigKey<String> NOTIFICATOR_NTFY_HTTP_URL = new StringConfigKey(
+            "notificator.ntfy.http.url",
+            List.of(KeyType.CONFIG),
+            "ntfy.sh");
+
+    public static final ConfigKey<String> NOTIFICATOR_NTFY_HTTP_TOKEN = new StringConfigKey(
+            "notificator.ntfy.http.token",
+            List.of(KeyType.CONFIG));
+
+    public static final ConfigKey<String> NOTIFICATOR_NTFY_TOPIC = new StringConfigKey(
+            "notificator.ntfy.topic",
+            List.of(KeyType.CONFIG),
+            "traccar");
+
     /**
      * WhatsApp Cloud API permanent access token.
      */
@@ -2108,5 +2122,4 @@ public final class Keys {
     public static final ConfigKey<Boolean> BROADCAST_SECONDARY = new BooleanConfigKey(
             "broadcast.secondary",
             List.of(KeyType.CONFIG));
-
 }

--- a/src/main/java/org/traccar/notification/NotificatorManager.java
+++ b/src/main/java/org/traccar/notification/NotificatorManager.java
@@ -30,6 +30,7 @@ import org.traccar.notificators.NotificatorTelegram;
 import org.traccar.notificators.NotificatorTraccar;
 import org.traccar.notificators.NotificatorWhatsapp;
 import org.traccar.notificators.NotificatorWeb;
+import org.traccar.notificators.NotificatorNtfy;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -51,7 +52,8 @@ public class NotificatorManager {
             "traccar", NotificatorTraccar.class,
             "telegram", NotificatorTelegram.class,
             "whatsapp", NotificatorWhatsapp.class,
-            "pushover", NotificatorPushover.class);
+            "pushover", NotificatorPushover.class,
+            "ntfy", NotificatorNtfy.class);
 
     private final Injector injector;
 

--- a/src/main/java/org/traccar/notificators/NotificatorNtfy.java
+++ b/src/main/java/org/traccar/notificators/NotificatorNtfy.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 - 2024 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 - 2018 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.notificators;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.codec.binary.Base32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traccar.Main;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+import org.traccar.model.User;
+import org.traccar.notification.MessageException;
+import org.traccar.notification.NotificationFormatter;
+import org.traccar.notification.NotificationMessage;
+
+import java.util.Objects;
+
+@Singleton
+public class NotificatorNtfy extends Notificator {
+    private final Client client;
+    private final String url;
+    private final String token;
+    private final String topic;
+
+    //        see: https://docs.ntfy.sh/subscribe/api/#json-message-format
+    public static class Message {
+        @JsonProperty("time")
+        public long time;
+        @JsonProperty("topic")
+        public String topic;
+        @JsonProperty("title")
+        public String title;
+        @JsonProperty("message")
+        public String message;
+        @JsonProperty("priority")
+        public int priority;
+
+        public Message(long time, String topic, String title, String message, int priority) {
+            this.time = time;
+            this.topic = topic;
+            this.title = title;
+            this.message = message;
+            this.priority = priority;
+        }
+    }
+
+    @Inject
+    public NotificatorNtfy(
+            Config config,
+            NotificationFormatter notificationFormatter,
+            Client client
+    ) {
+        super(notificationFormatter);
+        this.client = client;
+        url = config.getString(Keys.NOTIFICATOR_NTFY_HTTP_URL);
+        token = config.getString(Keys.NOTIFICATOR_NTFY_HTTP_TOKEN);
+        topic = config.getString(Keys.NOTIFICATOR_NTFY_TOPIC);
+    }
+
+    @Override
+    public void send(User user, NotificationMessage message, Event event, Position position) throws MessageException {
+        Invocation.Builder request = client.target(url).request();
+        if (this.token != null) {
+            // see: https://docs.ntfy.sh/publish/#authentication
+            request = request.header("Authorization", "Bearer " + token);
+        }
+
+        String topicToUse = Objects.requireNonNullElseGet(
+                user.getString("ntfyTopic"),
+                () -> topic
+                        .replace("{uid}", String.valueOf(user.getId()))
+                        .replace("{email_base32}", new Base32().encodeAsString(
+                                user.getEmail().getBytes()).replace("=", "")));
+
+        try (Response response = request.post(Entity.json(new Message(
+                System.currentTimeMillis(),
+                topicToUse,
+                message.subject(),
+                message.digest(),
+                message.priority() ? 5 : 3
+        )))) {
+            if (response.getStatus() / 100 != 2) {
+                throw new MessageException(response.readEntity(String.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
PR for adding ntfy support as a native integration, which allows it to be used in conjunction with the sms http integration as in my use case I need to use both.

```
Support for ntfy as a native integration
- Publishes notifications to either a global ntfy topic using Traccar users id, or base32 encoded email address, or per user ntfy topic defined in user attributes
- Support for ntfy message priority
- Support for editing ntfy topic in user attributes UI
```

Some server config is required
```
<entry key='notificator.ntfy.http.url'>https://ntfy.{{ cn }}</entry>
<entry key='notificator.ntfy.http.token'>{{ ntfy_traccar_token }}</entry>
```

Then the users' can have the ntfy topic as an attribute, or a more generic solution can be done like;

```
<entry key='notificator.ntfy.topic'>tc-{uid}</entry>
```

Let me know if there are some changes you would like to be able to merge this in?
I can also update some documentation somewhere?
Also there is an associated PR for the traccar-web project that I can raise if you agree that this is something that could be merged.

thanks
