### PR TITLE
MCP server: fix OAuth discovery/config bugs, harden startup, expand and optimize toolset

### DIFF
--- a/src/main/java/org/traccar/api/resource/OidcResource.java
+++ b/src/main/java/org/traccar/api/resource/OidcResource.java
@@ -173,12 +173,22 @@ public class OidcResource extends BaseResource {
         }
         Map<String, ClientConfig> clients = new LinkedHashMap<>();
         for (String entry : value.split(",")) {
-            String[] values = entry.split(":", 3);
+            String[] values = parseClientEntry(entry);
             clients.put(values[0], new ClientConfig(values[1], Arrays.stream(values[2].split("\\|"))
                     .map(URI::create)
                     .collect(Collectors.toSet())));
         }
         return clients;
+    }
+
+    static String[] parseClientEntry(String entry) {
+        String[] values = entry.split(":", 3);
+        if (values.length != 3 || values[0].isBlank() || values[1].isBlank() || values[2].isBlank()) {
+            throw new IllegalArgumentException(
+                    "Invalid openid.clients entry '" + entry
+                            + "': expected format 'clientId:clientSecret:redirectUri'");
+        }
+        return values;
     }
 
 }

--- a/src/main/java/org/traccar/web/McpServerHolder.java
+++ b/src/main/java/org/traccar/web/McpServerHolder.java
@@ -34,8 +34,15 @@ import org.traccar.api.security.PermissionsService;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
 import org.traccar.geocoder.Geocoder;
+import org.traccar.helper.DateUtil;
+import org.traccar.helper.model.DeviceUtil;
 import org.traccar.model.Device;
 import org.traccar.model.Position;
+import org.traccar.reports.RouteReportProvider;
+import org.traccar.reports.SummaryReportProvider;
+import org.traccar.reports.TripsReportProvider;
+import org.traccar.reports.model.SummaryReportItem;
+import org.traccar.reports.model.TripReportItem;
 import org.traccar.storage.Storage;
 import org.traccar.storage.StorageException;
 import org.traccar.storage.query.Columns;
