### PR TITLE
Add read-only annotations to MCP tools

### DIFF
--- a/src/main/java/org/traccar/web/McpServerHolder.java
+++ b/src/main/java/org/traccar/web/McpServerHolder.java
@@ -52,6 +52,9 @@ public class McpServerHolder implements AutoCloseable {
 
     public static final String PATH = "/api/mcp";
 
+    private static final McpSchema.ToolAnnotations READ_ONLY_ANNOTATIONS = new McpSchema.ToolAnnotations(
+            null, true, false, true, false, null);
+
     private final Storage storage;
     private final Provider<PermissionsService> permissionsService;
     private final Geocoder geocoder;
@@ -110,6 +113,7 @@ public class McpServerHolder implements AutoCloseable {
                 .name("traccar-version")
                 .title("Returns server version name")
                 .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
                 .build();
 
         return McpServerFeatures.AsyncToolSpecification.builder()
@@ -138,6 +142,7 @@ public class McpServerHolder implements AutoCloseable {
                 .name("device-position")
                 .title("Returns latest device position with address and other parameters")
                 .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
                 .build();
 
         return McpServerFeatures.AsyncToolSpecification.builder()


### PR DESCRIPTION
The MCP tools carry no annotations, so a client cannot tell that they only read data and may prompt for confirmation before calling them.

This marks both tools read-only and non-destructive. No behaviour change.

Testing: `./gradlew build`

Part of the split of #5970. This is the base of the MCP series; the remaining MCP parts build on it in order.

---
Disclosure: written with AI assistance (Claude), reviewed and tested by me against a production instance.