### PR TITLE
Fix: Handle missing alarmName in notification template

### DIFF
--- a/templates/notifications/en/alarm.vm
+++ b/templates/notifications/en/alarm.vm
@@ -1,6 +1,16 @@
 #set($subject = "$esc.html($device.name): alarm!")
 #set($alarmKey = $event.getString('alarm'))
-#set($alarmName = $translations.get("alarm${alarmKey.substring(0, 1).toUpperCase()}${alarmKey.substring(1)}"))
+#if(!$alarmKey)
+  #set($alarmKey = $event.getString('alarms'))
+#end
+#if($alarmKey)
+  #set($alarmName = $translations.get("alarm${alarmKey.substring(0, 1).toUpperCase()}${alarmKey.substring(1)}"))
+  #if(!$alarmName)
+    #set($alarmName = $alarmKey)
+  #end
+#else
+  #set($alarmName = "alarm")
+#end
 #set($digest = "$device.name alarm: $alarmName at $dateTool.format('yyyy-MM-dd HH:mm:ss', $event.eventTime, $locale, $timezone)")
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
### Problem
The notification was showing `$alarmName` as a literal string instead of the actual alarm type. This happened because the template logic failed to resolve `$alarmKey` and `$alarmName` when the expected 'alarm' attribute was missing or when the translation key didn't exist.

### Solution
- Added a fallback check for the `alarms` attribute if `alarm` is not present.
- Added defensive logic to use the raw `alarmKey` if a specific translation is not found in the translation files.
- Provided a default fallback string `"alarm"` to ensure the UI never shows the literal `$alarmName` placeholder.

### Changes
- Modified `templates/notifications/en/alarm.vm` to include these safety checks and fallbacks.
