### PR TITLE
Make memory storage concurrent-safe

### DIFF
--- a/src/main/java/org/traccar/storage/MemoryStorage.java
+++ b/src/main/java/org/traccar/storage/MemoryStorage.java
@@ -49,7 +49,9 @@ public class MemoryStorage extends Storage {
         Server server = new Server();
         server.setId(1);
         server.setRegistration(true);
-        objects.computeIfAbsent(Server.class, key -> new ConcurrentHashMap<>()).put(server.getId(), server);
+        Map<Long, Object> servers = new ConcurrentHashMap<>();
+        servers.put(server.getId(), server);
+        objects.put(Server.class, servers);
     }
 
     @Override

--- a/src/main/java/org/traccar/storage/MemoryStorage.java
+++ b/src/main/java/org/traccar/storage/MemoryStorage.java
@@ -29,19 +29,19 @@ import org.traccar.storage.query.Request;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 public class MemoryStorage extends Storage {
 
-    private final Map<Class<?>, Map<Long, Object>> objects = new HashMap<>();
-    private final Map<Pair<Class<?>, Class<?>>, Set<Pair<Long, Long>>> permissions = new HashMap<>();
+    private final Map<Class<?>, Map<Long, Object>> objects = new ConcurrentHashMap<>();
+    private final Map<Pair<Class<?>, Class<?>>, Set<Pair<Long, Long>>> permissions = new ConcurrentHashMap<>();
 
     private final AtomicLong increment = new AtomicLong();
 
@@ -49,7 +49,11 @@ public class MemoryStorage extends Storage {
         Server server = new Server();
         server.setId(1);
         server.setRegistration(true);
-        objects.put(Server.class, Map.of(server.getId(), server));
+        getObjectMap(Server.class).put(server.getId(), server);
+    }
+
+    private Map<Long, Object> getObjectMap(Class<?> clazz) {
+        return objects.computeIfAbsent(clazz, key -> new ConcurrentHashMap<>());
     }
 
     @Override
@@ -61,7 +65,7 @@ public class MemoryStorage extends Storage {
 
     @Override
     public <T> Stream<T> getObjectsStream(Class<T> clazz, Request request) {
-        var stream = objects.computeIfAbsent(clazz, key -> new HashMap<>()).values().stream()
+        var stream = getObjectMap(clazz).values().stream()
                 .filter(object -> checkCondition(request.getCondition(), object));
         Order order = request.getOrder();
         if (order != null) {
@@ -128,7 +132,7 @@ public class MemoryStorage extends Storage {
                 if (condition.getDeviceId() > 0 && positionDeviceId != condition.getDeviceId()) {
                     yield false;
                 }
-                yield objects.computeIfAbsent(Device.class, key -> new HashMap<>()).values().stream()
+                yield getObjectMap(Device.class).values().stream()
                         .anyMatch(device -> (Long) retrieveValue(device, "positionId") == positionId);
             }
             default -> false;
@@ -179,7 +183,7 @@ public class MemoryStorage extends Storage {
             if (!result.add(groupId)) {
                 break;
             }
-            Object group = objects.computeIfAbsent(Group.class, key -> new HashMap<>()).get(groupId);
+            Object group = getObjectMap(Group.class).get(groupId);
             if (group instanceof GroupedModel parent) {
                 groupId = parent.getGroupId();
             } else {
@@ -200,7 +204,7 @@ public class MemoryStorage extends Storage {
     @Override
     public <T> long addObject(T entity, Request request) {
         long id = increment.incrementAndGet();
-        objects.computeIfAbsent(entity.getClass(), key -> new HashMap<>()).put(id, entity);
+        getObjectMap(entity.getClass()).put(id, entity);
         return id;
     }
 
@@ -209,9 +213,10 @@ public class MemoryStorage extends Storage {
         Collection<Object> items;
         if (request.getCondition() != null) {
             long id = (Long) ((Condition.Equals) request.getCondition()).getValue();
-            items = List.of(objects.computeIfAbsent(entity.getClass(), key -> new HashMap<>()).get(id));
+            Object item = getObjectMap(entity.getClass()).get(id);
+            items = item != null ? List.of(item) : List.of();
         } else {
-            items = objects.computeIfAbsent(entity.getClass(), key -> new HashMap<>()).values();
+            items = getObjectMap(entity.getClass()).values();
         }
         var getters = ReflectionCache.getProperties(entity.getClass(), "get");
         var setters = ReflectionCache.getProperties(entity.getClass(), "set");
@@ -232,11 +237,11 @@ public class MemoryStorage extends Storage {
     @Override
     public void removeObject(Class<?> clazz, Request request) {
         long id = (Long) ((Condition.Equals) request.getCondition()).getValue();
-        objects.computeIfAbsent(clazz, key -> new HashMap<>()).remove(id);
+        getObjectMap(clazz).remove(id);
     }
 
     private Set<Pair<Long, Long>> getPermissionsSet(Class<?> ownerClass, Class<?> propertyClass) {
-        return permissions.computeIfAbsent(new Pair<>(ownerClass, propertyClass), k -> new HashSet<>());
+        return permissions.computeIfAbsent(new Pair<>(ownerClass, propertyClass), k -> ConcurrentHashMap.newKeySet());
     }
 
     @Override

--- a/src/main/java/org/traccar/storage/MemoryStorage.java
+++ b/src/main/java/org/traccar/storage/MemoryStorage.java
@@ -49,9 +49,7 @@ public class MemoryStorage extends Storage {
         Server server = new Server();
         server.setId(1);
         server.setRegistration(true);
-        Map<Long, Object> servers = new ConcurrentHashMap<>();
-        servers.put(server.getId(), server);
-        objects.put(Server.class, servers);
+        objects.put(Server.class, Map.of(server.getId(), server));
     }
 
     @Override

--- a/src/main/java/org/traccar/storage/MemoryStorage.java
+++ b/src/main/java/org/traccar/storage/MemoryStorage.java
@@ -49,11 +49,7 @@ public class MemoryStorage extends Storage {
         Server server = new Server();
         server.setId(1);
         server.setRegistration(true);
-        getObjectMap(Server.class).put(server.getId(), server);
-    }
-
-    private Map<Long, Object> getObjectMap(Class<?> clazz) {
-        return objects.computeIfAbsent(clazz, key -> new ConcurrentHashMap<>());
+        objects.computeIfAbsent(Server.class, key -> new ConcurrentHashMap<>()).put(server.getId(), server);
     }
 
     @Override
@@ -65,7 +61,7 @@ public class MemoryStorage extends Storage {
 
     @Override
     public <T> Stream<T> getObjectsStream(Class<T> clazz, Request request) {
-        var stream = getObjectMap(clazz).values().stream()
+        var stream = objects.computeIfAbsent(clazz, key -> new ConcurrentHashMap<>()).values().stream()
                 .filter(object -> checkCondition(request.getCondition(), object));
         Order order = request.getOrder();
         if (order != null) {
@@ -132,7 +128,7 @@ public class MemoryStorage extends Storage {
                 if (condition.getDeviceId() > 0 && positionDeviceId != condition.getDeviceId()) {
                     yield false;
                 }
-                yield getObjectMap(Device.class).values().stream()
+                yield objects.computeIfAbsent(Device.class, key -> new ConcurrentHashMap<>()).values().stream()
                         .anyMatch(device -> (Long) retrieveValue(device, "positionId") == positionId);
             }
             default -> false;
@@ -183,7 +179,7 @@ public class MemoryStorage extends Storage {
             if (!result.add(groupId)) {
                 break;
             }
-            Object group = getObjectMap(Group.class).get(groupId);
+            Object group = objects.computeIfAbsent(Group.class, key -> new ConcurrentHashMap<>()).get(groupId);
             if (group instanceof GroupedModel parent) {
                 groupId = parent.getGroupId();
             } else {
@@ -204,7 +200,7 @@ public class MemoryStorage extends Storage {
     @Override
     public <T> long addObject(T entity, Request request) {
         long id = increment.incrementAndGet();
-        getObjectMap(entity.getClass()).put(id, entity);
+        objects.computeIfAbsent(entity.getClass(), key -> new ConcurrentHashMap<>()).put(id, entity);
         return id;
     }
 
@@ -213,10 +209,10 @@ public class MemoryStorage extends Storage {
         Collection<Object> items;
         if (request.getCondition() != null) {
             long id = (Long) ((Condition.Equals) request.getCondition()).getValue();
-            Object item = getObjectMap(entity.getClass()).get(id);
+            Object item = objects.computeIfAbsent(entity.getClass(), key -> new ConcurrentHashMap<>()).get(id);
             items = item != null ? List.of(item) : List.of();
         } else {
-            items = getObjectMap(entity.getClass()).values();
+            items = objects.computeIfAbsent(entity.getClass(), key -> new ConcurrentHashMap<>()).values();
         }
         var getters = ReflectionCache.getProperties(entity.getClass(), "get");
         var setters = ReflectionCache.getProperties(entity.getClass(), "set");
@@ -237,7 +233,7 @@ public class MemoryStorage extends Storage {
     @Override
     public void removeObject(Class<?> clazz, Request request) {
         long id = (Long) ((Condition.Equals) request.getCondition()).getValue();
-        getObjectMap(clazz).remove(id);
+        objects.computeIfAbsent(clazz, key -> new ConcurrentHashMap<>()).remove(id);
     }
 
     private Set<Pair<Long, Long>> getPermissionsSet(Class<?> ownerClass, Class<?> propertyClass) {


### PR DESCRIPTION
Update `MemoryStorage` to use concurrent collections for shared in-memory object and permission maps.

The previous implementation used regular `HashMap` instances and exposed lazy streams over `values()`. With `database.memory=true` and `database.registerUnknown=true`, concurrent device logins can read from `getObjectsStream()` while another thread registers or updates an object, which can trigger `ConcurrentModificationException`.

This change replaces the shared maps with `ConcurrentHashMap`, centralizes object-map creation through `getObjectMap()`, and uses concurrent permission sets. This keeps the in-memory storage behavior unchanged while making concurrent access from decoder/session threads safer.