### PR TITLE
fix: pin jackson version to 2.21.2 to resolve jackson-core CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,10 +64,7 @@ def resolveTransitiveVersion = { String root, String group, String name ->
     artifact.moduleVersion.id.version
 }
 
-ext.jacksonVersion = resolveTransitiveVersion(
-        "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVersion}",
-        "com.fasterxml.jackson.core",
-        "jackson-databind")
+ext.jacksonVersion = "2.21.2"
 
 ext.hk2Version = resolveTransitiveVersion(
         "org.glassfish.jersey.inject:jersey-hk2:${jerseyVersion}",


### PR DESCRIPTION
## Summary

Pin `jacksonVersion` explicitly to `2.21.2` in `build.gradle` to address [SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551) (High severity — Resource Exhaustion in jackson-core).

Fixes #5859

## Problem

Currently, `jacksonVersion` is resolved transitively from `jersey-media-json-jackson:4.0.2`, which pulls in `jackson-core:2.19.1` — a version affected by this vulnerability. Upgrading Jersey alone won't help since `4.0.2` is the latest release.

## Solution

Replace the transitive version resolution:

```groovy
// Before
ext.jacksonVersion = resolveTransitiveVersion(
        "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVersion}",
        "com.fasterxml.jackson.core",
        "jackson-databind")

// After
ext.jacksonVersion = "2.21.2"
```

This ensures all Jackson artifacts (`jackson-core`, `jackson-databind`, `jackson-jaxrs-json-provider`, etc.) resolve to the fixed version, overriding the vulnerable transitive dependency.

## References

- [jackson-core 2.21.2 release](https://github.com/FasterXML/jackson-core/releases/tag/jackson-core-2.21.2)
- [Snyk advisory](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551)