### PR TITLE
Implement daily summary scheduled report

### DIFF
--- a/src/main/java/org/traccar/schedule/TaskReports.java
+++ b/src/main/java/org/traccar/schedule/TaskReports.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -129,7 +128,7 @@ public class TaskReports extends SingleScheduleTask {
         if (!groupIdsPart.isEmpty()) {
             url.append(groupIdsPart).append('&');
         }
-        if (Objects.equals(report.getType(), "summary") && report.hasAttribute("daily")) {
+        if (report.hasAttribute("daily")) {
             url.append("daily=").append(report.getBoolean("daily")).append('&');
         }
         url.append("from=").append(URLEncoder.encode(DateUtil.formatDate(from, true), StandardCharsets.UTF_8));


### PR DESCRIPTION
**Purpose:** Scheduled summary report only supports type `Summary` and not type `Daily Summary`.

**Solution:** This PR implements scheduled Summary report type `Daily Summary` in addition to type `Summary`.