### PR TITLE
Add hybridTime threshold config and unit tests for TimeHandler

### DIFF
--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1749,6 +1749,14 @@ public final class Keys {
             List.of(KeyType.CONFIG, KeyType.DEVICE));
 
     /**
+     * Number of days to use for hybrid time threshold. If not defined, defaults to 7 days.
+     */
+    public static final ConfigKey<Long> HYBRID_TIME_DAYS = new LongConfigKey(
+            "time.hybridDays",
+            List.of(KeyType.CONFIG),
+            7L);
+
+    /**
      * List of protocols to enable. If not specified, Traccar enables all protocols that have port numbers listed.
      * The value is a comma-separated list of protocol names.
      * Example value: teltonika,osmand

--- a/src/main/java/org/traccar/handler/TimeHandler.java
+++ b/src/main/java/org/traccar/handler/TimeHandler.java
@@ -35,11 +35,13 @@ public class TimeHandler extends BasePositionHandler {
 
     private final CacheManager cacheManager;
     private final Set<String> overrideProtocols;
+    private final long hybridTimeMillis;
 
     @Inject
     public TimeHandler(Config config, CacheManager cacheManager) {
 
         this.cacheManager = cacheManager;
+        hybridTimeMillis = Duration.ofDays(config.getLong(Keys.HYBRID_TIME_DAYS)).toMillis();
         String protocolList = config.getString(Keys.TIME_PROTOCOLS);
         if (protocolList != null) {
             overrideProtocols = new HashSet<>(Arrays.asList(protocolList.split("[, ]")));
@@ -82,7 +84,15 @@ public class TimeHandler extends BasePositionHandler {
                 position.setDeviceTime(position.getServerTime());
                 position.setFixTime(position.getServerTime());
                 break;
-            case "deviceTime":
+            case "hybridTime":
+                if (position.getDeviceTime() != null && position.getServerTime() != null
+                        && position.getDeviceTime().getTime() < position.getServerTime().getTime() - hybridTimeMillis) {
+                    position.setDeviceTime(position.getServerTime());
+                    position.setFixTime(position.getServerTime());
+                } else {
+                    position.setFixTime(position.getDeviceTime());
+                }
+                break;
             default:
                 position.setFixTime(position.getDeviceTime());
                 break;

--- a/src/test/java/org/traccar/handler/TimeHandlerTest.java
+++ b/src/test/java/org/traccar/handler/TimeHandlerTest.java
@@ -1,12 +1,22 @@
 package org.traccar.handler;
 
 import org.junit.jupiter.api.Test;
+import org.traccar.config.Config;
+import org.traccar.config.Keys;
+import org.traccar.handler.TimeHandler;
+import org.traccar.model.Device;
+import org.traccar.model.Position;
+import org.traccar.session.cache.CacheManager;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TimeHandlerTest {
 
@@ -31,6 +41,88 @@ public class TimeHandlerTest {
 
         assertEquals(epochTime, TimeHandler.adjustRollover(currentTime, new Date(epochTime)).getTime());
 
+    }
+
+    @Test
+    public void testHybridTimeUsesDefaultSevenDaysThreshold() {
+        Config config = new Config();
+        CacheManager cacheManager = mock(CacheManager.class);
+        Device device = new Device();
+        device.setId(1);
+        device.set(Keys.TIME_OVERRIDE.getKey(), "hybridTime");
+        when(cacheManager.getObject(eq(Device.class), eq(1L))).thenReturn(device);
+        when(cacheManager.getConfig()).thenReturn(config);
+
+        TimeHandler handler = new TimeHandler(config, cacheManager);
+
+        Date serverTime = Date.from(Instant.parse("2025-08-19T00:00:00Z"));
+        Date deviceTime = Date.from(Instant.parse("2025-08-10T00:00:00Z"));
+        Position position = new Position("test");
+        position.setDeviceId(1);
+        position.setServerTime(serverTime);
+        position.setDeviceTime(deviceTime);
+        position.setFixTime(deviceTime);
+
+        handler.onPosition(position, ignored -> {
+        });
+
+        assertEquals(serverTime, position.getDeviceTime());
+        assertEquals(serverTime, position.getFixTime());
+    }
+
+    @Test
+    public void testHybridTimeKeepsDeviceTimeWithinThreshold() {
+        Config config = new Config();
+        CacheManager cacheManager = mock(CacheManager.class);
+        Device device = new Device();
+        device.setId(1);
+        device.set(Keys.TIME_OVERRIDE.getKey(), "hybridTime");
+        when(cacheManager.getObject(eq(Device.class), eq(1L))).thenReturn(device);
+        when(cacheManager.getConfig()).thenReturn(config);
+
+        TimeHandler handler = new TimeHandler(config, cacheManager);
+
+        Date serverTime = Date.from(Instant.parse("2025-08-19T00:00:00Z"));
+        Date deviceTime = Date.from(Instant.parse("2025-08-15T00:00:00Z"));
+        Position position = new Position("test");
+        position.setDeviceId(1);
+        position.setServerTime(serverTime);
+        position.setDeviceTime(deviceTime);
+        position.setFixTime(deviceTime);
+
+        handler.onPosition(position, ignored -> {
+        });
+
+        assertEquals(deviceTime, position.getDeviceTime());
+        assertEquals(deviceTime, position.getFixTime());
+    }
+
+    @Test
+    public void testHybridTimeUsesCustomThresholdFromConfig() {
+        Config config = new Config();
+        config.setString(Keys.HYBRID_TIME_DAYS, "3");
+        CacheManager cacheManager = mock(CacheManager.class);
+        Device device = new Device();
+        device.setId(1);
+        device.set(Keys.TIME_OVERRIDE.getKey(), "hybridTime");
+        when(cacheManager.getObject(eq(Device.class), eq(1L))).thenReturn(device);
+        when(cacheManager.getConfig()).thenReturn(config);
+
+        TimeHandler handler = new TimeHandler(config, cacheManager);
+
+        Date serverTime = Date.from(Instant.parse("2025-08-19T00:00:00Z"));
+        Date deviceTime = Date.from(Instant.parse("2025-08-15T00:00:00Z"));
+        Position position = new Position("test");
+        position.setDeviceId(1);
+        position.setServerTime(serverTime);
+        position.setDeviceTime(deviceTime);
+        position.setFixTime(deviceTime);
+
+        handler.onPosition(position, ignored -> {
+        });
+
+        assertEquals(serverTime, position.getDeviceTime());
+        assertEquals(serverTime, position.getFixTime());
     }
 
 }


### PR DESCRIPTION
When Traccar Server have to hande hybrid devices, some sending the right deviceTime and other wiht bug deviceTime (lot of days or years ago), TimeHanderl_Hybrid filter bad deviceTime using the HYBRID_TIME_DAYS config value (Default: 7 days).