### PR TITLE
correct battery voltage for x3tech xt40 devices

### DIFF
--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -237,7 +237,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
             case MSG_LBS_ALARM:
                 return true;
             case MSG_GPS_LBS_2:
-                return model != null && Set.of("NT20", "VL100").contains(model.toUpperCase());
+                return model != null && Set.of("NT20", "VL100","XT40").contains(model.toUpperCase());
             case 0xA3: // MSG_FENCE_SINGLE / MSG_STATUS_3
                 return variant == Variant.SEEWORLD;
             default:
@@ -479,7 +479,8 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
         String model = deviceSession != null ? getDeviceModel(deviceSession) : null;
         boolean modelLW = model != null && model.toUpperCase().startsWith("LW");
         boolean modelSW = "SEEWORLD".equalsIgnoreCase(model);
-        boolean modelNT = model != null && Set.of("NT20", "VL100").contains(model.toUpperCase());
+        boolean modelXT = "XT40".equalsIgnoreCase(model);
+        boolean modelNT = modelXT || (model != null && Set.of("NT20", "VL100").contains(model.toUpperCase()));
         boolean modelVL = model != null && Set.of("VL103", "LL303", "VL512", "G18").contains(model.toUpperCase());
 
         if (type == MSG_LOGIN) {
@@ -876,13 +877,18 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                         position.set(Position.KEY_POWER, buf.readUnsignedShort() * 0.01);
                     } else {
                         int battery = buf.readUnsignedByte();
-                        if (modelNT && type == MSG_GPS_LBS_2) {
-                            battery = battery / 10;
-                        }
-                        if (battery <= 6) {
-                            position.set(Position.KEY_BATTERY_LEVEL, battery * 100 / 6);
-                        } else if (battery <= 100) {
-                            position.set(Position.KEY_BATTERY_LEVEL, battery);
+                        if (modelXT && type == MSG_GPS_LBS_2) {
+                            position.set(Position.KEY_BATTERY, battery / 10.0);
+                        } else {
+                            if (modelNT && type == MSG_GPS_LBS_2) {
+                                battery = battery / 10;
+                            }
+
+                            if (battery <= 6) {
+                                position.set(Position.KEY_BATTERY_LEVEL, battery * 100 / 6);
+                            } else if (battery <= 100) {
+                                position.set(Position.KEY_BATTERY_LEVEL, battery);
+                            }
                         }
                     }
                     position.set(Position.KEY_RSSI, buf.readUnsignedByte());

--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -237,7 +237,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
             case MSG_LBS_ALARM:
                 return true;
             case MSG_GPS_LBS_2:
-                return model != null && Set.of("NT20", "VL100","XT40").contains(model.toUpperCase());
+                return model != null && Set.of("NT20", "VL100", "XT40").contains(model.toUpperCase());
             case 0xA3: // MSG_FENCE_SINGLE / MSG_STATUS_3
                 return variant == Variant.SEEWORLD;
             default:

--- a/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
@@ -585,6 +585,22 @@ public class Gt06ProtocolDecoderTest extends ProtocolTest {
         verifyAttribute(decoder, binary(
                 "78783c22010357789648774484180c06142038180c06142038cb03313ee4061fe98300185e090000000000000000460984284c000200000000017101d6f35d0d0a"),
                 Position.KEY_HOURS, 22140000L);
+        verifyAttribute(decoder, binary(
+                "78783c22010357789648774484180c06142038180c06142038cb03313ee4061fe98300185e090000000000000000460984284c000200000000017101d6f35d0d0a"),
+                Position.KEY_BATTERY_LEVEL, 66);
+
+        decoder.setModelOverride("XT40");
+
+        verifyAttribute(decoder, binary(
+                "78783c220109999999999999991a04171433101a041714310fb00288a5a8050754500008000800000000000000000604e32933000200468b000025008d87ce0d0a"),
+                Position.KEY_POWER, 12.51);
+        verifyAttribute(decoder, binary(
+                "78783c220109999999999999991a04171433101a041714310fb00288a5a8050754500008000800000000000000000604e32933000200468b000025008d87ce0d0a"),
+                Position.KEY_BATTERY, 4.1);
+        verifyAttribute(decoder, binary(
+                "78783c220109999999999999991a04171433101a041714310fb00288a5a8050754500008000800000000000000000604e32933000200468b000025008d87ce0d0a"),
+                Position.KEY_BATTERY_LEVEL, null);
+
 
         decoder.setModelOverride("G18");
 


### PR DESCRIPTION
x3tech XT40 devices uses almost same protocol of NT20, but have battery voltage that cannot be direct converted to percent using 6V as maximum level.

apparently all other data are correct using the same decoding of NT20.

This PR define KEY_BATTERY instead of KEY_BATTERY_LEVEL for devices defined with model XT40

Protocol definition already attached on [#5810](https://github.com/traccar/traccar/issues/5810) - https://github.com/user-attachments/files/25785171/XT40-TM.Protocol.rev1.05.1.pdf

```
5.5.1.20. Battery Voltage
Battery voltage, value with one house multiplied by 10
```