### PR TITLE
Gt06ProtocolDecoder: populate power from adc1 if power is not present

### DIFF
--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -1159,7 +1159,14 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
 
             if (subType == 0x00) {
 
-                position.set(Position.PREFIX_ADC + 1, buf.readUnsignedShort() * 0.01);
+                double value = buf.readUnsignedShort() * 0.01;
+
+                position.set(Position.PREFIX_ADC + 1, value);
+
+                if (value > 0 && position.getAttributes().get(Position.KEY_POWER) == null) {
+                    position.set(Position.KEY_POWER, value);
+                }
+
                 return position;
 
             } else if (subType == 0x04) {


### PR DESCRIPTION
Set power from adc1 for MSG_INFO (subType 0x00) when power is not already present.