### PR TITLE
Fix NullPointerException in PathAwayProtocolDecoder

### DIFF
--- a/src/main/java/org/traccar/protocol/PathAwayProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/PathAwayProtocolDecoder.java
@@ -32,6 +32,7 @@ import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class PathAwayProtocolDecoder extends BaseProtocolDecoder {
@@ -63,13 +64,23 @@ public class PathAwayProtocolDecoder extends BaseProtocolDecoder {
         FullHttpRequest request = (FullHttpRequest) msg;
         QueryStringDecoder decoder = new QueryStringDecoder(request.uri());
 
+        List<String> userNames = decoder.parameters().get("UserName");
+        if (userNames == null || userNames.isEmpty()) {
+            return null;
+        }
+
         DeviceSession deviceSession = getDeviceSession(
-                channel, remoteAddress, decoder.parameters().get("UserName").get(0));
+                channel, remoteAddress, userNames.get(0));
         if (deviceSession == null) {
             return null;
         }
 
-        Parser parser = new Parser(PATTERN, decoder.parameters().get("LOC").get(0));
+        List<String> locations = decoder.parameters().get("LOC");
+        if (locations == null || locations.isEmpty()) {
+            return null;
+        }
+
+        Parser parser = new Parser(PATTERN, locations.get(0));
         if (!parser.matches()) {
             return null;
         }

--- a/src/test/java/org/traccar/protocol/PathAwayProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/PathAwayProtocolDecoderTest.java
@@ -9,7 +9,11 @@ public class PathAwayProtocolDecoderTest extends ProtocolTest {
     public void testDecode() throws Exception {
 
         var decoder = inject(new PathAwayProtocolDecoder(null));
-        
+
+        verifyNull(decoder, request("/"));
+
+        verifyNull(decoder, request("/?UserName=name"));
+
         verifyPosition(decoder, request(
                 "?UserName=name&Password=pass&LOC=$PWS,1,\"Roger\",,,100107,122846,45.317270,-79.642219,45.00,42,1,\"Comment\",0*58"));
 


### PR DESCRIPTION
## Fix for Issue #5933

### Problem
PathAwayProtocolDecoder throws a NullPointerException at line 67 when receiving malformed HTTP requests (e.g., GET / HTTP/1.0) that lack the required UserName and LOC query parameters.

The root cause is that decoder.parameters().get(UserName) returns 
ull when the parameter is absent, and calling .get(0) on 
ull causes the NPE.

### Changes
**PathAwayProtocolDecoder.java**:
- Extract UserName and LOC parameter lists into local variables
- Add null/empty checks before accessing .get(0) — return 
ull gracefully if either parameter is missing
- Added import java.util.List

**PathAwayProtocolDecoderTest.java**:
- Added test for bare GET / request (no query params) — verifies null return, no NPE
- Added test for request with UserName only (no LOC) — verifies null return, no NPE

### Impact
- Malformed/scanner HTTP requests are now handled gracefully (return null, session disconnects cleanly)
- No behavior change for valid PathAway device requests
- Prevents silent session drops if a real PathAway device sends a truncated first packet

Fixes #5933