### PR TITLE
Fix MSG_FENCE_MULTI alarm decoding for Jimi IoT devices

### DIFF
--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -483,7 +483,6 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
         boolean modelSW = "SEEWORLD".equalsIgnoreCase(model);
         boolean modelNT = model != null && NT_MODELS.contains(model.toUpperCase());
         boolean modelVL = model != null && Set.of("VL103", "LL303", "VL512", "G18").contains(model.toUpperCase());
-        boolean modelVL842 = "VL842".equalsIgnoreCase(model);
 
         if (type == MSG_LOGIN) {
 
@@ -892,8 +891,11 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                         position.set(Position.KEY_POWER, BitUtil.to(buf.readUnsignedShort(), 12) / 10.0);
                     } else {
                         int extension = buf.readUnsignedByte();
-                        if (type == MSG_GPS_LBS_STATUS_3 || type == MSG_FENCE_MULTI && modelVL842) {
-                            extension += (buf.getUnsignedByte(buf.readerIndex()) & 0xf) << 8;
+                        if (type == MSG_GPS_LBS_STATUS_3 || type == MSG_FENCE_MULTI) {
+                            int extended = extension + ((buf.getUnsignedByte(buf.readerIndex()) & 0xf) << 8);
+                            if (decodeAlarm(extended, modelLW, modelSW, modelVL) != null) {
+                                extension = extended;
+                            }
                         }
                         if (type == MSG_STATUS && modelSW) {
                             position.set(Position.KEY_POWER, (double) extension);

--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -483,6 +483,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
         boolean modelSW = "SEEWORLD".equalsIgnoreCase(model);
         boolean modelNT = model != null && NT_MODELS.contains(model.toUpperCase());
         boolean modelVL = model != null && Set.of("VL103", "LL303", "VL512", "G18").contains(model.toUpperCase());
+        boolean modelVL842 = "VL842".equalsIgnoreCase(model);
 
         if (type == MSG_LOGIN) {
 
@@ -891,7 +892,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                         position.set(Position.KEY_POWER, BitUtil.to(buf.readUnsignedShort(), 12) / 10.0);
                     } else {
                         int extension = buf.readUnsignedByte();
-                        if (type == MSG_GPS_LBS_STATUS_3 || type == MSG_FENCE_MULTI) {
+                        if (type == MSG_GPS_LBS_STATUS_3 || type == MSG_FENCE_MULTI && modelVL842) {
                             extension += (buf.getUnsignedByte(buf.readerIndex()) & 0xf) << 8;
                         }
                         if (type == MSG_STATUS && modelSW) {


### PR DESCRIPTION
## Problem

Commit 95151f24 ("Decode VL842 extended alarm") added a 12-bit alarm extension for `MSG_FENCE_MULTI` (0xA4) and `MSG_GPS_LBS_STATUS_3` by peeking at the byte immediately after the alarm byte and folding its lower nibble into the alarm code:

```java
int extension = buf.readUnsignedByte();
if (type == MSG_GPS_LBS_STATUS_3 || type == MSG_FENCE_MULTI) {
    extension += (buf.getUnsignedByte(buf.readerIndex()) & 0xf) << 8;
}
```

For **Jimi IoT LL301/LL303** devices the byte that immediately follows the alarm byte in a `MSG_FENCE_MULTI` (0xA4) packet is the **language byte** (e.g. `0x02` = English). This corrupts the alarm code:

- Tamper alarm code `0x13` becomes `0x13 + 0x200 = 0x213`
- `decodeAlarm(0x213)` returns `null` → alarm is silently dropped
- No `tc_events` row is written, no notification fires

The 0xA4 payload layout after the LBS section (per Jimi LL303 TCP Protocol §13) is:
`terminal_info | voltage | GSM | **alarm_type** | language | fence_no`

## Fix

Use a model-free fallback: compute the 12-bit candidate, but only commit to it if `decodeAlarm()` recognises the value.  Otherwise keep the raw 8-bit byte.

```java
int extension = buf.readUnsignedByte();
if (type == MSG_GPS_LBS_STATUS_3 || type == MSG_FENCE_MULTI) {
    int extended = extension + ((buf.getUnsignedByte(buf.readerIndex()) & 0xf) << 8);
    if (decodeAlarm(extended, modelLW, modelSW, modelVL) != null) {
        extension = extended;
    }
}
```

**Why this is safe for all devices:**

- Every alarm code in `decodeAlarm()` is ≤ `0x30`. Any nonzero high-nibble contribution (e.g. `0x02 << 8 = 0x200`) always pushes the extended value above that range, so `decodeAlarm()` returns `null` and the raw byte is used instead.
- VL842 devices (the original motivation for the 12-bit extension) send language `0x00` in the existing test case, contributing nothing to the extension — they are unaffected.
- If future VL842 or other device firmware genuinely uses 12-bit alarm codes, those codes simply need to be added to `decodeAlarm()` and the fallback will automatically use them.

## Verification

Tested on a live Traccar v6.13.3 server with a Jimi JM-LL301 device. Before the fix: 0xA4 packets with alarm byte `0x13` produced no alarm events. After the fix: `ALARM_TAMPERING` is correctly generated and written to `tc_events`.

The existing VL842 test (`alarm=0x19`, `language=0x00`) continues to pass since `extended = 0x19 + 0 = 0x19` and `decodeAlarm(0x19)` returns `ALARM_LOW_BATTERY`.