### PR TITLE
Added dedicated protocols for MT700 and MT532 with configuration encoders

### DIFF
--- a/src/main/java/org/traccar/config/PortConfigSuffix.java
+++ b/src/main/java/org/traccar/config/PortConfigSuffix.java
@@ -142,6 +142,8 @@ import org.traccar.protocol.MaxPbProtocol;
 import org.traccar.protocol.MegastekProtocol;
 import org.traccar.protocol.MeiligaoProtocol;
 import org.traccar.protocol.MeitrackProtocol;
+import org.traccar.protocol.MictrackHQProtocol;
+import org.traccar.protocol.MictrackMT700Protocol;
 import org.traccar.protocol.MictrackProtocol;
 import org.traccar.protocol.MilesmateProtocol;
 import org.traccar.protocol.Minifinder2Protocol;
@@ -562,6 +564,8 @@ public class PortConfigSuffix extends ConfigSuffix<Integer> {
         put(RadshidProtocol.class, 5265);
         put(R16hProtocol.class, 5266);
         put(JimiPhotoProtocol.class, 5267);
+        put(MictrackMT700Protocol.class, 5268);
+        put(MictrackHQProtocol.class, 5269);
     }
 
     PortConfigSuffix(String key, List<KeyType> types) {

--- a/src/main/java/org/traccar/protocol/MictrackHQProtocol.java
+++ b/src/main/java/org/traccar/protocol/MictrackHQProtocol.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Drew Taylor (Drew.Taylor@fognetx.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import org.traccar.BaseProtocol;
+import org.traccar.CharacterDelimiterFrameDecoder;
+import org.traccar.PipelineBuilder;
+import org.traccar.TrackerServer;
+import org.traccar.config.Config;
+import org.traccar.model.Command;
+
+import jakarta.inject.Inject;
+
+public class MictrackHQProtocol extends BaseProtocol {
+
+    @Inject
+    public MictrackHQProtocol(Config config) {
+        setSupportedDataCommands(
+                Command.TYPE_CUSTOM,
+                Command.TYPE_POSITION_PERIODIC,
+                Command.TYPE_ENGINE_STOP,
+                Command.TYPE_ENGINE_RESUME,
+                Command.TYPE_ALARM_ARM,
+                Command.TYPE_ALARM_DISARM);
+        addServer(new TrackerServer(config, getName(), false) {
+            @Override
+            protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
+                pipeline.addLast(new CharacterDelimiterFrameDecoder(1024, '#'));
+                pipeline.addLast(new StringEncoder());
+                pipeline.addLast(new StringDecoder());
+                pipeline.addLast(new MictrackHQProtocolEncoder(MictrackHQProtocol.this));
+                pipeline.addLast(new MictrackHQProtocolDecoder(MictrackHQProtocol.this));
+            }
+        });
+        addServer(new TrackerServer(config, getName(), true) {
+            @Override
+            protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
+                pipeline.addLast(new StringEncoder());
+                pipeline.addLast(new StringDecoder());
+                pipeline.addLast(new MictrackHQProtocolEncoder(MictrackHQProtocol.this));
+                pipeline.addLast(new MictrackHQProtocolDecoder(MictrackHQProtocol.this));
+            }
+        });
+    }
+
+}

--- a/src/main/java/org/traccar/protocol/MictrackHQProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/MictrackHQProtocolDecoder.java
@@ -104,12 +104,44 @@ public class MictrackHQProtocolDecoder extends BaseProtocolDecoder {
         }
     }
 
