### PR TITLE
Update Netty and PostgreSQL driver versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation "com.h2database:h2:2.4.240"
     implementation "com.mysql:mysql-connector-j:9.7.0"
     implementation "org.mariadb.jdbc:mariadb-java-client:3.5.8"
-    implementation "org.postgresql:postgresql:42.7.11"
+    implementation "org.postgresql:postgresql:42.7.13"
     implementation "com.kohlschutter.junixsocket:junixsocket-core:$junixsocketVersion"
     implementation "com.kohlschutter.junixsocket:junixsocket-mysql:$junixsocketVersion"
     implementation "com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     guiceVersion = "7.0.0"
     jettyVersion = "12.1.8"
     jerseyVersion = "4.0.2"
-    nettyVersion = "4.2.14.Final"
+    nettyVersion = "4.2.16.Final"
     protobufVersion = "4.35.0"
     jxlsVersion = "2.14.0" // version 3 has breaking changes
     junixsocketVersion = "2.10.1"


### PR DESCRIPTION
Fixes the two direct-dependency items from #5952: six HIGH advisories reported by Trivy against the `traccar/traccar:6.14.5` image, all fixed upstream before 6.14.5 was cut.

- **netty `4.2.14.Final` → `4.2.16.Final`** — clears CVE-2026-44249, CVE-2026-45416, CVE-2026-50010 (netty-handler) and CVE-2026-45674, CVE-2026-47691 (netty-resolver-dns). All five were fixed in 4.2.15.Final (2026-06-02); 4.2.16.Final (2026-07-07) is the current release. Patch-level bump within the same 4.2.x line.
- **postgresql `42.7.11` → `42.7.13`** — clears CVE-2026-54291 (silent channel-binding downgrade from SCRAM-SHA-256-PLUS with `channelBinding=require`). Fixed in REL42.7.12 (2026-06-29); REL42.7.13 (2026-07-06) is current.

Two commits, one per dependency, so either can be reverted independently. The remaining transitive findings from #5952 (jackson via jersey-media-json-jackson, commons-beanutils via velocity-tools) are intentionally not touched here.

**Verification** (JDK 21, `./gradlew build` = compile + checkstyle + full test suite):

- Baseline on unmodified master (c65980936): `BUILD SUCCESSFUL` — 597 tests, 0 failures, 0 errors, 27 skipped
- After both bumps: `BUILD SUCCESSFUL` — 597 tests, 0 failures, 0 errors, 27 skipped (same counts)

Resolved-dependency check (`gradlew dependencies --configuration runtimeClasspath`, diffed before vs after): every `io.netty:*` module resolves 4.2.14.Final → 4.2.16.Final, `org.postgresql:postgresql` resolves 42.7.13, and the only other movement is `org.checkerframework:checker-qual` 3.49.0 → 3.55.1 (annotations-only jar, now declared by pgjdbc 42.7.13). `dependencyInsight` confirms `io.netty:netty-handler:4.2.16.Final` and `org.postgresql:postgresql:42.7.13` on the runtime classpath.
