### PR TITLE
Return curated fields from MCP device-position

### DIFF
--- a/src/main/java/org/traccar/web/McpServerHolder.java
+++ b/src/main/java/org/traccar/web/McpServerHolder.java
@@ -44,6 +44,7 @@ import org.traccar.storage.query.Request;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -181,10 +182,26 @@ public class McpServerHolder implements AutoCloseable {
             String address = position.getAddress();
             if (address == null && geocoder != null && geocodeOnRequest) {
                 position.setAddress(geocoder.getAddress(position.getLatitude(), position.getLongitude(), null));
+                address = position.getAddress();
             }
 
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("deviceId", position.getDeviceId());
+            result.put("latitude", position.getLatitude());
+            result.put("longitude", position.getLongitude());
+            result.put("altitude", position.getAltitude());
+            result.put("speed", position.getSpeed());
+            result.put("course", position.getCourse());
+            result.put("valid", position.getValid());
+            result.put("address", address);
+            result.put("fixTime", position.getFixTime());
+            if (position.getGeofenceIds() != null && !position.getGeofenceIds().isEmpty()) {
+                result.put("geofenceIds", position.getGeofenceIds());
+            }
+            result.put("attributes", position.getAttributes());
+
             return Mono.just(McpSchema.CallToolResult.builder()
-                    .structuredContent(position)
+                    .structuredContent(result)
                     .build());
         } catch (StorageException | SecurityException e) {
             return Mono.just(errorResult(e.getMessage()));


### PR DESCRIPTION
`device-position` passes the whole `Position` object as structured content, so every response carries internal and network columns that are of no use to a client and inflate the result.

This returns an explicit set of fields instead — device id, coordinates, altitude, speed, course, validity, address, fix time, and the protocol attributes map — with geofence ids included only when the position has any.

Note this is a change to an existing tool's output shape, unlike the other parts of the series which only add things. It is last in the series for that reason and can be dropped independently.

Testing: `./gradlew build`

---

Part of the split of #5970. **Builds on #5979** — until that merges the diff here includes it. The commit to review is `5743cff31`, the single top commit.

Disclosure: written with AI assistance (Claude), reviewed and tested by me against a production instance.