### PR TITLE
Invert blocked status check in EelinkProtocolDecoder

### DIFF
--- a/src/main/java/org/traccar/protocol/EelinkProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/EelinkProtocolDecoder.java
@@ -264,7 +264,7 @@ public class EelinkProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.KEY_MOTION, BitUtil.check(status, 9));
             }
             if (BitUtil.check(status, 5)) {
-                position.set(Position.KEY_BLOCKED, BitUtil.check(status, 6));
+                position.set(Position.KEY_BLOCKED, !BitUtil.check(status, 6));
             }
             if (BitUtil.check(status, 7)) {
                 position.set(Position.KEY_CHARGE, BitUtil.check(status, 8));


### PR DESCRIPTION
Status bytes sometimes get interpreted incorrectly because of bit 6 (for blocked status) being processed incorrectly. In `decodeNew`, it is not the same as in `decodeStatus`. I assume this was done because of the change in firmware documentation by Eelink.

 I know they describe it weird, which could lead you to believe that they flipped the functionality, but this is not the case. They kept it the same.

I tested this with some devices where some packets show `blocked = true` and some show `blocked = false`. The change that I made fixes this to always show the correct status.