### PR TITLE
Add local.properties to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out
 build
 .vscode
 bin
+local.properties


### PR DESCRIPTION
Add local.properties to .gitignore

local.properties is auto-generated when server project is built. This fix makes it impossible for contributors to accidentally commit local.properties