### PR TITLE
fix: RFC 8414 §3 path-suffixed well-known URL for path-based issuers

### DIFF
--- a/src/main/java/org/traccar/web/WellKnownServlet.java
+++ b/src/main/java/org/traccar/web/WellKnownServlet.java
@@ -49,7 +49,7 @@ public class WellKnownServlet extends HttpServlet {
             case "/openid-configuration" -> openIdConfiguration();
             case "/oauth-authorization-server" -> authorizationServerConfiguration();
             case "/oauth-protected-resource" -> protectedResourceConfiguration();
-            default -> null;
+            default -> path.startsWith("/oauth-authorization-server") ? authorizationServerConfiguration() : null;
         };
         if (payload != null) {
             resp.setContentType("application/json");


### PR DESCRIPTION
`WellKnownServlet` only serves `/.well-known/oauth-authorization-server`. 

RFC 8414 §3 requires the path-suffixed form (`/.well-known/oauth-authorization-server/api/oidc`)
when the issuer has a path component. 

Strict clients construct this URL and get a 404.