### PR TITLE
Use Russian date format in ru notification templates

### DIFF
--- a/templates/notifications/ru/alarm.vm
+++ b/templates/notifications/ru/alarm.vm
@@ -1,13 +1,13 @@
 #set($subject = "$esc.html($device.name): тревога!")
 #set($alarmKey = $event.getString('alarm'))
 #set($alarmName = $translations.get("alarm${alarmKey.substring(0, 1).toUpperCase()}${alarmKey.substring(1)}"))
-#set($digest = "$device.name тревога: $alarmName в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name тревога: $alarmName в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Тревога: $esc.html($alarmName)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/commandResult.vm
+++ b/templates/notifications/ru/commandResult.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): получен результат команды")
-#set($digest = "$device.name получен результат команды: $position.getString('result') в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name получен результат команды: $position.getString('result') в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Результат: $esc.html($position.getString('result'))<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Ссылка: <a href="$webUrl/event/$event.id">$webUrl/event/$event.id</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/deviceFuelDrop.vm
+++ b/templates/notifications/ru/deviceFuelDrop.vm
@@ -1,10 +1,10 @@
 #set($subject = "$esc.html($device.name): сброс топлива)
-#set($digest = "$device.name сброс топлива в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name сброс топлива в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Количество до: $esc.html($event.attributes.before)<br>
 Количество после: $esc.html($event.attributes.after)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>

--- a/templates/notifications/ru/deviceFuelIncrease.vm
+++ b/templates/notifications/ru/deviceFuelIncrease.vm
@@ -1,10 +1,10 @@
 #set($subject = "$esc.html($device.name): увеличение расхода топлива")
-#set($digest = "$device.name увеличение расхода топлива в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name увеличение расхода топлива в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Количество до: $esc.html($event.attributes.before)<br>
 Количество после: $esc.html($event.attributes.after)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>

--- a/templates/notifications/ru/deviceInactive.vm
+++ b/templates/notifications/ru/deviceInactive.vm
@@ -1,13 +1,13 @@
 #set($subject = "$esc.html($device.name): неактивно")
 #set($lastUpdate = $dateTool.getDate())
 #set($ignore = $lastUpdate.setTime($event.getLong('lastUpdate')))
-#set($digest = "$device.name неактивно с $dateTool.format('yyyy-MM-dd HH:mm:ss', $lastUpdate, $locale, $timezone)")
+#set($digest = "$device.name неактивно с $dateTool.format('dd.MM.yyyy HH:mm:ss', $lastUpdate, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Неактивно<br>
-Последнее обновление: $dateTool.format('yyyy-MM-dd HH:mm:ss', $lastUpdate, $locale, $timezone)<br>
+Последнее обновление: $dateTool.format('dd.MM.yyyy HH:mm:ss', $lastUpdate, $locale, $timezone)<br>
 Ссылка: <a href="$webUrl/event/$event.id">$webUrl/event/$event.id</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/deviceMoving.vm
+++ b/templates/notifications/ru/deviceMoving.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): движется")
-#set($digest = "$device.name движется с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name движется с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Движется<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/deviceOffline.vm
+++ b/templates/notifications/ru/deviceOffline.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): не в сети")
-#set($digest = "$device.name не в сети с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name не в сети с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Не в сети<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>
 </body>

--- a/templates/notifications/ru/deviceOnline.vm
+++ b/templates/notifications/ru/deviceOnline.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): в сети")
-#set($digest = "$device.name в сети с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name в сети с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 В сети<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>
 </body>

--- a/templates/notifications/ru/deviceOverspeed.vm
+++ b/templates/notifications/ru/deviceOverspeed.vm
@@ -8,13 +8,13 @@
 #else
 #set($speedString = $numberTool.format('0.0 kn', $position.speed))
 #end
-#set($digest = "$device.name превышение сторости $speedString#{if}($geofence) в $geofence.name#{else}#{end} с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name превышение сторости $speedString#{if}($geofence) в $geofence.name#{else}#{end} с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Превышение сторости: $speedString#{if}($geofence) в $esc.html($geofence.name)#{else}#{end}<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/deviceStopped.vm
+++ b/templates/notifications/ru/deviceStopped.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): остановлено")
-#set($digest = "$device.name остановлено с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name остановлено с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Остановилено<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/deviceUnknown.vm
+++ b/templates/notifications/ru/deviceUnknown.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): статус неизвестен")
-#set($digest = "$device.name статус неизвестен с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name статус неизвестен с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Статус неизвестен<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>
 </body>

