### PR TITLE
Fix OpenID administrator flag not syncing for existing users

### DIFF
--- a/src/main/java/org/traccar/api/security/LoginService.java
+++ b/src/main/java/org/traccar/api/security/LoginService.java
@@ -35,6 +35,7 @@ import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.util.Objects;
 
 @Singleton
 public class LoginService {
@@ -130,18 +131,16 @@ public class LoginService {
             user.setFixedEmail(true);
             user.setAdministrator(administrator);
             user.setId(storage.addObject(user, new Request(new Columns.Exclude("id"))));
-        } else {
 
-            if (!java.util.Objects.equals(name, user.getName())
-                    || user.getAdministrator() != administrator) {
+        } else if (!Objects.equals(name, user.getName())
+                || user.getAdministrator() != administrator) {
 
-                user.setName(name);
-                user.setAdministrator(administrator);
+            user.setName(name);
+            user.setAdministrator(administrator);
 
-                storage.updateObject(user, new Request(
-                        new Columns.Include("name", "administrator"),
-                        new Condition.Equals("id", user.getId())));
-            }
+            storage.updateObject(user, new Request(
+                    new Columns.Include("name", "administrator"),
+                    new Condition.Equals("id", user.getId())));
         }
 
         checkUserEnabled(user);


### PR DESCRIPTION
###Issue:

When OpenID group membership changes, the administrator flag
is only set during initial user creation and is not updated
for existing users on subsequent logins.

###Steps to reproduce:

1. Login with a user in adminGroups (administrator = true)
2. Remove the user from adminGroups in the OpenID provider
3. Login again
4. Administrator flag remains unchanged

###Fix:

Synchronize the administrator flag on every OpenID login
by comparing and updating it if necessary.