### PR TITLE
Validate openid.clients configuration entries

### DIFF
--- a/src/main/java/org/traccar/api/resource/OidcResource.java
+++ b/src/main/java/org/traccar/api/resource/OidcResource.java
@@ -173,12 +173,22 @@ public class OidcResource extends BaseResource {
         }
         Map<String, ClientConfig> clients = new LinkedHashMap<>();
         for (String entry : value.split(",")) {
-            String[] values = entry.split(":", 3);
+            String[] values = parseClientEntry(entry);
             clients.put(values[0], new ClientConfig(values[1], Arrays.stream(values[2].split("\\|"))
                     .map(URI::create)
                     .collect(Collectors.toSet())));
         }
         return clients;
+    }
+
+    static String[] parseClientEntry(String entry) {
+        String[] values = entry.split(":", 3);
+        if (values.length != 3 || values[0].isBlank() || values[1].isBlank() || values[2].isBlank()) {
+            throw new IllegalArgumentException(
+                    "Invalid openid.clients entry '" + entry
+                            + "': expected format 'clientId:clientSecret:redirectUri'");
+        }
+        return values;
     }
 
 }

--- a/src/test/java/org/traccar/api/resource/OidcResourceTest.java
+++ b/src/test/java/org/traccar/api/resource/OidcResourceTest.java
@@ -1,0 +1,39 @@
+package org.traccar.api.resource;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OidcResourceTest {
+
+    @Test
+    public void testValidEntry() {
+        assertArrayEquals(
+                new String[] {"client", "secret", "https://example.com/callback"},
+                OidcResource.parseClientEntry("client:secret:https://example.com/callback"));
+    }
+
+    @Test
+    public void testValidEntryWithMultipleRedirectUris() {
+        assertArrayEquals(
+                new String[] {"client", "secret", "https://a.com|https://b.com"},
+                OidcResource.parseClientEntry("client:secret:https://a.com|https://b.com"));
+    }
+
+    @Test
+    public void testMissingRedirectUri() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> OidcResource.parseClientEntry("client:secret"));
+        assertTrue(exception.getMessage().contains("client:secret"));
+        assertTrue(exception.getMessage().contains("clientId:clientSecret:redirectUri"));
+    }
+
+    @Test
+    public void testBlankField() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OidcResource.parseClientEntry("client::https://example.com/callback"));
+    }
+
+}


### PR DESCRIPTION
`getClients()` splits each `openid.clients` entry into three fields and indexes them directly. An entry that does not have three fields, for example one left in an older two-field format, fails with a bare `ArrayIndexOutOfBoundsException` that names neither the offending entry nor the expected format. Working out what was wrong from that took a while, and others hit the same thing in the [forum thread](https://www.traccar.org/forums/topic/mcp-function-how-can-the-documentation-can-found/).

This validates that each entry has three non-blank fields and otherwise throws an `IllegalArgumentException` naming the entry and the expected `clientId:clientSecret:redirectUri` format.

Testing:
- `./gradlew build`
- Added `OidcResourceTest` covering a valid entry, an entry with multiple pipe-separated redirect URIs, a missing field and a blank field.

Part of the split of #5970. Independent of the other parts.

---
Disclosure: written with AI assistance (Claude), reviewed and tested by me against a production instance.