### PR TITLE
Add support for JT808 SMS response message (0x1300)

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -83,6 +83,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_REPORT_TEXT_MESSAGE = 0x6006;
     public static final int MSG_CONFIGURATION_PARAMETERS = 0x8103;
     public static final int MSG_COMMAND_RESPONSE = 0x0701;
+    public static final int MSG_TEXT_MESSAGE_RESPONSE = 0x1300;
     public static final int MSG_DRIVER_IDENTITY = 0x0702;
     public static final int MSG_VIDEO_REQUEST = 0x9101;
     public static final int MSG_VIDEO_CONTROL = 0x9102;
@@ -361,6 +362,22 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
             Charset charset = Charset.isSupported("GBK") ? Charset.forName("GBK") : StandardCharsets.US_ASCII;
 
             position.set(Position.KEY_RESULT, buf.readCharSequence(buf.readableBytes() - 2, charset).toString());
+
+            return position;
+
+        } else if (type == MSG_TEXT_MESSAGE_RESPONSE) {
+
+            Position position = new Position(getProtocolName());
+            position.setDeviceId(deviceSession.getDeviceId());
+
+            getLastLocation(position, null);
+
+            int bodyLength = BitUtil.to(attribute, 10);
+
+            buf.readUnsignedShort(); // response serial number
+
+            String result = buf.readCharSequence(bodyLength - 2, StandardCharsets.UTF_16BE).toString().trim();
+            position.set(Position.KEY_RESULT, result);
 
             return position;
 

--- a/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
@@ -252,6 +252,10 @@ public class Jt808ProtocolDecoderTest extends ProtocolTest {
                 "283734303139303331313138352c312c3030312c454c4f434b2c332c35323934333929"),
                 Position.KEY_RESULT, "(740190311185,1,001,ELOCK,3,529439)");
 
+        verifyAttribute(decoder, binary(
+                "7e13000012045450091546010900000053006500740020004f004b0021000d197e"),
+                Position.KEY_RESULT, "Set OK!");
+
         verifyPosition(decoder, binary(
                 "7e55028436740190311185091607200239270613212607536108630000170a000000014600005ded05e203000000000b010d0c06005b003e00ab0a0302dc65100100a37e"));
 


### PR DESCRIPTION
This change adds support for JT808 message type 0x1300 (SMS Response Transparent Transmission Protocol).

Some JT808-compatible devices reply to text commands (0x8300) using message 0x1300 instead of the existing response types currently handled by the decoder. As a result, command responses such as:

- Set OK!
- Set FAIL!
- Invalid sms cmd!

were ignored and not forwarded by Traccar because message 0x1300 was not decoded.

**Changes:**
- Added JT808 message constant MSG_TEXT_MESSAGE_RESPONSE (0x1300)
- Added decoder handling for 0x1300 messages
- Decoded text payloads and stored them in Position.KEY_RESULT
- Added unit test coverage for a real-world device response

This allows command execution results returned through 0x1300 to appear in Traccar in the same way as other supported command response messages and so allows command result forwarding.

**Evidence:**

Message ID 0x1300 is explained in the protocol documentation:
File: [Xchinchun JT808.docx](https://github.com/user-attachments/files/28387344/Xchinchun.JT808.docx)

It can be found on page 43 in the section:
SMS Response Transparent Transmission Protocol (0x1300) 3.27

Field | Meaning
-- | --
Message ID | 0x1300
Name | SMS Response Transparent Transmission Protocol
Start byte 0 | Response Serial Number, WORD
Start byte 2 | Text information, STRING
Encoding | Unicode
Purpose | Device response to SMS/text commands sent via 0x8300
