### PR TITLE
position removal logic in MemoryStorage

### DIFF
--- a/src/main/java/org/traccar/storage/MemoryStorage.java
+++ b/src/main/java/org/traccar/storage/MemoryStorage.java
@@ -204,14 +204,13 @@ public class MemoryStorage extends Storage {
         var items = objects.computeIfAbsent(entity.getClass(), key -> new ConcurrentHashMap<>());
 
         if (entity instanceof Position position) {
-            var iterator = items.values().iterator();
-            while (iterator.hasNext()) {
-                Position item = (Position) iterator.next();
+            for (var entry : items.entrySet()) {
+                Position item = (Position) entry.getValue();
                 if (item.getDeviceId() == position.getDeviceId()) {
                     if (item.getFixTime().after(position.getFixTime())) {
                         return id;
                     }
-                    iterator.remove();
+                    items.remove(entry.getKey(), item);
                     break;
                 }
             }


### PR DESCRIPTION
**This fixes a regression from my previous `MemoryStorage` change.**

My earlier change updated `MemoryStorage` to keep only the latest stored position per device when `database.memory=true` is used. That part worked conceptually, but I missed one important detail in the implementation.

The code removed older positions through the iterator of `ConcurrentHashMap.values()` using `iterator.remove()`. In production this caused repeated `ConcurrentModificationException` errors while devices were connecting and the cache was reading the latest position at the same time.

Example error:

`ConcurrentModificationException (... < Storage:64 < CacheManager:143 < ConnectionManager:174 < BaseProtocolDecoder:135 < ...)`

### What Changed

This change updates the removal logic in `MemoryStorage`:

1. Iterate over the map entries instead of only the values.
2. Remove the old position using the `ConcurrentHashMap` key/value remove API.
3. Keep the previous behavior of storing only the latest position per device.
4. Avoid mutating the values iterator during concurrent reads.

### Benefits

1. Fixes the `ConcurrentModificationException` seen in production.
2. Keeps the memory storage position limit behavior intact.
3. Makes the removal operation safer for concurrent access.
4. Keeps the fix local to `MemoryStorage`.

### Notes

Sorry for missing this in the original `MemoryStorage` fix. The previous implementation was too focused on reducing stored positions and overlooked the iterator behavior under concurrent access.