### PR TITLE
Add MCP server instructions and trip-report prompt

### DIFF
--- a/src/main/java/org/traccar/web/McpServerHolder.java
+++ b/src/main/java/org/traccar/web/McpServerHolder.java
@@ -84,8 +84,14 @@ public class McpServerHolder implements AutoCloseable {
 
         server = McpServer.async(transport)
                 .serverInfo("traccar-mcp", "1.0.0")
+                .instructions(
+                        "Call device-list first to find valid device ids. Prefer device-summary for totals over "
+                                + "long ranges (weeks or more), device-trips for a leg-by-leg breakdown, and "
+                                + "device-route only when the exact path is needed, ideally over a narrow "
+                                + "sub-range - it returns far more data than the other tools.")
                 .capabilities(capabilities)
                 .tools(createVersionTool(), createDevicePositionTool())
+                .prompts(createTripReportPrompt())
                 .build();
     }
 
@@ -144,6 +150,38 @@ public class McpServerHolder implements AutoCloseable {
                 .tool(toolSchema)
                 .callHandler(this::getDevicePosition)
                 .build();
+    }
+
+    private McpServerFeatures.AsyncPromptSpecification createTripReportPrompt() {
+        var prompt = new McpSchema.Prompt(
+                "trip-report",
+                "Summarizes a device's activity over a date range using the most efficient combination of tools",
+                List.of(
+                        new McpSchema.PromptArgument(
+                                "deviceId", "Device id, see device-list for available ids", true),
+                        new McpSchema.PromptArgument("from", "Start of the range, ISO-8601", true),
+                        new McpSchema.PromptArgument("to", "End of the range, ISO-8601", true)));
+
+        return new McpServerFeatures.AsyncPromptSpecification(prompt, this::getTripReportPrompt);
+    }
+
+    private Mono<McpSchema.GetPromptResult> getTripReportPrompt(
+            McpAsyncServerExchange context, McpSchema.GetPromptRequest request) {
+
+        Object deviceIdValue = request.arguments().get("deviceId");
+        Object fromValue = request.arguments().get("from");
+        Object toValue = request.arguments().get("to");
+
+        String text = "Build a trip report for device " + deviceIdValue
+                + " covering " + fromValue + " to " + toValue + ". "
+                + "Call device-summary first for totals (distance, duration, fuel, engine hours). "
+                + "Call device-trips for a leg-by-leg breakdown with start/end addresses and times. "
+                + "Only call device-route, and only for a narrow sub-range, if the user needs the exact "
+                + "path rather than a summary - it returns far more data than the other tools. "
+                + "Present distances in the user's preferred unit if known, otherwise kilometers.";
+
+        var message = new McpSchema.PromptMessage(McpSchema.Role.USER, new McpSchema.TextContent(text));
+        return Mono.just(new McpSchema.GetPromptResult("Trip report workflow guidance", List.of(message)));
     }
 
     private McpSchema.CallToolResult errorResult(String message) {


### PR DESCRIPTION
The server declares the `prompts` capability but registers no prompts, and offers no server-level guidance on how the tools relate to each other.

This adds server `instructions` pointing clients at `device-list` for discovery and steering them towards the aggregate tools rather than `device-route` for wide ranges, and registers a `trip-report` prompt for the common case of summarizing a device over a date range.

Testing: `./gradlew build`

---

Part of the split of #5970. Rebased on master, so the diff is only this commit (`0c304d746`). The instructions and prompt text reference the tools added in #5975 to #5978, so this one should land after those. It can be dropped without affecting them.

Disclosure: written with AI assistance (Claude), reviewed and tested by me against a production instance.