### PR TITLE
Decode JT808 0x0210 hibernation battery reports

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -342,6 +342,8 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
         int type = buf.readUnsignedShort();
         int attribute = buf.readUnsignedShort();
 
+        int bodyLength = BitUtil.to(attribute, 10);
+
         protocolVersion = BitUtil.check(attribute, 14) ? (int) buf.readUnsignedByte() : null;
         ByteBuf id = buf.readSlice(protocolVersion != null ? 10 : (delimiter == 0xe7 ? 7 : 6));
 
@@ -395,8 +397,6 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             getLastLocation(position, null);
 
-            int bodyLength = BitUtil.to(attribute, 10);
-
             buf.readUnsignedShort(); // response serial number
 
             String result = buf.readCharSequence(bodyLength - 2, StandardCharsets.UTF_16BE).toString().trim();
@@ -442,17 +442,19 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             return decodeLocation2(deviceSession, buf, type);
 
-        } else if (type == MSG_LOCATION_BATCH_2 && BitUtil.to(attribute, 10) == 7) {
+        } else if (type == MSG_LOCATION_BATCH_2 && bodyLength == 7) {
 
             sendGeneralResponse(channel, remoteAddress, id, type, index);
 
             Position position = new Position(getProtocolName());
             position.setDeviceId(deviceSession.getDeviceId());
 
-            getLastLocation(position, null);
+            int batteryLevel = buf.readUnsignedByte();
+            Date time = readDate(buf, deviceSession.get(DeviceSession.KEY_TIMEZONE));
 
-            position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());
-            position.setTime(readDate(buf, deviceSession.get(DeviceSession.KEY_TIMEZONE)));
+            getLastLocation(position, time);
+
+            position.set(Position.KEY_BATTERY_LEVEL, batteryLevel);
 
             return position;
 

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -442,6 +442,20 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             return decodeLocation2(deviceSession, buf, type);
 
+        } else if (type == MSG_LOCATION_BATCH_2 && BitUtil.to(attribute, 10) == 7) {
+
+            sendGeneralResponse(channel, remoteAddress, id, type, index);
+
+            Position position = new Position(getProtocolName());
+            position.setDeviceId(deviceSession.getDeviceId());
+
+            getLastLocation(position, null);
+
+            position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());
+            position.setTime(readDate(buf, deviceSession.get(DeviceSession.KEY_TIMEZONE)));
+
+            return position;
+
         } else if (type == MSG_LOCATION_BATCH || type == MSG_LOCATION_BATCH_2) {
 
             sendGeneralResponse(channel, remoteAddress, id, type, index);

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -449,12 +449,8 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
             Position position = new Position(getProtocolName());
             position.setDeviceId(deviceSession.getDeviceId());
 
-            int batteryLevel = buf.readUnsignedByte();
-            Date time = readDate(buf, deviceSession.get(DeviceSession.KEY_TIMEZONE));
-
-            getLastLocation(position, time);
-
-            position.set(Position.KEY_BATTERY_LEVEL, batteryLevel);
+            position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());
+            getLastLocation(position, readDate(buf, deviceSession.get(DeviceSession.KEY_TIMEZONE)));
 
             return position;
 

--- a/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
@@ -357,6 +357,10 @@ public class Jt808ProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, binary(
                 "7e02000072045460005635007300000000000000000236d51c00823f19000000000000260602220701010400000000300111310100e4020064e50100e60100e7080000000600000000e10c010c000600bbe4001ada1500ec23f0090dba115abb5091e3194157b9ce20bd25d93fb5ce20bd85d93fb57e9cd82cadd5b1f50101717e"));
 
+        verifyAttribute(decoder, binary(
+                "7e0210000704546000231900884f2606180229579c7e"),
+                Position.KEY_BATTERY_LEVEL, 79);                
+
         decoder.setModelOverride("MV710G");
 
         verifyAttribute(decoder, binary(


### PR DESCRIPTION
Add handling for JT808 0x0210 hibernation battery level updates.

Some devices use message 0x0210 with a 7-byte body to report battery level during sleep:
- 1 byte battery percentage
- 6 byte BCD timestamp

The existing decoder treated all 0x0210 messages as batch location uploads. This caused 7-byte sleep battery reports to be parsed incorrectly.

This change adds a length-based special case for 0x0210 messages with a 7-byte body, decodes the battery level and timestamp into a Position object, and keeps existing batch upload handling unchanged for other 0x0210 payloads.

A regression test is included using a real device frame: 7e0210000704546000231900884f2606180229579c7e

**Evidence** can be found in the [Xchinchun JT808.docx](https://github.com/user-attachments/files/29068497/Xchinchun.JT808.docx) on page 41, section **3.20 Hibernation Battery Level Update (0x 0210)**