### PR TITLE
fixed #5925: added dynamic periodinterval

### DIFF
--- a/src/main/java/org/traccar/api/resource/ReportResource.java
+++ b/src/main/java/org/traccar/api/resource/ReportResource.java
@@ -19,6 +19,7 @@ package org.traccar.api.resource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Context;
 import org.traccar.api.SimpleObjectResource;
+import org.traccar.helper.DateUtil;
 import org.traccar.helper.LogAction;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
@@ -237,10 +238,12 @@ public class ReportResource extends SimpleObjectResource<Report> {
             @QueryParam("groupId") List<Long> groupIds,
             @QueryParam("from") Date from,
             @QueryParam("to") Date to,
-            @QueryParam("daily") boolean daily) throws StorageException {
+            @QueryParam("daily") boolean daily,
+            @QueryParam("reportInterval") String reportInterval) throws StorageException {
         permissionsService.checkRestriction(getUserId(), UserRestrictions::getDisableReports);
         actionLogger.report(request, getUserId(), false, "summary", from, to, deviceIds, groupIds);
-        return summaryReportProvider.getObjects(getUserId(), deviceIds, groupIds, from, to, daily);
+        return summaryReportProvider.getObjects(getUserId(), deviceIds, groupIds, from, to,
+            DateUtil.nextSummaryReportInterval(reportInterval, daily));
     }
 
     @Path("summary")
@@ -252,11 +255,13 @@ public class ReportResource extends SimpleObjectResource<Report> {
             @QueryParam("from") Date from,
             @QueryParam("to") Date to,
             @QueryParam("daily") boolean daily,
+            @QueryParam("reportInterval") String reportInterval,
             @QueryParam("mail") boolean mail) throws StorageException {
         permissionsService.checkRestriction(getUserId(), UserRestrictions::getDisableReports);
         return executeReport(getUserId(), mail, stream -> {
             actionLogger.report(request, getUserId(), false, "summary", from, to, deviceIds, groupIds);
-            summaryReportProvider.getExcel(stream, getUserId(), deviceIds, groupIds, from, to, daily);
+            summaryReportProvider.getExcel(stream, getUserId(), deviceIds, groupIds, from, to,
+                DateUtil.nextSummaryReportInterval(reportInterval, daily));
         });
     }
 
@@ -269,8 +274,9 @@ public class ReportResource extends SimpleObjectResource<Report> {
             @QueryParam("from") Date from,
             @QueryParam("to") Date to,
             @QueryParam("daily") boolean daily,
+            @QueryParam("reportInterval") String reportInterval,
             @PathParam("type") String type) throws StorageException {
-        return getSummaryExcel(deviceIds, groupIds, from, to, daily, type.equals("mail"));
+        return getSummaryExcel(deviceIds, groupIds, from, to, daily, reportInterval, type.equals("mail"));
     }
 
     @Path("trips")

--- a/src/main/java/org/traccar/api/resource/ReportResource.java
+++ b/src/main/java/org/traccar/api/resource/ReportResource.java
@@ -19,8 +19,8 @@ package org.traccar.api.resource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Context;
 import org.traccar.api.SimpleObjectResource;
-import org.traccar.helper.DateUtil;
 import org.traccar.helper.LogAction;
+import org.traccar.helper.Parser;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 import org.traccar.model.Report;
@@ -238,12 +238,11 @@ public class ReportResource extends SimpleObjectResource<Report> {
             @QueryParam("groupId") List<Long> groupIds,
             @QueryParam("from") Date from,
             @QueryParam("to") Date to,
-            @QueryParam("daily") boolean daily,
             @QueryParam("reportInterval") String reportInterval) throws StorageException {
         permissionsService.checkRestriction(getUserId(), UserRestrictions::getDisableReports);
         actionLogger.report(request, getUserId(), false, "summary", from, to, deviceIds, groupIds);
         return summaryReportProvider.getObjects(getUserId(), deviceIds, groupIds, from, to,
-            DateUtil.nextSummaryReportInterval(reportInterval, daily));
+            Parser.parseDateInterval(reportInterval));
     }
 
     @Path("summary")
