### PR TITLE
ttnhttp: Add downlink support

### DIFF
--- a/src/main/java/org/traccar/command/CommandSenderManager.java
+++ b/src/main/java/org/traccar/command/CommandSenderManager.java
@@ -30,7 +30,8 @@ public class CommandSenderManager {
     private static final Map<String, Class<? extends CommandSender>> SENDERS_ALL = Map.of(
             "firebase", FirebaseCommandSender.class,
             "traccar", TraccarCommandSender.class,
-            "findHub", FindHubCommandSender.class);
+            "findHub", FindHubCommandSender.class,
+            "ttnhttp", TtnHttpCommandSender.class);
 
     private final Config config;
     private final Injector injector;
@@ -51,6 +52,8 @@ public class CommandSenderManager {
             } else if (config.hasKey(Keys.NOTIFICATOR_TRACCAR_KEY)) {
                 return injector.getInstance(TraccarCommandSender.class);
             }
+        } else if (device.hasAttribute("X-Downlink-Apikey")) {
+            return injector.getInstance(TtnHttpCommandSender.class);
         }
         return null;
     }

--- a/src/main/java/org/traccar/command/CommandSenderManager.java
+++ b/src/main/java/org/traccar/command/CommandSenderManager.java
@@ -52,7 +52,7 @@ public class CommandSenderManager {
             } else if (config.hasKey(Keys.NOTIFICATOR_TRACCAR_KEY)) {
                 return injector.getInstance(TraccarCommandSender.class);
             }
-        } else if (device.hasAttribute("X-Downlink-Apikey")) {
+        } else if (device.hasAttribute(Keys.COMMAND_TTNHTTP_APIKEY.getKey())) {
             return injector.getInstance(TtnHttpCommandSender.class);
         }
         return null;

--- a/src/main/java/org/traccar/command/TtnHttpCommandSender.java
+++ b/src/main/java/org/traccar/command/TtnHttpCommandSender.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Stephen Horvath (me@stevetech.au)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.command;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traccar.model.Command;
+import org.traccar.model.Device;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+@Singleton
+public class TtnHttpCommandSender implements CommandSender {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TtnHttpCommandSender.class);
+
+    private final Client client;
+
+    @Inject
+    public TtnHttpCommandSender(Client client) throws IOException {
+        this.client = client;
+    }
+
+    @Override
+    public Collection<String> getSupportedCommands() {
+        return List.of(Command.TYPE_CUSTOM);
+    }
+
+    @Override
+    public void sendCommand(Device device, Command command) throws Exception {
+        if (!device.hasAttribute("X-Downlink-Apikey")) {
+            throw new RuntimeException("Missing X-Downlink-Apikey header");
+        }
+        String key = device.getString("X-Downlink-Apikey");
+
+        String url = device.getString("X-Downlink-Push");
+        if (command.getBoolean(Command.KEY_NO_QUEUE) && device.hasAttribute("X-Downlink-Replace")) {
+            url = device.getString("X-Downlink-Replace");
+        }
+        if (url == null) {
+            throw new RuntimeException("Missing X-Downlink-Push or X-Downlink-Replace header");
+        }
+
+        String data = command.getString(Command.KEY_DATA);
+        if (data == null) {
+            throw new RuntimeException("Missing command data");
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode root = mapper.createObjectNode();
+        ArrayNode downlinks = root.putArray("downlinks");
+        if (!data.isEmpty()) {
+            ObjectNode downlink = downlinks.addObject();
+            try {
+                downlink.set("decoded_payload", mapper.readTree(data));
+            } catch (IOException e) {
+                ObjectNode payload = downlink.putObject("decoded_payload");
+                payload.put("command", data);
+            }
+        }
+        String message = mapper.writeValueAsString(root);
+
+        var request = client.target(url).request().header("Authorization", "Bearer " + key);
+        try {
+            request.post(Entity.json(message));
+        } catch (Exception e) {
+            LOGGER.warn("Command push error", e);
+        }
+    }
+
+}

--- a/src/main/java/org/traccar/command/TtnHttpCommandSender.java
+++ b/src/main/java/org/traccar/command/TtnHttpCommandSender.java
@@ -56,17 +56,9 @@ public class TtnHttpCommandSender implements CommandSender {
         }
         String key = device.getString(Keys.COMMAND_TTNHTTP_APIKEY.getKey());
 
