### PR TITLE
Fix NPE in OpenID login when user has no groups

### DIFF
--- a/src/main/java/org/traccar/database/OpenIdProvider.java
+++ b/src/main/java/org/traccar/database/OpenIdProvider.java
@@ -174,9 +174,9 @@ public class OpenIdProvider {
         UserInfo userInfo = getUserInfo(bearerToken);
 
         List<String> userGroups = userInfo.getStringListClaim(groupsClaimName);
-        Boolean administrator = adminGroup != null ? userGroups.contains(adminGroup) : null;
+        Boolean administrator = adminGroup != null && userGroups != null ? userGroups.contains(adminGroup) : null;
 
-        if (!(Boolean.TRUE.equals(administrator) || allowGroup == null || userGroups.contains(allowGroup))) {
+        if (!(Boolean.TRUE.equals(administrator) || allowGroup == null || (userGroups != null && userGroups.contains(allowGroup)))) {
             throw new GeneralSecurityException("Your OpenID Groups do not permit access");
         }
 

--- a/src/main/java/org/traccar/database/OpenIdProvider.java
+++ b/src/main/java/org/traccar/database/OpenIdProvider.java
@@ -176,7 +176,10 @@ public class OpenIdProvider {
         List<String> userGroups = userInfo.getStringListClaim(groupsClaimName);
         Boolean administrator = adminGroup != null && userGroups != null ? userGroups.contains(adminGroup) : null;
 
-        if (!(Boolean.TRUE.equals(administrator) || allowGroup == null || (userGroups != null && userGroups.contains(allowGroup)))) {
+        boolean authorized = Boolean.TRUE.equals(administrator)
+                || allowGroup == null
+                || (userGroups != null && userGroups.contains(allowGroup));
+        if (!authorized) {
             throw new GeneralSecurityException("Your OpenID Groups do not permit access");
         }
 


### PR DESCRIPTION
Fixes a NullPointerException when authenticating via OpenID if the user has no group memberships in their token.

## Changes

- Add null check for userGroups before calling contains() in admin group check
- Add null check for userGroups before calling contains() in allow group check