### PR TITLE
Allow generating session tokens for other users

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1621,6 +1621,9 @@ paths:
                 expiration:
                   type: string
                   format: date-time
+                userId:
+                  type: integer
+                  format: int64
         required: false
       responses:
         '200':

--- a/src/main/java/org/traccar/api/resource/SessionResource.java
+++ b/src/main/java/org/traccar/api/resource/SessionResource.java
@@ -145,14 +145,18 @@ public class SessionResource extends BaseResource {
     @Path("token")
     @POST
     public String requestToken(
-            @FormParam("expiration") Date expiration) throws StorageException, GeneralSecurityException, IOException {
+            @FormParam("expiration") Date expiration,
+            @FormParam("userId") Long userId) throws StorageException, GeneralSecurityException, IOException {
+        long currentUserId = getUserId();
+        long targetUserId = userId != null ? userId : currentUserId;
+        permissionsService.checkUser(currentUserId, targetUserId);
         Date currentExpiration = (Date) request.getSession().getAttribute(SessionHelper.EXPIRATION_KEY);
-        if (currentExpiration != null && currentExpiration.before(expiration)) {
+        if (currentExpiration != null && (expiration == null || currentExpiration.before(expiration))) {
             expiration = currentExpiration;
         }
-        String token = tokenManager.generateToken(getUserId(), expiration);
+        String token = tokenManager.generateToken(targetUserId, expiration);
         TokenManager.TokenData data = tokenManager.decodeToken(token);
-        actionLogger.token(request, getUserId(), data.getId());
+        actionLogger.token(request, targetUserId, data.getId());
         return token;
     }
 


### PR DESCRIPTION
## Summary
Add optional `userId` parameter to `POST /api/session/token` so
admin or manager accounts can request an access token on behalf of
another user without logging in as them.

## Changes
- `SessionResource.java`: new optional `userId` form param; permission
  check delegated to `PermissionsService.checkUser` (admin / manager
  with managed-user permission).
- `openapi.yaml`: document the new `userId` parameter.

## Backwards compatibility
The `userId` parameter is optional. Existing clients that omit it
keep working exactly as before (token is generated for the
authenticated user).

## Testing
- Admin can request tokens for any user.
- Manager can request tokens for their managed users (validated by
  existing `checkUser` logic).
- Non-admin / non-manager receives 403 when targeting another user.