### PR TITLE
Add support for H08E external battery voltage readings

### DIFF
--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -913,6 +913,14 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                     int moduleLength = buf.readUnsignedByte();
                     switch (moduleType) {
                         case 0x0018 -> position.set(Position.KEY_BATTERY, buf.readUnsignedShort() / 100.0);
+                        case 0x0027 -> {
+                            // H08E - possible 1 or 2 bytes (maybe 4)
+                            long value = 0;
+                            for (int i = 0; i < moduleLength && buf.isReadable(); i++) {
+                                value = (value << 8) | buf.readUnsignedByte();
+                            }
+                            position.set(Position.KEY_POWER, value / 100.0);
+                        }
                         case 0x0032 -> position.set("startupStatus", buf.readUnsignedByte());
                         case 0x006A -> position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());
                         default -> buf.skipBytes(moduleLength);

--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -913,14 +913,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                     int moduleLength = buf.readUnsignedByte();
                     switch (moduleType) {
                         case 0x0018 -> position.set(Position.KEY_BATTERY, buf.readUnsignedShort() / 100.0);
-                        case 0x0027 -> {
-                            // H08E - possible 1 or 2 bytes (maybe 4)
-                            long value = 0;
-                            for (int i = 0; i < moduleLength && buf.isReadable(); i++) {
-                                value = (value << 8) | buf.readUnsignedByte();
-                            }
-                            position.set(Position.KEY_POWER, value / 100.0);
-                        }
+                        case 0x0027 -> position.set(Position.KEY_POWER, buf.readUnsignedShort() / 100.0);
                         case 0x0032 -> position.set("startupStatus", buf.readUnsignedByte());
                         case 0x006A -> position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());
                         default -> buf.skipBytes(moduleLength);

--- a/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
@@ -238,6 +238,10 @@ public class Gt06ProtocolDecoderTest extends ProtocolTest {
                 Position.KEY_BATTERY_LEVEL, 100);
 
         verifyAttribute(decoder, binary(
+                "78780f3604060200020027021388004c80370d0a"),
+                Position.KEY_POWER, 50.00);
+
+        verifyAttribute(decoder, binary(
                 "7979000e941b02084277efef350303eadaed0d0a"),
                 Position.KEY_DRIVER_UNIQUE_ID, "4277efef");
 


### PR DESCRIPTION
Device info: https://www.traccar.org/forums/topic/unknown-gt06s-h08e-device/#post-83291
No internal battery (Always 100%).
External battery voltage stored in extended statistics message (module type 0x27, uint16_t, maybe 1 or 4 byte possible too)

Alternative (short) variant:
`case 0x0027 -> position.set(Position.KEY_POWER, buf.readUnsignedShort() / 100.0);`