### PR TITLE
 Set SSLEngine to server mode for secure protocols

### DIFF
--- a/src/main/java/org/traccar/TrackerServer.java
+++ b/src/main/java/org/traccar/TrackerServer.java
@@ -66,6 +66,9 @@ public abstract class TrackerServer implements TrackerConnector {
                 try {
                     if (isSecure()) {
                         SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+                        // Server-side engine: the JSSE default use-client-mode is not
+                        // guaranteed across JVMs, so set server mode to present the cert.
+                        engine.setUseClientMode(false);
                         pipeline.addLast(new SslHandler(engine));
                     }
                 } catch (Exception e) {

--- a/src/main/java/org/traccar/TrackerServer.java
+++ b/src/main/java/org/traccar/TrackerServer.java
@@ -66,8 +66,6 @@ public abstract class TrackerServer implements TrackerConnector {
                 try {
                     if (isSecure()) {
                         SSLEngine engine = SSLContext.getDefault().createSSLEngine();
-                        // Server-side engine: the JSSE default use-client-mode is not
-                        // guaranteed across JVMs, so set server mode to present the cert.
                         engine.setUseClientMode(false);
                         pipeline.addLast(new SslHandler(engine));
                     }


### PR DESCRIPTION
`TrackerServer` builds the `SSLEngine` for a secure protocol via `SSLContext.getDefault().createSSLEngine()` and passes it to Netty's `SslHandler` without calling `setUseClientMode(false)`.

`SSLEngine`'s default mode is unspecified and varies across JVM vendors. On a JVM where it does not default to server mode, the server-side engine acts as a client: `it presents no certificate and the TLS handshake fails`. 
Clients see errors such as `"no peer certificate available"` / `"unexpected eof"`, and on some JVMs the JSSE stack throws "`Client/Server mode has not yet been set"`.

Setting the engine to server mode explicitly makes any `<protocol>.ssl` port complete the handshake consistently across JVMs.

Tested on OpenJDK 21: an `osmand.ssl` port now completes a TLS 1.3 handshake and presents the server certificate, where the handshake previously failed.