### PR TITLE
Fix MiniFinder WiFi position decoding

### DIFF
--- a/src/main/java/org/traccar/protocol/Minifinder2ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Minifinder2ProtocolDecoder.java
@@ -331,12 +331,14 @@ public class Minifinder2ProtocolDecoder extends BaseProtocolDecoder {
                         }
                         break;
                     case 0x2A:
-                        buf.readUnsignedByte(); // flags
+                        int wifiFlags = buf.readUnsignedByte();
                         buf.skipBytes(6); // mac
                         buf.readUnsignedByte(); // rssi
-                        position.setLatitude(buf.readIntLE() * 0.0000001);
-                        position.setLongitude(buf.readIntLE() * 0.0000001);
-                        position.setValid(true);
+                        if (BitUtil.check(wifiFlags, 7)) {
+                            position.setLatitude(buf.readIntLE() * 0.0000001);
+                            position.setLongitude(buf.readIntLE() * 0.0000001);
+                            position.setValid(true);
+                        }
                         if (endIndex > buf.readerIndex()) {
                             position.set("description", buf.readCharSequence(
                                     endIndex - buf.readerIndex(), StandardCharsets.US_ASCII).toString());

--- a/src/test/java/org/traccar/protocol/Minifinder2ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Minifinder2ProtocolDecoderTest.java
@@ -11,6 +11,10 @@ public class Minifinder2ProtocolDecoderTest extends ProtocolTest {
 
         var decoder = inject(new Minifinder2ProtocolDecoder(null));
 
+        verifyAttribute(decoder, binary(
+                "ab102c0039aac6020110013836313632393035303632353039380924dc37f36900427e5b0f2a404a8cba41a770ba4e722e203137"),
+                "description", "Nr. 17");
+
         verifyPositions(decoder, binary(
                 "ab105b0063ca28000110013836323737313037363837383334300d246eaeb2690103fb2b030001001620eacce6217a59cf0800001e01a600050000000000160b2c00d14699811df7d600640b2c0187442817d4fdd100640b2c020a2f7f89cfc8cc0064"));
 


### PR DESCRIPTION
## Summary
- Handle MiniFinder2/Eview WiFi position records without embedded coordinates.
- Only decode latitude and longitude for key `0x2A` when the flags indicate coordinates are present.
- Add a regression sample for a WiFi description-only packet.

## Testing
- `./gradlew test --tests org.traccar.protocol.Minifinder2ProtocolDecoderTest`
- `./gradlew checkstyleMain checkstyleTest`