### PR TITLE
Add support for the Xinchun time zone synchronization command (0x1007) by sending a general response (0x8001)

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -424,7 +424,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
             }
 
         } else if (type == MSG_TERMINAL_AUTH || type == MSG_HEARTBEAT_2
-                || type == MSG_PHOTO || type == MSG_TERMINAL_LOGOUT) {
+                || type == MSG_PHOTO || type == MSG_TERMINAL_LOGOUT || type == MSG_TIMEZONE_SYNC) {
 
             sendGeneralResponse(channel, remoteAddress, id, type, index);
 
@@ -494,10 +494,6 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
                 channel.writeAndFlush(new NetworkMessage(
                         formatMessage(MSG_TERMINAL_REGISTER_RESPONSE, id, false, response), remoteAddress));
             }
-
-        } else if (type == MSG_TIMEZONE_SYNC) {
-
-            sendGeneralResponse(channel, remoteAddress, id, type, index);
 
         } else if (type == MSG_ACCELERATION) {
 

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -80,6 +80,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_OIL_CONTROL = 0XA006;
     public static final int MSG_TIME_SYNC_REQUEST = 0x0109;
     public static final int MSG_TIME_SYNC_RESPONSE = 0x8109;
+    public static final int MSG_TIMEZONE_SYNC = 0x1007;
     public static final int MSG_PHOTO = 0x8888;
     public static final int MSG_TRANSPARENT = 0x0900;
     public static final int MSG_TRANSPARENT_DOWNLINK = 0x8900;
@@ -493,6 +494,10 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
                 channel.writeAndFlush(new NetworkMessage(
                         formatMessage(MSG_TERMINAL_REGISTER_RESPONSE, id, false, response), remoteAddress));
             }
+
+        } else if (type == MSG_TIMEZONE_SYNC) {
+
+            sendGeneralResponse(channel, remoteAddress, id, type, index);
 
         } else if (type == MSG_ACCELERATION) {
 

--- a/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
@@ -369,6 +369,9 @@ public class Jt808ProtocolDecoderTest extends ProtocolTest {
                 "7e0107004904546000563500030000584300000043354c00000000000000000000000000000000003938383731323589883030000131882455001943354c5f56322e3620323032362f30362f30342031353a33310301f47e"),
                 Position.KEY_ICCID, "89883030000131882455");
 
+        verifyNull(decoder, binary(
+                "7e10070004045460002319090640000000567e"));
+
         decoder.setModelOverride("MV710G");
 
         verifyAttribute(decoder, binary(


### PR DESCRIPTION
## Details

Some devices send message ID 0x1007 after authentication and before the first location report. The current decoder does not explicitly handle this message and does not send a response.

This change adds support for 0x1007 and acknowledges the message with a standard JT808 general response (0x8001).

No position data is contained in this message and no device attributes are currently updated.

## Protocol Reference

[Xchinchun JT808.docx](https://github.com/user-attachments/files/29297571/Xchinchun.JT808.docx)

* Page 41
* Section 3.7: Time Zone Synchronization Command (0x1007)

The protocol defines a 4-byte payload containing time zone information.

Example frame observed from a C5L device:

```text
7e10070004045460002319090640000000567e
```

Payload:

```text
40 00 00 00
```

According to the protocol specification, the first byte represents the configured time zone. In this example, the value corresponds to GMT+8.

## Future Improvements

The time zone value is currently not stored or applied by the decoder.

While the protocol provides time zone information, this change intentionally limits the implementation to acknowledging the message. The observed devices report GMT+8, which matches the existing default behavior and does not currently provide any additional information required by the decoder.

Future work could include:

* Decoding the reported time zone value into a human-readable UTC offset
* Storing the reported device time zone as a device attribute
* Applying the reported time zone to device-specific date parsing where appropriate

These enhancements can be implemented later if devices are observed reporting different time zone values or if additional use cases require access to the reported configuration.

## Testing

Added a unit test using a real device frame to verify that the decoder accepts and processes the 0x1007 message without generating a position.

The message has been observed consistently on C5L devices immediately after authentication and before the first location report following a reconnect.