+    // *HQ,ID,V4,firmware,YYYYMMDDHHmmss#
+    private static final Pattern PATTERN_HEARTBEAT = new PatternBuilder()
+            .text("*HQ,")
+            .expression("([^,]+),")     // device ID
+            .text("V4,")
+            .expression("[^,]*,")       // firmware version
+            .number("(dddd)(dd)(dd)")   // date (YYYYMMDD)
+            .number("(dd)(dd)(dd)")     // time (HHmmss)
+            .any()
+            .compile();
+
+    private Object decodeHeartbeat(Channel channel, SocketAddress remoteAddress, String sentence) {
+        Parser parser = new Parser(PATTERN_HEARTBEAT, sentence);
+        if (!parser.matches()) {
+            return null;
+        }
+        String deviceId = parser.next();
+        if (getDeviceSession(channel, remoteAddress, deviceId) == null) {
+            return null;
+        }
+        if (channel != null) {
+            channel.writeAndFlush(new NetworkMessage(
+                    String.format("HQ,%s,R12,%s#", deviceId, UTC_TIME.format(Instant.now())),
+                    remoteAddress));
+        }
+        return null;
+    }
+
     @Override
     protected Object decode(Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
         String sentence = ((String) msg).trim();
 
         if (!sentence.startsWith("*HQ,")) {
             return null;
+        }
+
+        if (sentence.contains(",V4,")) {
+            return decodeHeartbeat(channel, remoteAddress, sentence);
         }
 
         Parser parser = new Parser(PATTERN_HQ, sentence);

--- a/src/main/java/org/traccar/protocol/MictrackHQProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/MictrackHQProtocolDecoder.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Drew Taylor (Drew.Taylor@fognetx.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import io.netty.channel.Channel;
+import org.traccar.BaseProtocolDecoder;
+import org.traccar.NetworkMessage;
+import org.traccar.Protocol;
+import org.traccar.helper.DateBuilder;
+import org.traccar.helper.Parser;
+import org.traccar.helper.PatternBuilder;
+import org.traccar.model.CellTower;
+import org.traccar.model.Network;
+import org.traccar.model.Position;
+import org.traccar.session.DeviceSession;
+
+import java.net.SocketAddress;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+
+public class MictrackHQProtocolDecoder extends BaseProtocolDecoder {
+
+    private static final DateTimeFormatter UTC_TIME = DateTimeFormatter
+            .ofPattern("HHmmss").withZone(ZoneOffset.UTC);
+
+    public MictrackHQProtocolDecoder(Protocol protocol) {
+        super(protocol);
+    }
+
+    // *HQ,ID,V1/V5/V6,hhmmss,A/V,lat,N/S,lon,E/W,speed,dir,ddmmyy,VSTATUS,MCC,MNC,LAC,CI[,extras]
+    private static final Pattern PATTERN_HQ = new PatternBuilder()
+            .text("*HQ,")
+            .expression("([^,]+),")           // device ID
+            .expression("(V\\d+),")           // data type
+            .number("(dd)(dd)(dd),")          // time (hhmmss)
+            .expression("([AV]),")            // validity
+            .number("(d+)(dd.d+),")           // latitude (ddmm.mmmm)
+            .expression("([NS]),")
+            .number("(d+)(dd.d+),")           // longitude (dddmm.mmmm)
+            .expression("([EW]),")
+            .number("(d+.?d*),")              // speed
+            .number("(d+),")                  // direction
+            .number("(dd)(dd)(dd),")          // date (ddmmyy)
+            .expression("([0-9A-Fa-f]{8}),")  // vehicle status (4 bytes as hex)
+            .number("(d+),")                  // MCC
+            .number("(d+),")                  // MNC
+            .number("(d+),")                  // LAC
+            .number("(d+)")                   // CI
+            .any()                            // optional V5/V6 trailing fields
+            .compile();
+
+    private void decodeVehicleStatus(Position position, String statusHex) {
+        // Four bytes, active-low (bit=0 means condition is active)
+        int byte1 = Integer.parseInt(statusHex.substring(0, 2), 16); // device alarms
+        int byte3 = Integer.parseInt(statusHex.substring(4, 6), 16); // vehicle status
+        int byte4 = Integer.parseInt(statusHex.substring(6, 8), 16); // alarm status
+
+        // Byte 1: bit1=towed, bit3=cut-off fuel/power, bit4=battery removal
+        if ((byte1 & 0x02) == 0) {
+            position.addAlarm(Position.ALARM_TOW);
+        }
+        if ((byte1 & 0x08) == 0) {
+            position.addAlarm(Position.ALARM_POWER_CUT);
+        }
+        if ((byte1 & 0x10) == 0) {
+            position.addAlarm(Position.ALARM_REMOVING);
+        }
+
+        // Byte 3: bit0=door open, bit2=ACC OFF, bit5=ACC ON
+        position.set(Position.KEY_DOOR, (byte3 & 0x01) == 0);
+        if ((byte3 & 0x20) == 0) {
+            position.set(Position.KEY_IGNITION, true);
+        } else if ((byte3 & 0x04) == 0) {
+            position.set(Position.KEY_IGNITION, false);
+        }
+
+        // Byte 4: bit1=SOS, bit2=overspeed, bit3=unauthorized ignition, bit5=low battery
+        if ((byte4 & 0x02) == 0) {
+            position.addAlarm(Position.ALARM_SOS);
+        }
+        if ((byte4 & 0x04) == 0) {
+            position.addAlarm(Position.ALARM_OVERSPEED);
+        }
+        if ((byte4 & 0x08) == 0) {
+            position.addAlarm(Position.ALARM_POWER_ON);
+        }
+        if ((byte4 & 0x20) == 0) {
+            position.addAlarm(Position.ALARM_LOW_BATTERY);
+        }
+    }
+
+    @Override
+    protected Object decode(Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
+        String sentence = ((String) msg).trim();
+
+        if (!sentence.startsWith("*HQ,")) {
+            return null;
+        }
+
+        Parser parser = new Parser(PATTERN_HQ, sentence);
+        if (!parser.matches()) {
+            return null;
+        }
+
+        String deviceId = parser.next();
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, deviceId);
+        if (deviceSession == null) {
+            return null;
+        }
+
+        // Send R12 acknowledgement
+        if (channel != null) {
+            channel.writeAndFlush(new NetworkMessage(
+                    String.format("HQ,%s,R12,%s#", deviceId, UTC_TIME.format(Instant.now())),
+                    remoteAddress));
+        }
+
+        Position position = new Position(getProtocolName());
+        position.setDeviceId(deviceSession.getDeviceId());
+
+        String dataType = parser.next();
+
+        DateBuilder dateBuilder = new DateBuilder()
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+
+        position.setValid(parser.next().equals("A"));
+        position.setLatitude(parser.nextCoordinate());
+        position.setLongitude(parser.nextCoordinate());
+        position.setSpeed(parser.nextDouble());
+        position.setCourse(parser.nextDouble());
+
+        dateBuilder.setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
+        position.setTime(dateBuilder.getDate());
+
+        decodeVehicleStatus(position, parser.next());
+
+        int mcc = parser.nextInt();
+        int mnc = parser.nextInt();
+        int lac = parser.nextInt();
+        int cid = parser.nextInt();
+        position.setNetwork(new Network(CellTower.from(mcc, mnc, lac, cid)));
+
+        // V5: trailing mileage,voltage
+        if (dataType.equals("V5")) {
+            String remaining = sentence.substring(sentence.lastIndexOf(String.valueOf(cid)) + String.valueOf(cid).length());
+            String[] extras = remaining.replaceAll("[,#]", ",").split(",");
+            int idx = 0;
+            while (idx < extras.length && extras[idx].isEmpty()) {
+                idx++;
+            }
+            if (idx < extras.length) {
+                try {
+                    position.set(Position.KEY_ODOMETER, Long.parseLong(extras[idx].trim()) * 1000);
+                } catch (NumberFormatException e) {
+                    // ignore
+                }
+                idx++;
+            }
+            if (idx < extras.length) {
+                try {
+                    int voltRaw = Integer.parseInt(extras[idx].trim());
+                    position.set(Position.KEY_POWER, voltRaw / 10.0);
+                } catch (NumberFormatException e) {
+                    // ignore
+                }
+            }
+        }
+
+        return position;
+    }
+
+}

--- a/src/main/java/org/traccar/protocol/MictrackHQProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/MictrackHQProtocolEncoder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Drew Taylor (Drew.Taylor@fognetx.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.traccar.BaseProtocolEncoder;
+import org.traccar.Protocol;
+import org.traccar.model.Command;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class MictrackHQProtocolEncoder extends BaseProtocolEncoder {
+
+    private static final DateTimeFormatter UTC_TIME = DateTimeFormatter
+            .ofPattern("HHmmss").withZone(ZoneOffset.UTC);
+
+    public MictrackHQProtocolEncoder(Protocol protocol) {
+        super(protocol);
+    }
+
+    private String utcNow() {
+        return UTC_TIME.format(Instant.now());
+    }
+
+    private String format(Command command, String cmd, String... params) {
+        String id = getUniqueId(command.getDeviceId());
+        String base = String.format("*HQ,%s,%s,%s", id, cmd, utcNow());
+        if (params.length > 0) {
+            base += "," + String.join(",", params);
+        }
+        return base + "#";
+    }
+
+    @Override
+    protected Object encodeCommand(Command command) {
+        return switch (command.getType()) {
+            case Command.TYPE_CUSTOM ->
+                    format(command, (String) command.getAttributes().get(Command.KEY_DATA));
+            case Command.TYPE_POSITION_PERIODIC -> {
+                int interval = ((Number) command.getAttributes().get(Command.KEY_FREQUENCY)).intValue();
+                yield format(command, "D1", String.valueOf(interval), "1");
+            }
+            case Command.TYPE_ENGINE_STOP ->
+                    format(command, "S20", "1", "1");
+            case Command.TYPE_ENGINE_RESUME ->
+                    format(command, "S20", "0", "0");
+            case Command.TYPE_ALARM_ARM ->
+                    format(command, "SF", "0", "0");
+            case Command.TYPE_ALARM_DISARM ->
+                    format(command, "CF", "1", "1");
+            default -> null;
+        };
+    }
+
+}

--- a/src/main/java/org/traccar/protocol/MictrackMT700Protocol.java
+++ b/src/main/java/org/traccar/protocol/MictrackMT700Protocol.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Drew Taylor (Drew.Taylor@fognetx.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import org.traccar.BaseProtocol;
+import org.traccar.CharacterDelimiterFrameDecoder;
+import org.traccar.PipelineBuilder;
+import org.traccar.TrackerServer;
+import org.traccar.config.Config;
+import org.traccar.model.Command;
+
+import jakarta.inject.Inject;
+
+public class MictrackMT700Protocol extends BaseProtocol {
+
+    @Inject
+    public MictrackMT700Protocol(Config config) {
+        setSupportedDataCommands(
+                Command.TYPE_CUSTOM,
+                Command.TYPE_REBOOT_DEVICE,
+                Command.TYPE_POSITION_PERIODIC,
+                Command.TYPE_MODE_DEEP_SLEEP,
+                Command.TYPE_SET_CONNECTION,
+                Command.TYPE_GET_DEVICE_STATUS);
+        addServer(new TrackerServer(config, getName(), false) {
+            @Override
+            protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
+                pipeline.addLast(new CharacterDelimiterFrameDecoder(1024, "##"));
+                pipeline.addLast(new StringEncoder());
+                pipeline.addLast(new StringDecoder());
+                pipeline.addLast(new MictrackMT700ProtocolEncoder(MictrackMT700Protocol.this));
+                pipeline.addLast(new MictrackMT700ProtocolDecoder(MictrackMT700Protocol.this));
+            }
+        });
+        addServer(new TrackerServer(config, getName(), true) {
+            @Override
+            protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
+                pipeline.addLast(new StringEncoder());
+                pipeline.addLast(new StringDecoder());
+                pipeline.addLast(new MictrackMT700ProtocolEncoder(MictrackMT700Protocol.this));
+                pipeline.addLast(new MictrackMT700ProtocolDecoder(MictrackMT700Protocol.this));
+            }
+        });
+    }
+
+}

--- a/src/main/java/org/traccar/protocol/MictrackMT700ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/MictrackMT700ProtocolDecoder.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 Drew Taylor (Drew.Taylor@fognetx.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import io.netty.channel.Channel;
+import org.traccar.BaseProtocolDecoder;
+import org.traccar.Protocol;
+import org.traccar.helper.DateBuilder;
+import org.traccar.model.CellTower;
+import org.traccar.model.Network;
+import org.traccar.model.Position;
+import org.traccar.model.WifiAccessPoint;
+import org.traccar.session.DeviceSession;
+
+import java.net.SocketAddress;
+
+public class MictrackMT700ProtocolDecoder extends BaseProtocolDecoder {
+
+    public MictrackMT700ProtocolDecoder(Protocol protocol) {
+        super(protocol);
+    }
+
+    private String decodeAlarm(String event) {
+        return switch (event) {
+            case "SHAKE" -> Position.ALARM_VIBRATION;
+            case "DEF" -> Position.ALARM_TAMPERING;
+            case "BLP" -> Position.ALARM_LOW_BATTERY;
+            default -> null;
+        };
+    }
+
+    private void parseCellTower(Position position, String data) {
+        // Format: MCC,MNC,LAC,CellID (LAC and CellID are hex for CAT-M1/NB-IoT)
+        String[] parts = data.split(",");
+        if (parts.length < 4) {
+            return;
+        }
+        try {
+            int mcc = Integer.parseInt(parts[0].trim());
+            int mnc = Integer.parseInt(parts[1].trim());
+            long lac = Long.parseLong(parts[2].trim(), 16);
+            long cid = Long.parseLong(parts[3].trim(), 16);
+            Network network = position.getNetwork() != null ? position.getNetwork() : new Network();
+            network.addCellTower(CellTower.from(mcc, mnc, (int) lac, cid));
+            position.setNetwork(network);
+        } catch (NumberFormatException e) {
+            // ignore malformed cell data
+        }
+    }
+
+    private static double parseNmea(String value) {
+        // ddmm.mmmm or dddmm.mmmm → decimal degrees
+        int dot = value.indexOf('.');
+        double minutes = Double.parseDouble(value.substring(dot - 2));
+        double degrees = Integer.parseInt(value.substring(0, dot - 2));
+        return degrees + minutes / 60.0;
+    }
+
+    private Position decodeGprmc(Position position, String sentence) {
+        // $GPRMC,hhmmss.ss,A/V,lat,NS,lon,EW,speed,course,ddmmyy,...
+        int starIndex = sentence.indexOf('*');
+        if (starIndex >= 0) {
+            sentence = sentence.substring(0, starIndex);
+        }
+
+        String[] f = sentence.split(",", -1);
+        if (f.length < 10) {
+            return null;
+        }
+
+        String timeStr = f[1];
+        String dateStr = f[9];
+        if (timeStr.length() < 6 || dateStr.length() < 6) {
+            return null;
+        }
+
+        DateBuilder dateBuilder = new DateBuilder()
+                .setTime(Integer.parseInt(timeStr.substring(0, 2)),
+                        Integer.parseInt(timeStr.substring(2, 4)),
+                        Integer.parseInt(timeStr.substring(4, 6)))
+                .setDateReverse(Integer.parseInt(dateStr.substring(0, 2)),
+                        Integer.parseInt(dateStr.substring(2, 4)),
+                        Integer.parseInt(dateStr.substring(4, 6)));
+
+        boolean valid = f[2].equals("A");
+        position.setValid(valid);
+
+        if (valid && !f[3].isEmpty() && !f[5].isEmpty()) {
+            double lat = parseNmea(f[3]);
+            double lon = parseNmea(f[5]);
+            position.setLatitude(f[4].equals("S") ? -lat : lat);
+            position.setLongitude(f[6].equals("W") ? -lon : lon);
+            if (!f[7].isEmpty()) {
+                position.setSpeed(Double.parseDouble(f[7]));
+            }
+            if (!f[8].isEmpty()) {
+                position.setCourse(Double.parseDouble(f[8]));
+            }
+            position.setTime(dateBuilder.getDate());
+        } else {
+            getLastLocation(position, dateBuilder.getDate());
+        }
+
+        return position;
+    }
+
+    private Position decodeWifi(Position position, String sentence) {
+        // $WIFI,hhmmss.ss,A/V,rssi,mac,...,ddmmyy*CS
+        int starIndex = sentence.indexOf('*');
+        if (starIndex >= 0) {
+            sentence = sentence.substring(0, starIndex);
+        }
+
+        String[] parts = sentence.split(",");
+        if (parts.length < 3) {
+            return null;
+        }
+
+        // parts[0]=$WIFI, parts[1]=time, parts[2]=status
+        // pairs [3..n-2]: rssi, mac  (variable count)
+        // parts[n-1]=date (ddmmyy)
+        String timeStr = parts[1];
+        if (timeStr.length() < 6) {
+            return null;
+        }
+        int hour = Integer.parseInt(timeStr.substring(0, 2));
+        int minute = Integer.parseInt(timeStr.substring(2, 4));
+        int second = Integer.parseInt(timeStr.substring(4, 6));
+
+        String dateStr = parts[parts.length - 1];
+        if (dateStr.length() < 6) {
+            return null;
+        }
+        int day = Integer.parseInt(dateStr.substring(0, 2));
+        int month = Integer.parseInt(dateStr.substring(2, 4));
+        int year = 2000 + Integer.parseInt(dateStr.substring(4, 6));
+
+        DateBuilder dateBuilder = new DateBuilder()
+                .setDate(year, month, day)
+                .setTime(hour, minute, second);
+
+        Network network = position.getNetwork() != null ? position.getNetwork() : new Network();
+
+        // WiFi pairs occupy indices [3..parts.length-2], stepping by 2
+        for (int i = 3; i + 1 < parts.length - 1; i += 2) {
+            try {
+                int rssi = Integer.parseInt(parts[i].trim());
+                String mac = parts[i + 1].trim();
+                if (mac.length() == 12) {
+                    String formatted = mac.replaceAll("(?<=\\G.{2})(?=.)", ":").toLowerCase();
+                    network.addWifiAccessPoint(WifiAccessPoint.from(formatted, rssi));
+                }
+            } catch (NumberFormatException e) {
+                // ignore malformed entry
+            }
+        }
+
+        position.setNetwork(network);
+        getLastLocation(position, dateBuilder.getDate());
+
+        return position;
+    }
+
+    @Override
+    protected Object decode(Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
+        String sentence = ((String) msg).trim();
+
+        if (!sentence.startsWith("#")) {
+            return null;
+        }
+
+        // Message: #IMEI#MT700#0000#EVENT#1\r\n#voltage[#cell]$GPRMC/$WIFI,...\r\n
+        String[] lines = sentence.split("\r?\n");
+        if (lines.length < 2) {
+            return null;
+        }
+
+        // Header: #IMEI#MT700W?#0000#EVENT#1
+        String[] header = lines[0].split("#");
+        // [0]="", [1]=IMEI, [2]=MT700/MT700W, [3]=0000, [4]=event, [5]=1
+        if (header.length < 5) {
+            return null;
+        }
+        String imei = header[1];
+        String event = header[4];
+
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, imei);
+        if (deviceSession == null) {
+            return null;
+        }
+
+        Position position = new Position(getProtocolName());
+        position.setDeviceId(deviceSession.getDeviceId());
+        position.addAlarm(decodeAlarm(event));
+
+        // Body: #voltage[#cellinfo]$GPRMC/WIFI,...
+        String body = lines[1];
+        if (!body.startsWith("#")) {
+            return null;
+        }
+        body = body.substring(1); // strip leading #
+
+        int dollarIndex = body.indexOf('$');
+        if (dollarIndex < 0) {
+            return null;
+        }
+
+        String prefix = body.substring(0, dollarIndex);  // e.g. "3815" or "3815#" or "3815#460,00,1D29,abc"
+        String gpsData = body.substring(dollarIndex);
+
+        String[] prefixParts = prefix.split("#", 2);
+        try {
+            int voltageRaw = Integer.parseInt(prefixParts[0].trim());
+            position.set(Position.KEY_BATTERY, voltageRaw / 1000.0);
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+
+        if (prefixParts.length > 1 && !prefixParts[1].isEmpty()) {
+            parseCellTower(position, prefixParts[1]);
+        }
+
+        if (gpsData.startsWith("$GPRMC")) {
+            return decodeGprmc(position, gpsData);
+        } else if (gpsData.startsWith("$WIFI")) {
+            return decodeWifi(position, gpsData);
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/org/traccar/protocol/MictrackMT700ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/MictrackMT700ProtocolDecoder.java
@@ -36,8 +36,13 @@ public class MictrackMT700ProtocolDecoder extends BaseProtocolDecoder {
     private String decodeAlarm(String event) {
         return switch (event) {
             case "SHAKE" -> Position.ALARM_VIBRATION;
+            case "TOWED" -> Position.ALARM_TOW;
             case "DEF" -> Position.ALARM_TAMPERING;
             case "BLP" -> Position.ALARM_LOW_BATTERY;
+            case "SOS" -> Position.ALARM_SOS;
+            case "OVERSPEED" -> Position.ALARM_OVERSPEED;
+            case "OS" -> Position.ALARM_GEOFENCE_EXIT;
+            case "RS" -> Position.ALARM_GEOFENCE_ENTER;
             default -> null;
         };
     }
@@ -224,7 +229,7 @@ public class MictrackMT700ProtocolDecoder extends BaseProtocolDecoder {
         String[] prefixParts = prefix.split("#", 2);
         try {
             int voltageRaw = Integer.parseInt(prefixParts[0].trim());
-            position.set(Position.KEY_BATTERY, voltageRaw / 1000.0);
+            position.set(Position.KEY_BATTERY, voltageRaw > 100 ? voltageRaw / 1000.0 : voltageRaw / 10.0);
         } catch (NumberFormatException e) {
             // ignore
         }

--- a/src/main/java/org/traccar/protocol/MictrackMT700ProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/MictrackMT700ProtocolEncoder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Drew Taylor (Drew.Taylor@fognetx.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.traccar.Protocol;
+import org.traccar.StringProtocolEncoder;
+import org.traccar.model.Command;
+
+public class MictrackMT700ProtocolEncoder extends StringProtocolEncoder {
+
+    public MictrackMT700ProtocolEncoder(Protocol protocol) {
+        super(protocol);
+    }
+
+    @Override
+    protected Object encodeCommand(Command command) {
+        return switch (command.getType()) {
+            case Command.TYPE_CUSTOM -> formatCommand(command, "%s", Command.KEY_DATA);
+            case Command.TYPE_REBOOT_DEVICE -> "REBOOT";
+            case Command.TYPE_POSITION_PERIODIC -> formatCommand(command, "MODE,1,%s", Command.KEY_FREQUENCY);
+            case Command.TYPE_MODE_DEEP_SLEEP -> {
+                long hours = Math.max(1, Math.min(24,
+                        ((Number) command.getAttributes().get(Command.KEY_FREQUENCY)).longValue() / 3600));
+                yield String.format("MODE,3,%d", hours);
+            }
+            case Command.TYPE_SET_CONNECTION -> formatCommand(command, "804,%s,%s", Command.KEY_SERVER, Command.KEY_PORT);
+            case Command.TYPE_GET_DEVICE_STATUS -> "RCONF,1";
+            default -> null;
+        };
+    }
+
+}

--- a/src/test/java/org/traccar/protocol/MictrackHQProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/MictrackHQProtocolDecoderTest.java
@@ -34,6 +34,15 @@ public class MictrackHQProtocolDecoderTest extends ProtocolTest {
                 "*HQ,8168000008,V1,043602,A,2234.9273,N,11354.3980,E,000.06,000,100715,FBFFBBFB,460,00,10342,4283"),
                 Position.KEY_ALARM, Position.ALARM_OVERSPEED);
 
+        // V4 heartbeat
+        verifyNull(decoder, text(
+                "*HQ,8168000008,V4,V1,20150710043602"));
+
+        // V1 western hemisphere, ignition off (byte3 bit2=0), no alarm
+        verifyPosition(decoder, text(
+                "*HQ,8168000008,V1,083000,A,3600.0000,N,09600.0000,W,000.00,142,010124,FFF7FBFF,310,410,12345,67890"),
+                position("2024-01-01 08:30:00.000", true, 36.0, -96.0));
+
     }
 
 }

--- a/src/test/java/org/traccar/protocol/MictrackHQProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/MictrackHQProtocolDecoderTest.java
@@ -1,0 +1,39 @@
+package org.traccar.protocol;
+
+import org.junit.jupiter.api.Test;
+import org.traccar.ProtocolTest;
+import org.traccar.model.Position;
+
+public class MictrackHQProtocolDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testDecode() throws Exception {
+
+        var decoder = inject(new MictrackHQProtocolDecoder(null));
+
+        // V1 heartbeat
+        verifyPosition(decoder, text(
+                "*HQ,8168000008,V1,043602,A,2234.9273,N,11354.3980,E,000.06,000,100715,FBFFBBFF,460,00,10342,4283"),
+                position("2015-07-10 04:36:02.000", true, 22.58212, 113.90664));
+
+        // V5 with mileage and external power voltage
+        verifyPosition(decoder, text(
+                "*HQ,8168000008,V5,043602,A,2234.9273,N,11354.3980,E,000.06,000,100715,FBFFBBFF,460,00,10342,4283,1000,125"));
+
+        // V6 with ICCID
+        verifyPosition(decoder, text(
+                "*HQ,8168000008,V6,043602,A,2234.9273,N,11354.3980,E,000.06,000,100715,FBFFBBFF,460,00,10342,4283,898602A2091508006821"));
+
+        // SOS alarm (byte4 bit1 = 0)
+        verifyAttribute(decoder, text(
+                "*HQ,8168000008,V1,043602,A,2234.9273,N,11354.3980,E,000.06,000,100715,FBFFBBFD,460,00,10342,4283"),
+                Position.KEY_ALARM, Position.ALARM_SOS);
+
+        // Overspeed alarm (byte4 bit2 = 0)
+        verifyAttribute(decoder, text(
+                "*HQ,8168000008,V1,043602,A,2234.9273,N,11354.3980,E,000.06,000,100715,FBFFBBFB,460,00,10342,4283"),
+                Position.KEY_ALARM, Position.ALARM_OVERSPEED);
+
+    }
+
+}

--- a/src/test/java/org/traccar/protocol/MictrackMT700ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/MictrackMT700ProtocolDecoderTest.java
@@ -1,0 +1,43 @@
+package org.traccar.protocol;
+
+import org.junit.jupiter.api.Test;
+import org.traccar.ProtocolTest;
+
+public class MictrackMT700ProtocolDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testDecode() throws Exception {
+
+        var decoder = inject(new MictrackMT700ProtocolDecoder(null));
+
+        // GPS available, LBS OFF
+        verifyPosition(decoder, text(
+                "#862255061947757#MT700#0000#AUTO#1\n#3815$GPRMC,123318.00,A,2238.8946,N,11402.0635,E,,,100124,,,A*5C\n"));
+
+        // GPS available, LBS ON
+        verifyPosition(decoder, text(
+                "#862255061947757#MT700#0000#AUTO#1\n#3815#$GPRMC,123548.00,A,2238.8936,N,11402.0640,E,,,100124,,,A*5A\n"));
+
+        // GPS unavailable, LBS ON
+        verifyAttributes(decoder, text(
+                "#862255061947757#MT700#0000#AUTO#1\n#3815#460,00,1D29,156153D$GPRMC,121831.00,V,,,,,,,100124,,,A*7C\n"));
+
+        // WiFi, LBS OFF, AGPS ON
+        verifyAttributes(decoder, text(
+                "#862255061947757#MT700#0000#AUTO#1\n#3815$WIFI,124517.00,A,-39,6877248FA31A,-39,7E77248FA31A,-73,DC333DF82C74,-75,0260736CF982,-77,90769F421140,100124*0E\n"));
+
+        // WiFi, LBS ON, AGPS ON
+        verifyAttributes(decoder, text(
+                "#862255061947757#MT700#0000#AUTO#1\n#3815#460,00,262C,11F1$WIFI,022300.00,A,-31,6877248FA31A,-32,7E77248FA31A,-73,0260736CF982,-74,DC333DF82C74,-74,90769F421140,100124*74\n"));
+
+        // SHAKE alarm
+        verifyPosition(decoder, text(
+                "#862255061947757#MT700#0000#SHAKE#1\n#3815$GPRMC,090000.00,A,2238.8946,N,11402.0635,E,0.0,0.0,100124,,,A*00\n"));
+
+        // MT700W variant header
+        verifyAttributes(decoder, text(
+                "#862255061947757#MT700W#0000#AUTO#1\n#3815#460,00,262C,11F1$WIFI,095147.00,V,,,,,,,,,,,241223*06\n"));
+
+    }
+
+}

--- a/src/test/java/org/traccar/protocol/MictrackMT700ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/MictrackMT700ProtocolDecoderTest.java
@@ -2,6 +2,7 @@ package org.traccar.protocol;
 
 import org.junit.jupiter.api.Test;
 import org.traccar.ProtocolTest;
+import org.traccar.model.Position;
 
 public class MictrackMT700ProtocolDecoderTest extends ProtocolTest {
 
@@ -37,6 +38,11 @@ public class MictrackMT700ProtocolDecoderTest extends ProtocolTest {
         // MT700W variant header
         verifyAttributes(decoder, text(
                 "#862255061947757#MT700W#0000#AUTO#1\n#3815#460,00,262C,11F1$WIFI,095147.00,V,,,,,,,,,,,241223*06\n"));
+
+        // TOWED alarm, GPS unavailable, low voltage raw value (37 = 3.7V)
+        verifyAttribute(decoder, text(
+                "#862255061947757#MT700#0000#TOWED#1\n#37$GPRMC,090000.00,V,,,,,,,100124,,,A*7C\n"),
+                Position.KEY_ALARM, Position.ALARM_TOW);
 
     }
 


### PR DESCRIPTION
Added dedicated protocols for the mictrack MT700 and MT532 with defined alarms, and tested with real packets. Additionally added encoders to support pushing device configuration. Also added unit tests for the protocols.

