### PR TITLE
Fix accumulators getting overwritten bug due to caching

### DIFF
--- a/src/main/java/org/traccar/api/resource/DeviceResource.java
+++ b/src/main/java/org/traccar/api/resource/DeviceResource.java
@@ -49,6 +49,7 @@ import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -160,6 +161,7 @@ public class DeviceResource extends BaseObjectResource<Device> {
             if (entity.getHours() != null) {
                 position.getAttributes().put(Position.KEY_HOURS, entity.getHours());
             }
+            position.setServerTime(new Date());
             position.setId(storage.addObject(position, new Request(new Columns.Exclude("id"))));
 
             Device device = new Device();


### PR DESCRIPTION
This fix makes sure that cache always picks the updated position as latest position.

Addresses the following 2 issues (already closed).

#5892
#5882

Side note: I wonder if it would be a better idea to store accumulator values in device table or another new table.

Note: Tests are mostly written by AI (Grok 4.5), but I have confirmed they both fail without fix, and pass with fix.