@@ -254,14 +253,13 @@ public class ReportResource extends SimpleObjectResource<Report> {
             @QueryParam("groupId") List<Long> groupIds,
             @QueryParam("from") Date from,
             @QueryParam("to") Date to,
-            @QueryParam("daily") boolean daily,
             @QueryParam("reportInterval") String reportInterval,
             @QueryParam("mail") boolean mail) throws StorageException {
         permissionsService.checkRestriction(getUserId(), UserRestrictions::getDisableReports);
         return executeReport(getUserId(), mail, stream -> {
             actionLogger.report(request, getUserId(), false, "summary", from, to, deviceIds, groupIds);
             summaryReportProvider.getExcel(stream, getUserId(), deviceIds, groupIds, from, to,
-                DateUtil.nextSummaryReportInterval(reportInterval, daily));
+                Parser.parseDateInterval(reportInterval));
         });
     }
 
@@ -273,10 +271,9 @@ public class ReportResource extends SimpleObjectResource<Report> {
             @QueryParam("groupId") List<Long> groupIds,
             @QueryParam("from") Date from,
             @QueryParam("to") Date to,
-            @QueryParam("daily") boolean daily,
             @QueryParam("reportInterval") String reportInterval,
             @PathParam("type") String type) throws StorageException {
-        return getSummaryExcel(deviceIds, groupIds, from, to, daily, reportInterval, type.equals("mail"));
+        return getSummaryExcel(deviceIds, groupIds, from, to, reportInterval, type.equals("mail"));
     }
 
     @Path("trips")

--- a/src/main/java/org/traccar/helper/DateUtil.java
+++ b/src/main/java/org/traccar/helper/DateUtil.java
@@ -15,9 +15,12 @@
  */
 package org.traccar.helper;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -78,6 +81,54 @@ public final class DateUtil {
         } else {
             return LOCAL_DATE_TIME.format(date.toInstant());
         }
+    }
+
+    public enum SummaryReportInterval {
+        NONE,
+        DAILY,
+        WEEKLY,
+        MONTHLY,
+        YEARLY
+    }
+
+    public static SummaryReportInterval nextSummaryReportInterval(String reportInterval, boolean daily) {
+        if (daily) {
+            return SummaryReportInterval.DAILY;
+        }else if (reportInterval == null) {
+            return SummaryReportInterval.NONE;
+        }
+        switch (reportInterval) {
+            case "daily" -> {
+                return SummaryReportInterval.DAILY;
+            }
+            case "weekly" -> {
+                return SummaryReportInterval.WEEKLY;
+            }
+            case "monthly" -> {
+                return SummaryReportInterval.MONTHLY;
+            }
+            case "yearly" -> {
+                return SummaryReportInterval.YEARLY;
+            }
+            default -> {}
+        }
+        return SummaryReportInterval.NONE;
+    }
+
+    public static ZonedDateTime startOfZDTDay(ZonedDateTime date) {
+        return date.truncatedTo(ChronoUnit.DAYS);
+    }
+
+    public static ZonedDateTime startOfZDTWeek(ZonedDateTime date) {
+        return date.with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
+    }
+
+    public static ZonedDateTime startOfZDTMonth(ZonedDateTime date) {
+        return date.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+    }
+
+    public static ZonedDateTime startOfZDTYear(ZonedDateTime date) {
+        return date.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS);
     }
 
 }

