### PR TITLE
Add support for JT808 terminal attribute report (0x0107) ICCID decoding

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -558,7 +558,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             return position;
 
-        }        
+        }
 
         return null;
     }

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -436,12 +436,12 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             getLastLocation(position, null);
 
-            buf.skipBytes(2); // terminal type
+            buf.readUnsignedShort(); // terminal type
             buf.skipBytes(5); // manufacturer id
             buf.skipBytes(20); // terminal model
             buf.skipBytes(7); // terminal id
 
-            position.set(Position.KEY_ICCID, ByteBufUtil.hexDump(buf.readSlice(10)).replaceAll("f", ""));
+            position.set(Position.KEY_ICCID, ByteBufUtil.hexDump(buf.readSlice(10)).substring(0, 20));
 
             return position;
 

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -441,7 +441,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
             buf.skipBytes(20); // terminal model
             buf.skipBytes(7); // terminal id
 
-            position.set(Position.KEY_ICCID, ByteBufUtil.hexDump(buf.readSlice(10)).substring(0, 20));
+            position.set(Position.KEY_ICCID, ByteBufUtil.hexDump(buf.readSlice(10)));
 
             return position;
 

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -70,6 +70,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_TERMINAL_REGISTER_RESPONSE = 0x8100;
     public static final int MSG_TERMINAL_CONTROL = 0x8105;
     public static final int MSG_TERMINAL_AUTH = 0x0102;
+    public static final int MSG_TERMINAL_ATTRIBUTES = 0x0107;
     public static final int MSG_LOCATION_REPORT = 0x0200;
     public static final int MSG_LOCATION_BATCH_2 = 0x0210;
     public static final int MSG_ACCELERATION = 0x2070;
@@ -426,6 +427,24 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             sendGeneralResponse(channel, remoteAddress, id, type, index);
 
+        } else if (type == MSG_TERMINAL_ATTRIBUTES) {
+
+            sendGeneralResponse(channel, remoteAddress, id, type, index);
+
+            Position position = new Position(getProtocolName());
+            position.setDeviceId(deviceSession.getDeviceId());
+
+            getLastLocation(position, null);
+
+            buf.skipBytes(2); // terminal type
+            buf.skipBytes(5); // manufacturer id
+            buf.skipBytes(20); // terminal model
+            buf.skipBytes(7); // terminal id
+
+            position.set(Position.KEY_ICCID, ByteBufUtil.hexDump(buf.readSlice(10)).replaceAll("f", ""));
+
+            return position;
+
         } else if (type == MSG_LOCATION_REPORT) {
 
             sendGeneralResponse(channel, remoteAddress, id, type, index);
@@ -539,7 +558,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
 
             return position;
 
-        }
+        }        
 
         return null;
     }

--- a/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
@@ -361,6 +361,10 @@ public class Jt808ProtocolDecoderTest extends ProtocolTest {
                 "7e0210000704546000231900884f2606180229579c7e"),
                 Position.KEY_BATTERY_LEVEL, 79);                
 
+        verifyAttribute(decoder, binary(
+                "7e0107004904546000563500030000584300000043354c00000000000000000000000000000000003938383731323589883030000131882455001943354c5f56322e3620323032362f30362f30342031353a33310301f47e"),
+                Position.KEY_ICCID, "89883030000131882455");
+
         decoder.setModelOverride("MV710G");
 
         verifyAttribute(decoder, binary(


### PR DESCRIPTION
## Summary

Add support for decoding ICCID information from JT808 terminal attribute report messages (0x0107).

## Details

Some devices report terminal information using message ID 0x0107 immediately after connection. The message contains device metadata including terminal model, terminal ID, ICCID, hardware version, and firmware version.

The current decoder ignores 0x0107 messages, causing ICCID information to be unavailable until a vendor-specific (e.g. 0x1107) message is received. This change adds support for extracting the ICCID from the standard JT808 terminal attribute report.

## Protocol Reference

[Xchinchun JT808.docx](https://github.com/user-attachments/files/29208352/Xchinchun.JT808.docx)

- Page 33
- Section 2.22: Query Terminal Attribute Reporting (0x0107)

The specification defines the following fields in the 0x0107 message:

- Terminal Type
- Manufacturer ID
- Terminal Model
- Terminal ID
- Terminal SIM Card ICCID (BCD[10])
- Hardware Version
- Firmware Version

This change decodes the standard ICCID field from the terminal attribute report and stores it in `Position.KEY_ICCID`.

## Testing

Added a unit test using a real C5L terminal attribute report frame containing:

- Model: C5L
- ICCID: 89883030000131882455
- Firmware Version: C5L_V2.6 2026/06/04 15:31

The test verifies that the decoder correctly extracts and stores the ICCID from the 0x0107 message.