### PR TITLE
Include conflicting port in log

### DIFF
--- a/src/main/java/org/traccar/ServerManager.java
+++ b/src/main/java/org/traccar/ServerManager.java
@@ -73,7 +73,7 @@ public class ServerManager implements LifecycleObject {
             try {
                 connector.start();
             } catch (BindException e) {
-                LOGGER.warn("Port disabled due to conflict", e);
+                LOGGER.warn("Port {} disabled due to conflict", connector.getPort(), e);
             } catch (ConnectException e) {
                 LOGGER.warn("Connection failed", e);
             }

--- a/src/main/java/org/traccar/TrackerClient.java
+++ b/src/main/java/org/traccar/TrackerClient.java
@@ -98,6 +98,11 @@ public abstract class TrackerClient implements TrackerConnector {
     }
 
     @Override
+    public int getPort() {
+        return port;
+    }
+
+    @Override
     public ChannelGroup getChannelGroup() {
         return channelGroup;
     }

--- a/src/main/java/org/traccar/TrackerConnector.java
+++ b/src/main/java/org/traccar/TrackerConnector.java
@@ -23,6 +23,8 @@ public interface TrackerConnector extends LifecycleObject {
 
     boolean isSecure();
 
+    int getPort();
+
     ChannelGroup getChannelGroup();
 
 }

--- a/src/main/java/org/traccar/TrackerServer.java
+++ b/src/main/java/org/traccar/TrackerServer.java
@@ -97,6 +97,7 @@ public abstract class TrackerServer implements TrackerConnector {
 
     protected abstract void addProtocolHandlers(PipelineBuilder pipeline, Config config);
 
+    @Override
     public int getPort() {
         return port;
     }


### PR DESCRIPTION
Fixes #5552

Include the connector port in the warning logged when a BindException occurs, while preserving the original exception.

Expose the configured port through TrackerConnector so ServerManager can include it in the warning.

Testing:
- ./gradlew check