--- a/src/main/java/org/traccar/helper/DateUtil.java
+++ b/src/main/java/org/traccar/helper/DateUtil.java
@@ -94,7 +94,7 @@ public final class DateUtil {
     public static SummaryReportInterval nextSummaryReportInterval(String reportInterval, boolean daily) {
         if (daily) {
             return SummaryReportInterval.DAILY;
-        }else if (reportInterval == null) {
+        } else if (reportInterval == null) {
             return SummaryReportInterval.NONE;
         }
         switch (reportInterval) {

--- a/src/main/java/org/traccar/helper/DateUtil.java
+++ b/src/main/java/org/traccar/helper/DateUtil.java
@@ -83,38 +83,6 @@ public final class DateUtil {
         }
     }
 
-    public enum SummaryReportInterval {
-        NONE,
-        DAILY,
-        WEEKLY,
-        MONTHLY,
-        YEARLY
-    }
-
-    public static SummaryReportInterval nextSummaryReportInterval(String reportInterval, boolean daily) {
-        if (daily) {
-            return SummaryReportInterval.DAILY;
-        } else if (reportInterval == null) {
-            return SummaryReportInterval.NONE;
-        }
-        switch (reportInterval) {
-            case "daily" -> {
-                return SummaryReportInterval.DAILY;
-            }
-            case "weekly" -> {
-                return SummaryReportInterval.WEEKLY;
-            }
-            case "monthly" -> {
-                return SummaryReportInterval.MONTHLY;
-            }
-            case "yearly" -> {
-                return SummaryReportInterval.YEARLY;
-            }
-            default -> {}
-        }
-        return SummaryReportInterval.NONE;
-    }
-
     public static ZonedDateTime startOfZDTDay(ZonedDateTime date) {
         return date.truncatedTo(ChronoUnit.DAYS);
     }

--- a/src/main/java/org/traccar/helper/Parser.java
+++ b/src/main/java/org/traccar/helper/Parser.java
@@ -367,22 +367,13 @@ public class Parser {
         if (reportInterval == null) {
             return null;
         }
-        switch (reportInterval) {
-            case "daily" -> {
-                return ChronoUnit.DAYS;
-            }
-            case "weekly" -> {
-                return ChronoUnit.WEEKS;
-            }
-            case "monthly" -> {
-                return ChronoUnit.MONTHS;
-            }
-            case "yearly" -> {
-                return ChronoUnit.YEARS;
-            }
-            default -> {}
-        }
-        return null;
+        return switch (reportInterval) {
+            case "daily" -> ChronoUnit.DAYS;
+            case "weekly" -> ChronoUnit.WEEKS;
+            case "monthly" -> ChronoUnit.MONTHS;
+            case "yearly" -> ChronoUnit.YEARS;
+            default -> null;
+        };
     }
 
 }

--- a/src/main/java/org/traccar/helper/Parser.java
+++ b/src/main/java/org/traccar/helper/Parser.java
@@ -15,6 +15,7 @@
  */
 package org.traccar.helper;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -360,6 +361,28 @@ public class Parser {
 
     public Date nextDateTime() {
         return nextDateTime(DateTimeFormat.YMD_HMS, null);
+    }
+
+    public static ChronoUnit parseDateInterval(String reportInterval) {
+        if (reportInterval == null) {
+            return null;
+        }
+        switch (reportInterval) {
+            case "daily" -> {
+                return ChronoUnit.DAYS;
+            }
+            case "weekly" -> {
+                return ChronoUnit.WEEKS;
+            }
+            case "monthly" -> {
+                return ChronoUnit.MONTHS;
+            }
+            case "yearly" -> {
+                return ChronoUnit.YEARS;
+            }
+            default -> {}
+        }
+        return null;
     }
 
 }

--- a/src/main/java/org/traccar/reports/SummaryReportProvider.java
+++ b/src/main/java/org/traccar/reports/SummaryReportProvider.java
@@ -43,7 +43,6 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;

--- a/src/main/java/org/traccar/reports/SummaryReportProvider.java
+++ b/src/main/java/org/traccar/reports/SummaryReportProvider.java
@@ -25,6 +25,7 @@ import org.traccar.helper.model.AttributeUtil;
 import org.traccar.helper.model.DeviceUtil;
 import org.traccar.helper.model.PositionUtil;
 import org.traccar.helper.model.UserUtil;
+import org.traccar.helper.DateUtil;
 import org.traccar.model.Device;
 import org.traccar.model.Position;
 import org.traccar.reports.common.ReportUtils;
@@ -123,17 +124,50 @@ public class SummaryReportProvider {
     }
 
     private Collection<SummaryReportItem> calculateDeviceResults(
-            Device device, ZonedDateTime from, ZonedDateTime to, boolean daily) throws StorageException {
+            Device device, ZonedDateTime from, ZonedDateTime to,
+            DateUtil.SummaryReportInterval reportInterval) throws StorageException {
 
         boolean fast = Duration.between(from, to).toSeconds() > config.getLong(Keys.REPORT_FAST_THRESHOLD);
         var results = new ArrayList<SummaryReportItem>();
-        if (daily) {
-            while (from.truncatedTo(ChronoUnit.DAYS).isBefore(to.truncatedTo(ChronoUnit.DAYS))) {
-                ZonedDateTime fromDay = from.truncatedTo(ChronoUnit.DAYS);
-                ZonedDateTime nextDay = fromDay.plusDays(1);
-                results.addAll(calculateDeviceResult(
-                        device, Date.from(from.toInstant()), Date.from(nextDay.toInstant()), fast));
-                from = nextDay;
+        if (reportInterval != DateUtil.SummaryReportInterval.NONE) {
+            switch (reportInterval) {
+                case DateUtil.SummaryReportInterval.DAILY -> {
+                    while (DateUtil.startOfZDTDay(from).isBefore(DateUtil.startOfZDTDay(to))) {
+                        ZonedDateTime fromDay = DateUtil.startOfZDTDay(from);
+                        ZonedDateTime nextDay = fromDay.plusDays(1);
+                        results.addAll(calculateDeviceResult(device, Date.from(from.toInstant()),
+                            Date.from(nextDay.toInstant()), fast));
+                        from = nextDay;
+                    }
+                }
+                case DateUtil.SummaryReportInterval.WEEKLY -> {
+                    while (DateUtil.startOfZDTWeek(from).isBefore(DateUtil.startOfZDTWeek(to))) {
+                        ZonedDateTime fromWeek = DateUtil.startOfZDTWeek(from);
+                        ZonedDateTime nextWeek = fromWeek.plusWeeks(1);
+                        results.addAll(calculateDeviceResult(device, Date.from(from.toInstant()),
+                            Date.from(nextWeek.toInstant()), fast));
+                        from = nextWeek;
+                    }
+                }
+                case DateUtil.SummaryReportInterval.MONTHLY -> {
+                    while (DateUtil.startOfZDTMonth(from).isBefore(DateUtil.startOfZDTMonth(to))) {
+                        ZonedDateTime fromMonth = DateUtil.startOfZDTMonth(from);
+                        ZonedDateTime nextMonth = fromMonth.plusMonths(1);
+                        results.addAll(calculateDeviceResult(device, Date.from(from.toInstant()),
+                            Date.from(nextMonth.toInstant()), fast));
+                        from = nextMonth;
+                    }
+                }
+                case DateUtil.SummaryReportInterval.YEARLY -> {
+                    while (DateUtil.startOfZDTYear(from).isBefore(DateUtil.startOfZDTYear(to))) {
+                        ZonedDateTime fromYear = DateUtil.startOfZDTYear(from);
+                        ZonedDateTime nextYear = fromYear.plusYears(1);
+                        results.addAll(calculateDeviceResult(device, Date.from(from.toInstant()),
+                            Date.from(nextYear.toInstant()), fast));
+                        from = nextYear;
+                    }
+                }
+                default -> {}
             }
         }
         results.addAll(calculateDeviceResult(device, Date.from(from.toInstant()), Date.from(to.toInstant()), fast));
@@ -142,7 +176,8 @@ public class SummaryReportProvider {
 
     public Collection<SummaryReportItem> getObjects(
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
-            Date from, Date to, boolean daily) throws StorageException {
+            Date from, Date to,
+            DateUtil.SummaryReportInterval reportInterval) throws StorageException {
         reportUtils.checkPeriodLimit(from, to);
 
         var tz = UserUtil.getTimezone(permissionsService.getServer(), permissionsService.getUser(userId)).toZoneId();
@@ -150,7 +185,7 @@ public class SummaryReportProvider {
         ArrayList<SummaryReportItem> result = new ArrayList<>();
         for (Device device: DeviceUtil.getAccessibleDevices(storage, userId, deviceIds, groupIds)) {
             var deviceResults = calculateDeviceResults(
-                    device, from.toInstant().atZone(tz), to.toInstant().atZone(tz), daily);
+                    device, from.toInstant().atZone(tz), to.toInstant().atZone(tz), reportInterval);
             for (SummaryReportItem summaryReport : deviceResults) {
                 if (summaryReport.getStartTime() != null && summaryReport.getEndTime() != null) {
                     result.add(summaryReport);
@@ -162,8 +197,10 @@ public class SummaryReportProvider {
 
     public void getExcel(OutputStream outputStream,
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
-            Date from, Date to, boolean daily) throws StorageException, IOException {
-        Collection<SummaryReportItem> summaries = getObjects(userId, deviceIds, groupIds, from, to, daily);
+            Date from, Date to,
+            DateUtil.SummaryReportInterval reportInterval) throws StorageException, IOException {
+        Collection<SummaryReportItem> summaries = getObjects(userId, deviceIds, groupIds, from, to,
+                reportInterval);
 
         File file = Paths.get(config.getString(Keys.TEMPLATES_ROOT), "export", "summary.xlsx").toFile();
         try (InputStream inputStream = new FileInputStream(file)) {

--- a/src/main/java/org/traccar/reports/SummaryReportProvider.java
+++ b/src/main/java/org/traccar/reports/SummaryReportProvider.java
@@ -43,6 +43,7 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -124,13 +125,13 @@ public class SummaryReportProvider {
 
     private Collection<SummaryReportItem> calculateDeviceResults(
             Device device, ZonedDateTime from, ZonedDateTime to,
-            DateUtil.SummaryReportInterval reportInterval) throws StorageException {
+            ChronoUnit reportInterval) throws StorageException {
 
         boolean fast = Duration.between(from, to).toSeconds() > config.getLong(Keys.REPORT_FAST_THRESHOLD);
         var results = new ArrayList<SummaryReportItem>();
-        if (reportInterval != DateUtil.SummaryReportInterval.NONE) {
+        if (reportInterval != null) {
             switch (reportInterval) {
-                case DateUtil.SummaryReportInterval.DAILY -> {
+                case ChronoUnit.DAYS -> {
                     while (DateUtil.startOfZDTDay(from).isBefore(DateUtil.startOfZDTDay(to))) {
                         ZonedDateTime fromDay = DateUtil.startOfZDTDay(from);
                         ZonedDateTime nextDay = fromDay.plusDays(1);
@@ -139,7 +140,7 @@ public class SummaryReportProvider {
                         from = nextDay;
                     }
                 }
-                case DateUtil.SummaryReportInterval.WEEKLY -> {
+                case ChronoUnit.WEEKS -> {
                     while (DateUtil.startOfZDTWeek(from).isBefore(DateUtil.startOfZDTWeek(to))) {
                         ZonedDateTime fromWeek = DateUtil.startOfZDTWeek(from);
                         ZonedDateTime nextWeek = fromWeek.plusWeeks(1);
@@ -148,7 +149,7 @@ public class SummaryReportProvider {
                         from = nextWeek;
                     }
                 }
-                case DateUtil.SummaryReportInterval.MONTHLY -> {
+                case ChronoUnit.MONTHS -> {
                     while (DateUtil.startOfZDTMonth(from).isBefore(DateUtil.startOfZDTMonth(to))) {
                         ZonedDateTime fromMonth = DateUtil.startOfZDTMonth(from);
                         ZonedDateTime nextMonth = fromMonth.plusMonths(1);
@@ -157,7 +158,7 @@ public class SummaryReportProvider {
                         from = nextMonth;
                     }
                 }
-                case DateUtil.SummaryReportInterval.YEARLY -> {
+                case ChronoUnit.YEARS -> {
                     while (DateUtil.startOfZDTYear(from).isBefore(DateUtil.startOfZDTYear(to))) {
                         ZonedDateTime fromYear = DateUtil.startOfZDTYear(from);
                         ZonedDateTime nextYear = fromYear.plusYears(1);
@@ -176,7 +177,7 @@ public class SummaryReportProvider {
     public Collection<SummaryReportItem> getObjects(
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Date from, Date to,
-            DateUtil.SummaryReportInterval reportInterval) throws StorageException {
+            ChronoUnit reportInterval) throws StorageException {
         reportUtils.checkPeriodLimit(from, to);
 
         var tz = UserUtil.getTimezone(permissionsService.getServer(), permissionsService.getUser(userId)).toZoneId();
@@ -197,7 +198,7 @@ public class SummaryReportProvider {
     public void getExcel(OutputStream outputStream,
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Date from, Date to,
-            DateUtil.SummaryReportInterval reportInterval) throws StorageException, IOException {
+            ChronoUnit reportInterval) throws StorageException, IOException {
         Collection<SummaryReportItem> summaries = getObjects(userId, deviceIds, groupIds, from, to,
                 reportInterval);
 

--- a/src/main/java/org/traccar/reports/SummaryReportProvider.java
+++ b/src/main/java/org/traccar/reports/SummaryReportProvider.java
@@ -124,8 +124,7 @@ public class SummaryReportProvider {
     }
 
     private Collection<SummaryReportItem> calculateDeviceResults(
-            Device device, ZonedDateTime from, ZonedDateTime to,
-            ChronoUnit reportInterval) throws StorageException {
+            Device device, ZonedDateTime from, ZonedDateTime to, ChronoUnit reportInterval) throws StorageException {
 
         boolean fast = Duration.between(from, to).toSeconds() > config.getLong(Keys.REPORT_FAST_THRESHOLD);
         var results = new ArrayList<SummaryReportItem>();
@@ -176,8 +175,7 @@ public class SummaryReportProvider {
 
     public Collection<SummaryReportItem> getObjects(
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
-            Date from, Date to,
-            ChronoUnit reportInterval) throws StorageException {
+            Date from, Date to, ChronoUnit reportInterval) throws StorageException {
         reportUtils.checkPeriodLimit(from, to);
 
         var tz = UserUtil.getTimezone(permissionsService.getServer(), permissionsService.getUser(userId)).toZoneId();
@@ -197,8 +195,7 @@ public class SummaryReportProvider {
 
     public void getExcel(OutputStream outputStream,
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
-            Date from, Date to,
-            ChronoUnit reportInterval) throws StorageException, IOException {
+            Date from, Date to, ChronoUnit reportInterval) throws StorageException, IOException {
         Collection<SummaryReportItem> summaries = getObjects(userId, deviceIds, groupIds, from, to,
                 reportInterval);
 


### PR DESCRIPTION
This is a fix for #5925 <-- read this to see what it does

and cleaner overwrite for #5924 

NB: Currently, the code does not try to correct the user. For example: if the user sets a range of 1 month (from=01.06.2026 to=30.06.206) and chooses yearly view. The code respects the user choice and calculates the sum for that year WITHIN the date range, in this case within 1 month and not within that full year.