--- a/templates/notifications/ru/driverChanged.vm
+++ b/templates/notifications/ru/driverChanged.vm
@@ -4,12 +4,12 @@
 #else
 #set($driverName = $event.getString('driverUniqueId'))
 #end
-#set($digest = "Водитель $driverName изменился на $device.name с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "Водитель $driverName изменился на $device.name с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 Водитель: $esc.html($driverName)<br>
 <br>

--- a/templates/notifications/ru/geofenceEnter.vm
+++ b/templates/notifications/ru/geofenceEnter.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): вошёл в геозону")
-#set($digest = "$device.name вошёл в геозону $geofence.name в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name вошёл в геозону $geofence.name в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Вошел в геозону: $esc.html($geofence.name)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/geofenceExit.vm
+++ b/templates/notifications/ru/geofenceExit.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): вышел из геозоны")
-#set($digest = "$device.name вышел из геозоны $geofence.name в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name вышел из геозоны $geofence.name в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Вышел из геозоны: $esc.html($geofence.name)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/ignitionOff.vm
+++ b/templates/notifications/ru/ignitionOff.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): Зажигание ВЫКЛЮЧЕНО")
-#set($digest = "$device.name Зажигание ВЫКЛЮЧЕНО в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name Зажигание ВЫКЛЮЧЕНО в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Зажигание ВЫКЛЮЧЕНО<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/ignitionOn.vm
+++ b/templates/notifications/ru/ignitionOn.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): Зажигание ВКЛЮЧЕНО")
-#set($digest = "$device.name Зажигание ВКЛЮЧЕНО в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name Зажигание ВКЛЮЧЕНО в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Зажигание ВКЛЮЧЕНО<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/maintenance.vm
+++ b/templates/notifications/ru/maintenance.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): требуется техническое обслуживание")
-#set($digest = "$device.name техническое обслуживание $maintenance.name требуется с $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name техническое обслуживание $maintenance.name требуется с $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Требуется техническое обслуживание: $esc.html($maintenance.name)<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Координаты: <a href="$webUrl/event/$event.id">#{if}($position.address)$position.address#{else}$position.latitude&deg;, $position.longitude&deg;#{end}</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/media.vm
+++ b/templates/notifications/ru/media.vm
@@ -1,12 +1,12 @@
 #set($subject = "$esc.html($device.name): получен медиафайл")
-#set($digest = "$device.name $event.getString('media') получен: $event.getString('file') в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "$device.name $event.getString('media') получен: $event.getString('file') в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Тип: $esc.html($event.getString('media'))<br>
 Файл: <a href="$webUrl/api/media/$device.uniqueId/$esc.html($event.getString('file'))">$esc.html($event.getString('file'))</a><br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 Ссылка: <a href="$webUrl/event/$event.id">$webUrl/event/$event.id</a><br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>

--- a/templates/notifications/ru/queuedCommandSent.vm
+++ b/templates/notifications/ru/queuedCommandSent.vm
@@ -1,11 +1,11 @@
 #set($subject = "$esc.html($device.name): отправленная команда в очереди")
-#set($digest = "Команда, поставленная в очередь, отправлена на устройство $device.name в $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
+#set($digest = "Команда, поставленная в очередь, отправлена на устройство $device.name в $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>
 <body>
 Устройство: $esc.html($device.name)<br>
 Отправленная команда в очереди<br>
-Время: $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
+Время: $dateTool.format('dd.MM.yyyy HH:mm:ss', $event.eventTime, $locale, $timezone)<br>
 <br>
 <a href="$webUrl/settings/notifications?token=$token">Отписаться</a>
 </body>


### PR DESCRIPTION
- What: Change date formatting in Russian notification templates from yyyy-MM-dd HH:mm:ss to dd.MM.yyyy HH:mm:ss.
- Why: ISO format is uncommon for Russian locale; templates already specify $locale/$timezone, only format string is adjusted.