-        String url;
-        if (command.getBoolean(Command.KEY_NO_QUEUE)) {
-            url = device.getString(Keys.COMMAND_TTNHTTP_REPLACEURL.getKey());
-            if (url == null) {
-                throw new RuntimeException("Missing " + Keys.COMMAND_TTNHTTP_REPLACEURL.getKey() + " attribute");
-            }
-        } else {
-            url = device.getString(Keys.COMMAND_TTNHTTP_PUSHURL.getKey());
-            if (url == null) {
-                throw new RuntimeException("Missing " + Keys.COMMAND_TTNHTTP_PUSHURL.getKey() + " attribute");
-            }
+        String url = device.getString(Keys.COMMAND_TTNHTTP_PUSHURL.getKey());
+        if (url == null) {
+            throw new RuntimeException("Missing " + Keys.COMMAND_TTNHTTP_PUSHURL.getKey() + " attribute");
         }
 
         String data = command.getString(Command.KEY_DATA);

--- a/src/main/java/org/traccar/command/TtnHttpCommandSender.java
+++ b/src/main/java/org/traccar/command/TtnHttpCommandSender.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.traccar.config.Keys;
 import org.traccar.model.Command;
 import org.traccar.model.Device;
 
@@ -50,17 +51,22 @@ public class TtnHttpCommandSender implements CommandSender {
 
     @Override
     public void sendCommand(Device device, Command command) throws Exception {
-        if (!device.hasAttribute("X-Downlink-Apikey")) {
-            throw new RuntimeException("Missing X-Downlink-Apikey header");
+        if (!device.hasAttribute(Keys.COMMAND_TTNHTTP_APIKEY.getKey())) {
+            throw new RuntimeException("Missing " + Keys.COMMAND_TTNHTTP_APIKEY.getKey() + " attribute");
         }
-        String key = device.getString("X-Downlink-Apikey");
+        String key = device.getString(Keys.COMMAND_TTNHTTP_APIKEY.getKey());
 
-        String url = device.getString("X-Downlink-Push");
-        if (command.getBoolean(Command.KEY_NO_QUEUE) && device.hasAttribute("X-Downlink-Replace")) {
-            url = device.getString("X-Downlink-Replace");
-        }
-        if (url == null) {
-            throw new RuntimeException("Missing X-Downlink-Push or X-Downlink-Replace header");
+        String url;
+        if (command.getBoolean(Command.KEY_NO_QUEUE)) {
+            url = device.getString(Keys.COMMAND_TTNHTTP_REPLACEURL.getKey());
+            if (url == null) {
+                throw new RuntimeException("Missing " + Keys.COMMAND_TTNHTTP_REPLACEURL.getKey() + " attribute");
+            }
+        } else {
+            url = device.getString(Keys.COMMAND_TTNHTTP_PUSHURL.getKey());
+            if (url == null) {
+                throw new RuntimeException("Missing " + Keys.COMMAND_TTNHTTP_PUSHURL.getKey() + " attribute");
+            }
         }
 
         String data = command.getString(Command.KEY_DATA);

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -2111,4 +2111,25 @@ public final class Keys {
             "broadcast.secondary",
             List.of(KeyType.CONFIG));
 
+    /**
+     * The Things Network Downlink API key.
+     */
+    public static final ConfigKey<String> COMMAND_TTNHTTP_APIKEY = new StringConfigKey(
+            "command.ttnhttp.apiKey",
+            List.of(KeyType.DEVICE));
+
+    /**
+     * The Things Network Downlink push URL.
+     */
+    public static final ConfigKey<String> COMMAND_TTNHTTP_PUSHURL = new StringConfigKey(
+            "command.ttnhttp.pushUrl",
+            List.of(KeyType.DEVICE));
+
+    /**
+     * The Things Network Downlink replace URL.
+     */
+    public static final ConfigKey<String> COMMAND_TTNHTTP_REPLACEURL = new StringConfigKey(
+            "command.ttnhttp.replaceUrl",
+            List.of(KeyType.DEVICE));
+
 }

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -2125,11 +2125,4 @@ public final class Keys {
             "command.ttnhttp.pushUrl",
             List.of(KeyType.DEVICE));
 
-    /**
-     * The Things Network Downlink replace URL.
-     */
-    public static final ConfigKey<String> COMMAND_TTNHTTP_REPLACEURL = new StringConfigKey(
-            "command.ttnhttp.replaceUrl",
-            List.of(KeyType.DEVICE));
-
 }

--- a/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
@@ -68,11 +68,11 @@ public class TtnHttpProtocolDecoder extends BaseHttpProtocolDecoder {
         Device device = getCacheManager().getObject(Device.class, deviceSession.getDeviceId());
         if (device != null) {
             String apiKey = request.headers().get("X-Downlink-Apikey");
-            if (apiKey != null) {
+            if (apiKey != null && !apiKey.equals(device.getString(Keys.COMMAND_TTNHTTP_APIKEY.getKey()))) {
                 device.set(Keys.COMMAND_TTNHTTP_APIKEY.getKey(), apiKey);
             }
             String push = request.headers().get("X-Downlink-Push");
-            if (push != null) {
+            if (push != null && !push.equals(device.getString(Keys.COMMAND_TTNHTTP_PUSHURL.getKey()))) {
                 device.set(Keys.COMMAND_TTNHTTP_PUSHURL.getKey(), push);
             }
         }

--- a/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
@@ -75,10 +75,6 @@ public class TtnHttpProtocolDecoder extends BaseHttpProtocolDecoder {
             if (push != null) {
                 device.set(Keys.COMMAND_TTNHTTP_PUSHURL.getKey(), push);
             }
-            String replace = request.headers().get("X-Downlink-Replace");
-            if (replace != null) {
-                device.set(Keys.COMMAND_TTNHTTP_REPLACEURL.getKey(), replace);
-            }
         }
 
         Position position = new Position(getProtocolName());

--- a/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
@@ -28,6 +28,7 @@ import jakarta.json.JsonValue;
 import org.traccar.BaseHttpProtocolDecoder;
 import org.traccar.Protocol;
 import org.traccar.helper.DateUtil;
+import org.traccar.model.Device;
 import org.traccar.model.Network;
 import org.traccar.model.Position;
 import org.traccar.model.WifiAccessPoint;
@@ -61,6 +62,16 @@ public class TtnHttpProtocolDecoder extends BaseHttpProtocolDecoder {
         if (deviceSession == null) {
             sendResponse(channel, HttpResponseStatus.NOT_FOUND);
             return null;
+        }
+
+        Device device = getCacheManager().getObject(Device.class, deviceSession.getDeviceId());
+        if (device != null) {
+            for (String header : new String[] {"X-Downlink-Apikey", "X-Downlink-Push", "X-Downlink-Replace"}) {
+                String value = request.headers().get(header);
+                if (value != null) {
+                    device.set(header, value);
+                }
+            }
         }
 
         Position position = new Position(getProtocolName());

--- a/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TtnHttpProtocolDecoder.java
@@ -27,6 +27,7 @@ import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import org.traccar.BaseHttpProtocolDecoder;
 import org.traccar.Protocol;
+import org.traccar.config.Keys;
 import org.traccar.helper.DateUtil;
 import org.traccar.model.Device;
 import org.traccar.model.Network;
@@ -66,11 +67,17 @@ public class TtnHttpProtocolDecoder extends BaseHttpProtocolDecoder {
 
         Device device = getCacheManager().getObject(Device.class, deviceSession.getDeviceId());
         if (device != null) {
-            for (String header : new String[] {"X-Downlink-Apikey", "X-Downlink-Push", "X-Downlink-Replace"}) {
-                String value = request.headers().get(header);
-                if (value != null) {
-                    device.set(header, value);
-                }
+            String apiKey = request.headers().get("X-Downlink-Apikey");
+            if (apiKey != null) {
+                device.set(Keys.COMMAND_TTNHTTP_APIKEY.getKey(), apiKey);
+            }
+            String push = request.headers().get("X-Downlink-Push");
+            if (push != null) {
+                device.set(Keys.COMMAND_TTNHTTP_PUSHURL.getKey(), push);
+            }
+            String replace = request.headers().get("X-Downlink-Replace");
+            if (replace != null) {
+                device.set(Keys.COMMAND_TTNHTTP_REPLACEURL.getKey(), replace);
             }
         }
 


### PR DESCRIPTION
Hi, The Things Network provides an API for [scheduling 'downlinks'](https://www.thethingsindustries.com/docs/integrations/webhooks/scheduling-downlinks/), which are messages sent back to the device (e.g. to sound a buzzer, etc.).

To make the configuration easy, the HTTP headers of the normal 'uplink' webhooks can optionally provide Traccar an API key (`X-Downlink-Apikey`) and 2 URLs to POST to (`X-Downlink-Push` - pushes to the queue, `X-Downlink-Replace` - replaces the queue [not used]). I've implemented this auto configuration, but they can also be manually configured from the device attributes.

I am unsure if this is the best way of passing those headers from the decoder to the command sender (though it does work), but I am happy to receive feedback.

As there are no standard commands, only custom commands are handled. If the command data entered by the user is valid JSON, then it is passed straight to TTN's downlink encoder, otherwise the data is wrapped into `{"command": "<data>"}` to become valid JSON.

Thanks,
Steve