### PR TITLE
Fix JT808 0x0109 Time Synchronization Response

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -491,8 +491,9 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
                 response.writeByte(calendar.get(Calendar.HOUR_OF_DAY));
                 response.writeByte(calendar.get(Calendar.MINUTE));
                 response.writeByte(calendar.get(Calendar.SECOND));
+                response.writeByte(RESULT_SUCCESS);
                 channel.writeAndFlush(new NetworkMessage(
-                        formatMessage(MSG_TERMINAL_REGISTER_RESPONSE, id, false, response), remoteAddress));
+                        formatMessage(MSG_TIME_SYNC_RESPONSE, id, false, response), remoteAddress));
             }
 
         } else if (type == MSG_ACCELERATION) {


### PR DESCRIPTION
### Description

This PR corrects the response generated for JT808 **0x0109 (Time Synchronization Request)**.

### Changes

* Respond with **0x8109 (Time Synchronization Response)** instead of **0x8100 (Terminal Register Response)**.
* Include the **result/status byte (0x00 = Success)** in the response payload.

### Motivation

The decoder already defines both message IDs (`0x0109` and `0x8109`), but the current implementation replies using the terminal registration response (`0x8100`). Returning the dedicated time synchronization response improves protocol compliance and interoperability with devices that expect the standard reply.

### Evidence

See the [Xchinchun JT808.docx](https://github.com/user-attachments/files/29335613/Xchinchun.JT808.docx):

* **Section:** Time Synchronization
* **Message IDs:** `0x0109` (Time Synchronization Request) / `0x8109` (Time Synchronization Response)
* **Page:** 13 (Time Synchronization section) *(according to the Xchinchun JT808 protocol documentation provided with this project).*

### Test

I did not add a dedicated unit test for this small change because the fix only corrects the response message type used for an already handled message.