### PR TITLE
gt06: decode MSG_GPS_LBS_RFID (0x17) frames with length 0x27

### DIFF
--- a/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -1601,7 +1601,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
             variant = Variant.SEEWORLD;
         } else if (header == 0x7878 && type == MSG_STATUS_3 && length == 0x0c) {
             variant = Variant.SEEWORLD;
-        } else if (header == 0x7878 && type == MSG_GPS_LBS_RFID && length == 0x28) {
+        } else if (header == 0x7878 && type == MSG_GPS_LBS_RFID && (length == 0x28 || length == 0x27)) {
             variant = Variant.RFID;
         } else if (header == 0x7878 && type == MSG_GPS_LBS_STATUS_5 && length == 0x40) {
             variant = Variant.LW4G;

--- a/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gt06ProtocolDecoderTest.java
@@ -11,6 +11,9 @@ public class Gt06ProtocolDecoderTest extends ProtocolTest {
 
         var decoder = inject(new Gt06ProtocolDecoder(null));
 
+        verifyPosition(decoder, binary(
+                "787827171a060e160e33cd022e10560453b05500592102d40b1bd7002a9f4606500e020129f800238ffa0d0a"));
+
         verifyNull(decoder, binary(
                 "787805120099abec0d0a"));
 


### PR DESCRIPTION
Some gt06 trackers send the GPS+LBS position in a `0x17` (`MSG_GPS_LBS_RFID`) frame with **length `0x27`** — one byte shorter than the RFID variant's `0x28` (they omit the trailing validity byte).

`decodeVariant()` only selected `Variant.RFID` for length `0x28`, so these frames fell through to `Variant.STANDARD`, were parsed as `MSG_WIFI`, and overran the buffer:

```
WARN: [Txxxxxxxx] error - readerIndex(44) + length(1) exceeds writerIndex(44): ...
```

The channel is then closed and the device reconnects in a loop ("connects and drops, never reports a position").

This accepts length `0x27` for `MSG_GPS_LBS_RFID` so the frame is decoded as GPS+LBS through the existing RFID path. The trailing RFID validity read lands on the serial bytes (no overrun) and the position decodes correctly. The change is additive — it only affects `type 0x17 && length 0x27`, which currently always crashes.

### Sample

```
787827171a060e160e33cd022e10560453b05500592102d40b1bd7002a9f4606500e020129f800238ffa0d0a
```

Decodes to `2026-06-14 22:14:51`, lat `-20.31848`, lon `-40.32972`, course `289°`. Verified against a running `6.14.4` instance with this patch, and added as a `verifyPosition` test case.