@@ -43,19 +50,32 @@ import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Request;
 import reactor.core.publisher.Mono;
 
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Singleton
 public class McpServerHolder implements AutoCloseable {
 
     public static final String PATH = "/api/mcp";
 
+    private static final McpSchema.ToolAnnotations READ_ONLY_ANNOTATIONS = new McpSchema.ToolAnnotations(
+            null, true, false, true, false, null);
+
     private final Storage storage;
     private final Provider<PermissionsService> permissionsService;
     private final Geocoder geocoder;
     private final boolean geocodeOnRequest;
+    private final Provider<RouteReportProvider> routeReportProvider;
+    private final Provider<TripsReportProvider> tripsReportProvider;
+    private final Provider<SummaryReportProvider> summaryReportProvider;
 
     private final HttpServletStreamableServerTransportProvider transport;
     private final McpAsyncServer server;
@@ -63,11 +83,16 @@ public class McpServerHolder implements AutoCloseable {
     @Inject
     public McpServerHolder(
             ObjectMapper objectMapper, Storage storage, Provider<PermissionsService> permissionsService,
-            Config config, @Nullable Geocoder geocoder) {
+            Config config, @Nullable Geocoder geocoder,
+            Provider<RouteReportProvider> routeReportProvider, Provider<TripsReportProvider> tripsReportProvider,
+            Provider<SummaryReportProvider> summaryReportProvider) {
 
         this.storage = storage;
         this.permissionsService = permissionsService;
         this.geocoder = geocoder;
+        this.routeReportProvider = routeReportProvider;
+        this.tripsReportProvider = tripsReportProvider;
+        this.summaryReportProvider = summaryReportProvider;
         geocodeOnRequest = config.getBoolean(Keys.GEOCODER_ON_REQUEST);
 
         transport = HttpServletStreamableServerTransportProvider.builder()
@@ -84,8 +109,17 @@ public class McpServerHolder implements AutoCloseable {
 
         server = McpServer.async(transport)
                 .serverInfo("traccar-mcp", "1.0.0")
+                .instructions(
+                        "Call device-list first to find valid device ids. Prefer device-summary for totals over "
+                                + "long ranges (weeks or more), device-trips for a leg-by-leg breakdown, and "
+                                + "device-route only when the exact path is needed, ideally over a narrow "
+                                + "sub-range - it returns far more data than the other tools.")
                 .capabilities(capabilities)
-                .tools(createVersionTool(), createDevicePositionTool())
+                .tools(
+                        createVersionTool(), createDevicePositionTool(),
+                        createDeviceListTool(), createDeviceRouteTool(), createDeviceTripsTool(),
+                        createDeviceSummaryTool())
+                .prompts(createTripReportPrompt())
                 .build();
     }
 
@@ -101,6 +135,10 @@ public class McpServerHolder implements AutoCloseable {
         return McpTransportContext.create(contextData);
     }
 
+    private Map<String, Object> schemaProperty(String type, String description) {
+        return Map.of("type", type, "description", description);
+    }
+
     private McpServerFeatures.AsyncToolSpecification createVersionTool() {
 
         var inputSchema = new McpSchema.JsonSchema(
@@ -109,7 +147,9 @@ public class McpServerHolder implements AutoCloseable {
         var toolSchema = McpSchema.Tool.builder()
                 .name("traccar-version")
                 .title("Returns server version name")
+                .description("Returns the Traccar server version string.")
                 .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
                 .build();
 
         return McpServerFeatures.AsyncToolSpecification.builder()
@@ -125,19 +165,20 @@ public class McpServerHolder implements AutoCloseable {
 
     private McpServerFeatures.AsyncToolSpecification createDevicePositionTool() {
 
-        var deviceIdSchema = new McpSchema.JsonSchema(
-                "number", Map.of(), null, null, null, null);
-
         var inputSchema = new McpSchema.JsonSchema(
                 "object",
-                Map.of("deviceId", deviceIdSchema),
+                Map.of("deviceId", schemaProperty("number", "Device id, see device-list for available ids")),
                 List.of("deviceId"),
                 null, null, null);
 
         var toolSchema = McpSchema.Tool.builder()
                 .name("device-position")
                 .title("Returns latest device position with address and other parameters")
+                .description(
+                        "Returns the latest known position for a single device, including address, "
+                                + "coordinates and raw protocol attributes. Speed is reported in knots.")
                 .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
                 .build();
 
         return McpServerFeatures.AsyncToolSpecification.builder()
@@ -146,11 +187,258 @@ public class McpServerHolder implements AutoCloseable {
                 .build();
     }
 
+    private McpServerFeatures.AsyncToolSpecification createDeviceListTool() {
+
+        var inputSchema = new McpSchema.JsonSchema(
+                "object",
+                Map.of(
+                        "name", schemaProperty("string", "Case-insensitive substring filter on device name"),
+                        "limit", schemaProperty("integer", "Maximum number of devices to return, default 200")),
+                null, null, null, null);
+
+        var toolSchema = McpSchema.Tool.builder()
+                .name("device-list")
+                .title("Lists accessible devices, optionally filtered by name")
+                .description(
+                        "Lists devices accessible to the current user with id, name, uniqueId, status "
+                                + "and lastUpdate. Use the returned id as deviceId in other tools.")
+                .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
+                .build();
+
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(toolSchema)
+                .callHandler(this::getDeviceList)
+                .build();
+    }
+
+    private McpSchema.JsonSchema deviceRangeInputSchema(Map<String, Object> extraProperties) {
+        var properties = new LinkedHashMap<String, Object>();
+        properties.put("deviceId", schemaProperty("number", "Device id, see device-list for available ids"));
+        properties.put("from", schemaProperty("string", "Start of the time range, ISO-8601, e.g. "
+                + "2024-01-01T00:00:00Z"));
+        properties.put("to", schemaProperty("string", "End of the time range, ISO-8601, e.g. "
+                + "2024-01-02T00:00:00Z"));
+        properties.putAll(extraProperties);
+        return new McpSchema.JsonSchema(
+                "object", properties, List.of("deviceId", "from", "to"), null, null, null);
+    }
+
+    private McpServerFeatures.AsyncToolSpecification createDeviceRouteTool() {
+
+        var inputSchema = deviceRangeInputSchema(Map.of(
+                "limit", schemaProperty("integer",
+                        "Maximum positions to return after filtering, default 200, clamped to 1-2000"),
+                "dedup", schemaProperty("boolean",
+                        "Collapse consecutive stationary positions to first/last of each run, default true. "
+                                + "Set false for raw fidelity within the same limit, e.g. diagnosing a flaky "
+                                + "tracker or verifying a reported distance.")));
+
+        var toolSchema = McpSchema.Tool.builder()
+                .name("device-route")
+                .title("Returns recorded positions for a device within a time range")
+                .description(
+                        "Returns recorded positions for a device within a time range, ordered by time. "
+                                + "Consecutive stationary positions (motion attribute false) are collapsed to "
+                                + "just the first and last of each stationary run unless dedup is false, and "
+                                + "the result is downsampled to at most limit points while always keeping the "
+                                + "first and last point. Speed is reported in knots. The response includes "
+                                + "rawCount (positions returned by the server before this tool's own filtering, "
+                                + "itself capped by the server's report.maxPositions setting for very large "
+                                + "ranges) and returnedCount so filtering is visible to the caller. For "
+                                + "genuinely bulk or full-fidelity export beyond what this tool should return "
+                                + "inline, use Traccar's Reports page GPX/KML/XLSX export instead.")
+                .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
+                .build();
+
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(toolSchema)
+                .callHandler(this::getDeviceRoute)
+                .build();
+    }
+
+    private McpServerFeatures.AsyncToolSpecification createDeviceTripsTool() {
+
+        var inputSchema = deviceRangeInputSchema(Map.of(
+                "limit", schemaProperty("integer", "Maximum trips to return, default 100, clamped to 1-1000")));
+
+        var toolSchema = McpSchema.Tool.builder()
+                .name("device-trips")
+                .title("Returns detected trips for a device within a time range")
+                .description(
+                        "Returns detected trips (motion-based segments) for a device within a time range, "
+                                + "each with start/end time, coordinates, address, distance and speed. Trips "
+                                + "are already a pre-aggregated view of the raw route, no further dedup "
+                                + "applies. Use device-summary instead if you only need totals for a long "
+                                + "range rather than a leg-by-leg breakdown.")
+                .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
+                .build();
+
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(toolSchema)
+                .callHandler(this::getDeviceTrips)
+                .build();
+    }
+
+    private McpServerFeatures.AsyncToolSpecification createDeviceSummaryTool() {
+
+        var inputSchema = deviceRangeInputSchema(Map.of(
+                "daily", schemaProperty("boolean",
+                        "Return one summary per day instead of one for the whole range, default false"),
+                "limit", schemaProperty("integer",
+                        "Maximum summaries to return, relevant when daily is true, default 60, clamped to "
+                                + "1-1000")));
+
+        var toolSchema = McpSchema.Tool.builder()
+                .name("device-summary")
+                .title("Returns aggregate distance/duration for a device over a time range")
+                .description(
+                        "Returns a single summary (or one per day if daily is true) with total distance, "
+                                + "average/max speed, fuel, odometer and engine hours. Use this instead of "
+                                + "device-trips when you need totals for a long range like a multi-week trip, "
+                                + "not a leg-by-leg breakdown. When daily is true the result count is bounded "
+                                + "by limit.")
+                .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
+                .build();
+
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(toolSchema)
+                .callHandler(this::getDeviceSummary)
+                .build();
+    }
+
+    private McpServerFeatures.AsyncPromptSpecification createTripReportPrompt() {
+        var prompt = new McpSchema.Prompt(
+                "trip-report",
+                "Summarizes a device's activity over a date range using the most efficient combination of tools",
+                List.of(
+                        new McpSchema.PromptArgument(
+                                "deviceId", "Device id, see device-list for available ids", true),
+                        new McpSchema.PromptArgument("from", "Start of the range, ISO-8601", true),
+                        new McpSchema.PromptArgument("to", "End of the range, ISO-8601", true)));
+
+        return new McpServerFeatures.AsyncPromptSpecification(prompt, this::getTripReportPrompt);
+    }
+
+    private Mono<McpSchema.GetPromptResult> getTripReportPrompt(
+            McpAsyncServerExchange context, McpSchema.GetPromptRequest request) {
+
+        Object deviceIdValue = request.arguments().get("deviceId");
+        Object fromValue = request.arguments().get("from");
+        Object toValue = request.arguments().get("to");
+
+        String text = "Build a trip report for device " + deviceIdValue
+                + " covering " + fromValue + " to " + toValue + ". "
+                + "Call device-summary first for totals (distance, duration, fuel, engine hours). "
+                + "Call device-trips for a leg-by-leg breakdown with start/end addresses and times. "
+                + "Only call device-route, and only for a narrow sub-range, if the user needs the exact "
+                + "path rather than a summary - it returns far more data than the other tools. "
+                + "Present distances in the user's preferred unit if known, otherwise kilometers.";
+
+        var message = new McpSchema.PromptMessage(McpSchema.Role.USER, new McpSchema.TextContent(text));
+        return Mono.just(new McpSchema.GetPromptResult("Trip report workflow guidance", List.of(message)));
+    }
+
     private McpSchema.CallToolResult errorResult(String message) {
         return McpSchema.CallToolResult.builder()
                 .addTextContent(message)
                 .isError(true)
                 .build();
+    }
+
+    private boolean isKnownStationary(Position position) {
+        return position.hasAttribute(Position.KEY_MOTION) && !position.getBoolean(Position.KEY_MOTION);
+    }
+
+    private List<Position> collapseStationaryRuns(List<Position> positions) {
+        List<Position> result = new ArrayList<>();
+        int i = 0;
+        while (i < positions.size()) {
+            if (!isKnownStationary(positions.get(i))) {
+                result.add(positions.get(i));
+                i++;
+                continue;
+            }
+            int runStart = i;
+            while (i < positions.size() && isKnownStationary(positions.get(i))) {
+                i++;
+            }
+            result.add(positions.get(runStart));
+            if (i - 1 > runStart) {
+                result.add(positions.get(i - 1));
+            }
+        }
+        return result;
+    }
+
+    private List<Position> downsample(List<Position> positions, int limit) {
+        if (positions.size() <= limit) {
+            return positions;
+        }
+        if (limit <= 1) {
+            return List.of(positions.get(0));
+        }
+        List<Position> result = new ArrayList<>(limit);
+        double step = (double) (positions.size() - 1) / (limit - 1);
+        for (int i = 0; i < limit; i++) {
+            result.add(positions.get((int) Math.round(i * step)));
+        }
+        return result;
+    }
+
+    private Map<String, Object> curateRoutePosition(Position position) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("latitude", position.getLatitude());
+        item.put("longitude", position.getLongitude());
+        item.put("speed", position.getSpeed());
+        item.put("course", position.getCourse());
+        item.put("fixTime", position.getFixTime());
+        item.put("valid", position.getValid());
+        item.put("address", position.getAddress());
+
+        Map<String, Object> attributes = position.getAttributes();
+        Object ignition = attributes.get(Position.KEY_IGNITION);
+        if (ignition != null) {
+            item.put("ignition", ignition);
+        }
+        Object batteryLevel = attributes.get(Position.KEY_BATTERY_LEVEL);
+        if (batteryLevel != null) {
+            item.put("batteryLevel", batteryLevel);
+        }
+        Object totalDistance = attributes.get(Position.KEY_TOTAL_DISTANCE);
+        if (totalDistance != null) {
+            item.put("totalDistance", totalDistance);
+        }
+        return item;
+    }
+
+    private Map<String, Object> curateTrip(TripReportItem trip) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("startTime", trip.getStartTime());
+        item.put("endTime", trip.getEndTime());
+        item.put("duration", trip.getDuration());
+        item.put("distance", trip.getDistance());
+        item.put("averageSpeed", trip.getAverageSpeed());
+        item.put("maxSpeed", trip.getMaxSpeed());
+        item.put("spentFuel", trip.getSpentFuel());
+        item.put("startOdometer", trip.getStartOdometer());
+        item.put("endOdometer", trip.getEndOdometer());
+        item.put("startLat", trip.getStartLat());
+        item.put("startLon", trip.getStartLon());
+        item.put("endLat", trip.getEndLat());
+        item.put("endLon", trip.getEndLon());
+        item.put("startAddress", trip.getStartAddress());
+        item.put("endAddress", trip.getEndAddress());
+        if (trip.getDriverUniqueId() != null) {
+            item.put("driverUniqueId", trip.getDriverUniqueId());
+        }
+        if (trip.getDriverName() != null) {
+            item.put("driverName", trip.getDriverName());
+        }
+        return item;
     }
 
     private Mono<McpSchema.CallToolResult> getDevicePosition(
@@ -181,12 +469,254 @@ public class McpServerHolder implements AutoCloseable {
             String address = position.getAddress();
             if (address == null && geocoder != null && geocodeOnRequest) {
                 position.setAddress(geocoder.getAddress(position.getLatitude(), position.getLongitude(), null));
+                address = position.getAddress();
             }
 
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("deviceId", position.getDeviceId());
+            result.put("latitude", position.getLatitude());
+            result.put("longitude", position.getLongitude());
+            result.put("altitude", position.getAltitude());
+            result.put("speed", position.getSpeed());
+            result.put("course", position.getCourse());
+            result.put("valid", position.getValid());
+            result.put("address", address);
+            result.put("fixTime", position.getFixTime());
+            if (position.getGeofenceIds() != null && !position.getGeofenceIds().isEmpty()) {
+                result.put("geofenceIds", position.getGeofenceIds());
+            }
+            result.put("attributes", position.getAttributes());
+
             return Mono.just(McpSchema.CallToolResult.builder()
-                    .structuredContent(position)
+                    .structuredContent(result)
                     .build());
         } catch (StorageException | SecurityException e) {
+            return Mono.just(errorResult(e.getMessage()));
+        }
+    }
+
+    private Mono<McpSchema.CallToolResult> getDeviceList(
+            McpAsyncServerExchange context, McpSchema.CallToolRequest request) {
+
+        Long userId = (Long) context.transportContext().get(McpAuthFilter.ATTRIBUTE_USER_ID);
+        if (userId == null) {
+            return Mono.just(errorResult("User context is missing"));
+        }
+
+        Object nameValue = request.arguments().get("name");
+        String nameFilter = nameValue instanceof String s && !s.isBlank()
+                ? s.toLowerCase(Locale.ROOT) : null;
+
+        Object limitValue = request.arguments().get("limit");
+        int limit = limitValue instanceof Number number ? number.intValue() : 200;
+        limit = Math.max(1, Math.min(limit, 1000));
+
+        try {
+            Collection<Device> devices = DeviceUtil.getAccessibleDevices(storage, userId, List.of(), List.of());
+            List<Map<String, Object>> result = devices.stream()
+                    .filter(device -> nameFilter == null || device.getName() != null
+                            && device.getName().toLowerCase(Locale.ROOT).contains(nameFilter))
+                    .map(device -> {
+                        Map<String, Object> item = new LinkedHashMap<>();
+                        item.put("id", device.getId());
+                        item.put("name", device.getName());
+                        item.put("uniqueId", device.getUniqueId());
+                        item.put("status", device.getStatus());
+                        item.put("lastUpdate", device.getLastUpdate());
+                        return item;
+                    })
+                    .limit(limit)
+                    .toList();
+
+            return Mono.just(McpSchema.CallToolResult.builder()
+                    .structuredContent(Map.of("devices", result))
+                    .build());
+        } catch (StorageException e) {
+            return Mono.just(errorResult(e.getMessage()));
+        }
+    }
+
+    private Mono<McpSchema.CallToolResult> getDeviceRoute(
+            McpAsyncServerExchange context, McpSchema.CallToolRequest request) {
+
+        Long userId = (Long) context.transportContext().get(McpAuthFilter.ATTRIBUTE_USER_ID);
+        if (userId == null) {
+            return Mono.just(errorResult("User context is missing"));
+        }
+
+        Object deviceIdValue = request.arguments().get("deviceId");
+        if (!(deviceIdValue instanceof Number deviceIdNumber)) {
+            return Mono.just(errorResult("deviceId argument is required"));
+        }
+        long deviceId = deviceIdNumber.longValue();
+
+        Object fromValue = request.arguments().get("from");
+        Object toValue = request.arguments().get("to");
+        if (!(fromValue instanceof String) || !(toValue instanceof String)) {
+            return Mono.just(errorResult("from and to arguments are required"));
+        }
+
+        Date from;
+        Date to;
+        try {
+            from = DateUtil.parseDate((String) fromValue);
+            to = DateUtil.parseDate((String) toValue);
+        } catch (DateTimeParseException e) {
+            return Mono.just(errorResult(
+                    "Invalid from/to date-time: expected ISO-8601, e.g. 2024-01-01T00:00:00Z"));
+        }
+
+        Object limitValue = request.arguments().get("limit");
+        int limit = limitValue instanceof Number number ? number.intValue() : 200;
+        limit = Math.max(1, Math.min(limit, 2000));
+
+        Object dedupValue = request.arguments().get("dedup");
+        boolean dedup = !(dedupValue instanceof Boolean dedupBoolean) || dedupBoolean;
+
+        try {
+            permissionsService.get().checkPermission(Device.class, userId, deviceId);
+
+            List<Position> positions;
+            try (Stream<Position> stream = routeReportProvider.get().getObjects(
+                    userId, List.of(deviceId), List.of(), from, to)) {
+                positions = stream.toList();
+            }
+
+            List<Position> filtered = dedup ? collapseStationaryRuns(positions) : positions;
+            List<Position> sampled = downsample(filtered, limit);
+            List<Map<String, Object>> curated = sampled.stream().map(this::curateRoutePosition).toList();
+
+            return Mono.just(McpSchema.CallToolResult.builder()
+                    .structuredContent(Map.of(
+                            "positions", curated,
+                            "returnedCount", curated.size(),
+                            "rawCount", positions.size()))
+                    .build());
+        } catch (StorageException | SecurityException e) {
+            return Mono.just(errorResult(e.getMessage()));
+        }
+    }
+
+    private Mono<McpSchema.CallToolResult> getDeviceTrips(
+            McpAsyncServerExchange context, McpSchema.CallToolRequest request) {
+
+        Long userId = (Long) context.transportContext().get(McpAuthFilter.ATTRIBUTE_USER_ID);
+        if (userId == null) {
+            return Mono.just(errorResult("User context is missing"));
+        }
+
+        Object deviceIdValue = request.arguments().get("deviceId");
+        if (!(deviceIdValue instanceof Number deviceIdNumber)) {
+            return Mono.just(errorResult("deviceId argument is required"));
+        }
+        long deviceId = deviceIdNumber.longValue();
+
+        Object fromValue = request.arguments().get("from");
+        Object toValue = request.arguments().get("to");
+        if (!(fromValue instanceof String) || !(toValue instanceof String)) {
+            return Mono.just(errorResult("from and to arguments are required"));
+        }
+
+        Date from;
+        Date to;
+        try {
+            from = DateUtil.parseDate((String) fromValue);
+            to = DateUtil.parseDate((String) toValue);
+        } catch (DateTimeParseException e) {
+            return Mono.just(errorResult(
+                    "Invalid from/to date-time: expected ISO-8601, e.g. 2024-01-01T00:00:00Z"));
+        }
+
+        Object limitValue = request.arguments().get("limit");
+        int limit = limitValue instanceof Number number ? number.intValue() : 100;
+        limit = Math.max(1, Math.min(limit, 1000));
+
+        try {
+            permissionsService.get().checkPermission(Device.class, userId, deviceId);
+
+            Collection<TripReportItem> trips = tripsReportProvider.get().getObjects(
+                    userId, List.of(deviceId), List.of(), from, to);
+
+            List<Map<String, Object>> curated = trips.stream()
+                    .limit(limit)
+                    .map(this::curateTrip)
+                    .toList();
+
+            return Mono.just(McpSchema.CallToolResult.builder()
+                    .structuredContent(Map.of(
+                            "trips", curated,
+                            "returnedCount", curated.size(),
+                            "rawCount", trips.size()))
+                    .build());
+        } catch (StorageException | SecurityException | IllegalArgumentException e) {
+            return Mono.just(errorResult(e.getMessage()));
+        }
+    }
+
+    private Mono<McpSchema.CallToolResult> getDeviceSummary(
+            McpAsyncServerExchange context, McpSchema.CallToolRequest request) {
+
+        Long userId = (Long) context.transportContext().get(McpAuthFilter.ATTRIBUTE_USER_ID);
+        if (userId == null) {
+            return Mono.just(errorResult("User context is missing"));
+        }
+
+        Object deviceIdValue = request.arguments().get("deviceId");
+        if (!(deviceIdValue instanceof Number deviceIdNumber)) {
+            return Mono.just(errorResult("deviceId argument is required"));
+        }
+        long deviceId = deviceIdNumber.longValue();
+
+        Object fromValue = request.arguments().get("from");
+        Object toValue = request.arguments().get("to");
+        if (!(fromValue instanceof String) || !(toValue instanceof String)) {
+            return Mono.just(errorResult("from and to arguments are required"));
+        }
+
+        Date from;
+        Date to;
+        try {
+            from = DateUtil.parseDate((String) fromValue);
+            to = DateUtil.parseDate((String) toValue);
+        } catch (DateTimeParseException e) {
+            return Mono.just(errorResult(
+                    "Invalid from/to date-time: expected ISO-8601, e.g. 2024-01-01T00:00:00Z"));
+        }
+
+        Object dailyValue = request.arguments().get("daily");
+        boolean daily = dailyValue instanceof Boolean dailyBoolean && dailyBoolean;
+
+        Object limitValue = request.arguments().get("limit");
+        int limit = limitValue instanceof Number number ? number.intValue() : 60;
+        limit = Math.max(1, Math.min(limit, 1000));
+
+        try {
+            permissionsService.get().checkPermission(Device.class, userId, deviceId);
+
+            Collection<SummaryReportItem> summaries = summaryReportProvider.get().getObjects(
+                    userId, List.of(deviceId), List.of(), from, to, daily);
+
+            List<Map<String, Object>> curated = summaries.stream().limit(limit).map(summary -> {
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("startTime", summary.getStartTime());
+                item.put("endTime", summary.getEndTime());
+                item.put("distance", summary.getDistance());
+                item.put("averageSpeed", summary.getAverageSpeed());
+                item.put("maxSpeed", summary.getMaxSpeed());
+                item.put("spentFuel", summary.getSpentFuel());
+                item.put("startOdometer", summary.getStartOdometer());
+                item.put("endOdometer", summary.getEndOdometer());
+                item.put("engineHours", summary.getEngineHours());
+                return item;
+            }).toList();
+
+            return Mono.just(McpSchema.CallToolResult.builder()
+                    .structuredContent(Map.of(
+                            "summaries", curated,
+                            "returnedCount", curated.size(),
+                            "rawCount", summaries.size()))
+                    .build());
+        } catch (StorageException | SecurityException | IllegalArgumentException e) {
             return Mono.just(errorResult(e.getMessage()));
         }
     }

--- a/src/main/java/org/traccar/web/WellKnownServlet.java
+++ b/src/main/java/org/traccar/web/WellKnownServlet.java
@@ -33,6 +33,9 @@ import java.util.Map;
 @Singleton
 public class WellKnownServlet extends HttpServlet {
 
+    private static final String OIDC_PATH_SUFFIX = "/api/oidc";
+    private static final String MCP_PATH_SUFFIX = "/api/mcp";
+
     private final Config config;
     private final ObjectMapper objectMapper;
 
@@ -44,7 +47,7 @@ public class WellKnownServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        String path = req.getPathInfo();
+        String path = normalizePath(req.getPathInfo());
         Map<String, Object> payload = switch (path) {
             case "/openid-configuration" -> openIdConfiguration();
             case "/oauth-authorization-server" -> authorizationServerConfiguration();
@@ -57,6 +60,22 @@ public class WellKnownServlet extends HttpServlet {
         } else {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
+    }
+
+    String normalizePath(String path) {
+        if (path == null) {
+            return "";
+        }
+        if (path.equals("/openid-configuration" + OIDC_PATH_SUFFIX)) {
+            return "/openid-configuration";
+        }
+        if (path.equals("/oauth-authorization-server" + OIDC_PATH_SUFFIX)) {
+            return "/oauth-authorization-server";
+        }
+        if (path.equals("/oauth-protected-resource" + MCP_PATH_SUFFIX)) {
+            return "/oauth-protected-resource";
+        }
+        return path;
     }
 
     private String issuer() {

--- a/src/test/java/org/traccar/api/resource/OidcResourceTest.java
+++ b/src/test/java/org/traccar/api/resource/OidcResourceTest.java
@@ -1,0 +1,39 @@
+package org.traccar.api.resource;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OidcResourceTest {
+
+    @Test
+    public void testValidEntry() {
+        assertArrayEquals(
+                new String[] {"client", "secret", "https://example.com/callback"},
+                OidcResource.parseClientEntry("client:secret:https://example.com/callback"));
+    }
+
+    @Test
+    public void testValidEntryWithMultipleRedirectUris() {
+        assertArrayEquals(
+                new String[] {"client", "secret", "https://a.com|https://b.com"},
+                OidcResource.parseClientEntry("client:secret:https://a.com|https://b.com"));
+    }
+
+    @Test
+    public void testMissingRedirectUri() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> OidcResource.parseClientEntry("client:secret"));
+        assertTrue(exception.getMessage().contains("client:secret"));
+        assertTrue(exception.getMessage().contains("clientId:clientSecret:redirectUri"));
+    }
+
+    @Test
+    public void testBlankField() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OidcResource.parseClientEntry("client::https://example.com/callback"));
+    }
+
+}

--- a/src/test/java/org/traccar/web/WellKnownServletTest.java
+++ b/src/test/java/org/traccar/web/WellKnownServletTest.java
@@ -1,0 +1,43 @@
+package org.traccar.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.traccar.config.Config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WellKnownServletTest {
+
+    private final WellKnownServlet servlet = new WellKnownServlet(new Config(), new ObjectMapper());
+
+    @Test
+    public void testBarePathUnchanged() {
+        assertEquals("/openid-configuration", servlet.normalizePath("/openid-configuration"));
+        assertEquals("/oauth-authorization-server", servlet.normalizePath("/oauth-authorization-server"));
+        assertEquals("/oauth-protected-resource", servlet.normalizePath("/oauth-protected-resource"));
+    }
+
+    @Test
+    public void testSuffixedPathNormalized() {
+        assertEquals("/openid-configuration", servlet.normalizePath("/openid-configuration/api/oidc"));
+        assertEquals("/oauth-authorization-server", servlet.normalizePath("/oauth-authorization-server/api/oidc"));
+        assertEquals("/oauth-protected-resource", servlet.normalizePath("/oauth-protected-resource/api/mcp"));
+    }
+
+    @Test
+    public void testWrongSuffixNotNormalized() {
+        assertEquals("/oauth-protected-resource/api/oidc", servlet.normalizePath("/oauth-protected-resource/api/oidc"));
+        assertEquals("/openid-configuration/api/mcp", servlet.normalizePath("/openid-configuration/api/mcp"));
+    }
+
+    @Test
+    public void testUnknownPathUnchanged() {
+        assertEquals("/unknown-path", servlet.normalizePath("/unknown-path"));
+    }
+
+    @Test
+    public void testNullPath() {
+        assertEquals("", servlet.normalizePath(null));
+    }
+
+}


### PR DESCRIPTION
## Heads up - this was AI-assisted ("vibe coded")

I built this with Claude Code, prompting and reviewing as I went rather than
writing every line myself. I've tested it against a real production instance
and it's been running stable, but I have not personally audited every line
against Traccar's conventions the way a from-scratch human PR would be. Please
review this thoroughly - I'd rather over-flag that up front than have it
treated as more vetted than it is. Happy to address anything in review.

## Motivation

This started from friction documented across a multi-page forum thread trying
to get the MCP server working:
https://www.traccar.org/forums/topic/mcp-function-how-can-the-documentation-can-found/

Several people (including me) hit the same OAuth discovery/config issues with
no clear fix, and separately asked for more MCP tools than just
`device-position`. This PR addresses both.

## What's in here

**Fix RFC 8414/9728 discovery + unclear config error**
- `WellKnownServlet` only served the bare `/.well-known/<name>` path. RFC
  8414/9728-compliant clients request the path-suffixed form instead
  (`/.well-known/oauth-authorization-server/api/oidc`) and got a 404 - this is
  the root cause behind the "blank page when authorizing" reports in the
  thread. Now serves both forms.
- A malformed `openid.clients` entry (e.g. a stale 2-field config) threw a raw
  `ArrayIndexOutOfBoundsException` with no indication of what was wrong. Now
  throws a clear error naming the bad entry and the expected format.

**Expand and fix the MCP toolset**
- Added `device-list`, `device-route`, `device-trips`, `device-summary` (the
  most-requested features in the thread).
- The new tools' report providers pull in `ReportUtils`, which takes the
  request-scoped `PermissionsService` directly. `McpServerHolder` is a
  singleton built once at server startup, outside any HTTP request - injecting
  those providers directly crashed the server on boot with a Guice
  `OutOfScopeException`. Fixed by injecting `Provider<X>` and resolving lazily
  inside each tool handler, matching the existing pattern already used for
  `PermissionsService` in this same file.

**Token efficiency**
- `device-route` over a full day from a 5-second-interval tracker was
  returning 17k+ raw positions (3.2MB) - unusable for an LLM context. Now:
  consecutive stationary positions collapse to first/last of each run (opt
  out via `dedup: false`), results downsample to a configurable `limit`
  (default 200, always keeping first/last), and per-point output is curated
  instead of dumping the full raw `Position` object.
- Added `device-summary` (via the existing `SummaryReportProvider`) for
  whole-range totals - distance, fuel, engine hours - without needing a full
  trip-by-trip list for long ranges.
- Added tool descriptions, per-parameter schema descriptions, `readOnlyHint`/
  non-destructive tool annotations, server-level `instructions`, and a
  `trip-report` prompt tying the tools together (the `prompts` capability was
  already declared but nothing was registered).

## Testing

- `./gradlew build` passes (compile, checkstyle, full existing test suite).
- Added unit tests for the discovery path-normalization logic and the
  `openid.clients` validation logic.
- Manually verified end-to-end against a live production instance: discovery
  endpoints (both old and new paths), a deliberately malformed `openid.clients`
  entry, and every MCP tool exercised with real device data.
- No test coverage added for the MCP tool handlers themselves (no existing
  test infrastructure for `McpServerHolder` to build on - flagged as a gap).
