### PR TITLE
Add more JT808 command types support

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808Protocol.java
+++ b/src/main/java/org/traccar/protocol/Jt808Protocol.java
@@ -30,13 +30,24 @@ public class Jt808Protocol extends BaseProtocol {
         setSupportedDataCommands(
                 Command.TYPE_CUSTOM,
                 Command.TYPE_REBOOT_DEVICE,
+                Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_POSITION_PERIODIC,
+                Command.TYPE_POSITION_STOP,
                 Command.TYPE_ALARM_ARM,
                 Command.TYPE_ALARM_DISARM,
+                Command.TYPE_ALARM_DISMISS,
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME,
+                Command.TYPE_POWER_OFF,
+                Command.TYPE_FACTORY_RESET,
+                Command.TYPE_MESSAGE,
+                Command.TYPE_VOICE_MESSAGE,
+                Command.TYPE_REQUEST_PHOTO,
+                Command.TYPE_SET_SPEED_LIMIT,
+                Command.TYPE_OUTPUT_CONTROL,
                 Command.TYPE_VIDEO_START,
-                Command.TYPE_VIDEO_STOP);
+                Command.TYPE_VIDEO_STOP,
+                Command.TYPE_SET_CONNECTION);
         addServer(new TrackerServer(config, getName(), false) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -70,6 +70,11 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_TERMINAL_REGISTER = 0x0100;
     public static final int MSG_TERMINAL_REGISTER_RESPONSE = 0x8100;
     public static final int MSG_TERMINAL_CONTROL = 0x8105;
+    public static final int MSG_LOCATION_QUERY = 0x8201;
+    public static final int MSG_TEMPORARY_TRACKING = 0x8202;
+    public static final int MSG_ALARM_ACK = 0x8203;
+    public static final int MSG_VEHICLE_CONTROL = 0x8500;
+    public static final int MSG_TAKE_PHOTO = 0x8801;
     public static final int MSG_TERMINAL_AUTH = 0x0102;
     public static final int MSG_TERMINAL_ATTRIBUTES = 0x0107;
     public static final int MSG_LOCATION_REPORT = 0x0200;

--- a/src/main/java/org/traccar/protocol/Jt808ProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolEncoder.java
@@ -98,6 +98,13 @@ public class Jt808ProtocolEncoder extends BaseProtocolEncoder {
                     data.writeInt(command.getInteger(Command.KEY_FREQUENCY));
                     return decoder.formatMessage(
                             Jt808ProtocolDecoder.MSG_PARAMETER_SETTING, id, false, data);
+                case Command.TYPE_POSITION_SINGLE:
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_LOCATION_QUERY, id, false, data);
+                case Command.TYPE_POSITION_STOP:
+                    data.writeShort(0); // time interval (stop tracking)
+                    data.writeShort(0); // validity period
+                    data.writeShort(0); // reserved
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_TEMPORARY_TRACKING, id, false, data);
                 case Command.TYPE_ALARM_ARM:
                 case Command.TYPE_ALARM_DISARM:
                     data.writeByte(1); // number of parameters
@@ -127,6 +134,58 @@ public class Jt808ProtocolEncoder extends BaseProtocolEncoder {
                         return decoder.formatMessage(
                                 Jt808ProtocolDecoder.MSG_TERMINAL_CONTROL, id, false, data);
                     }
+                case Command.TYPE_SET_CONNECTION:
+                    data.writeByte(2); // number of parameters
+                    byte[] server = command.getString(Command.KEY_SERVER).getBytes(StandardCharsets.US_ASCII);
+                    data.writeInt(0x13); // server ip or domain
+                    data.writeByte(server.length); // parameter value length
+                    data.writeBytes(server);
+                    data.writeInt(0x18); // server tcp port
+                    data.writeByte(4); // parameter value length
+                    data.writeInt(command.getInteger(Command.KEY_PORT));
+                    return decoder.formatMessage(
+                            Jt808ProtocolDecoder.MSG_CONFIGURATION_PARAMETERS, id, false, data);
+                case Command.TYPE_ALARM_DISMISS:
+                    data.writeShort(0); // message serial number
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_ALARM_ACK, id, false, data);
+                case Command.TYPE_POWER_OFF:
+                    data.writeByte(0x02); // command: power off
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_TERMINAL_CONTROL, id, false, data);
+                case Command.TYPE_FACTORY_RESET:
+                    data.writeByte(0x03); // command: restore factory settings
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_TERMINAL_CONTROL, id, false, data);
+                case Command.TYPE_MESSAGE:
+                    data.writeByte(0x04); // text flag: display on terminal screen
+                    data.writeCharSequence(command.getString(Command.KEY_MESSAGE),
+                            Charset.isSupported("GBK") ? Charset.forName("GBK") : StandardCharsets.US_ASCII);
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_SEND_TEXT_MESSAGE, id, false, data);
+                case Command.TYPE_VOICE_MESSAGE:
+                    data.writeByte(0x08); // text flag: TTS voice broadcast
+                    data.writeCharSequence(command.getString(Command.KEY_MESSAGE),
+                            Charset.isSupported("GBK") ? Charset.forName("GBK") : StandardCharsets.US_ASCII);
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_SEND_TEXT_MESSAGE, id, false, data);
+                case Command.TYPE_REQUEST_PHOTO:
+                    data.writeByte(0); // channel id (all channels)
+                    data.writeByte(1); // shooting command: take one photo immediately
+                    data.writeShort(0); // photo interval / video duration
+                    data.writeByte(0); // save flag
+                    data.writeByte(0); // resolution
+                    data.writeByte(0); // image quality
+                    data.writeByte(0); // brightness
+                    data.writeByte(0); // contrast
+                    data.writeByte(0); // saturation
+                    data.writeByte(0); // chroma
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_TAKE_PHOTO, id, false, data);
+                case Command.TYPE_SET_SPEED_LIMIT:
+                    data.writeByte(1); // number of parameters
+                    data.writeInt(0x55); // overspeed alarm threshold parameter id
+                    data.writeByte(2); // parameter value length
+                    data.writeShort(command.getInteger(Command.KEY_DATA));
+                    return decoder.formatMessage(
+                            Jt808ProtocolDecoder.MSG_CONFIGURATION_PARAMETERS, id, false, data);
+                case Command.TYPE_OUTPUT_CONTROL:
+                    data.writeByte(command.getInteger(Command.KEY_INDEX)); // control flag
+                    return decoder.formatMessage(Jt808ProtocolDecoder.MSG_VEHICLE_CONTROL, id, false, data);
                 case Command.TYPE_VIDEO_START:
                     var config = getCacheManager().getConfig();
                     String host = URI.create(config.getString(Keys.WEB_URL)).getHost();

--- a/src/test/java/org/traccar/protocol/Jt808ProtocolEncoderTest.java
+++ b/src/test/java/org/traccar/protocol/Jt808ProtocolEncoderTest.java
@@ -55,4 +55,86 @@ public class Jt808ProtocolEncoderTest extends ProtocolTest {
 
     }
 
+    @Test
+    public void testEncodeSetConnection() throws Exception {
+
+        var decoder = inject(new Jt808ProtocolDecoder(null));
+        var encoder = inject(new Jt808ProtocolEncoder(null));
+
+        Command command = new Command();
+        command.setDeviceId(1);
+        command.setType(Command.TYPE_SET_CONNECTION);
+        command.set(Command.KEY_SERVER, "1.2.3.4");
+        command.set(Command.KEY_PORT, 5555);
+
+        verifyFrame(
+            binary("7e810300160b3a73ce2ff20000020000001307312e322e332e340000001804000015b3437e"),
+            encodeCommand(encoder, decoder, command));
+
+    }
+
+    @Test
+    public void testEncodeOtherCommands() throws Exception {
+
+        var decoder = inject(new Jt808ProtocolDecoder(null));
+        var encoder = inject(new Jt808ProtocolEncoder(null));
+
+        Command command = new Command();
+        command.setDeviceId(1);
+
+        command.setType(Command.TYPE_POSITION_SINGLE);
+        verifyFrame(
+            binary("7e820100000b3a73ce2ff20000d27e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_POSITION_STOP);
+        verifyFrame(
+            binary("7e820200060b3a73ce2ff20000000000000000d77e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_ALARM_DISMISS);
+        verifyFrame(
+            binary("7e820300020b3a73ce2ff200000000d27e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_POWER_OFF);
+        verifyFrame(
+            binary("7e810500010b3a73ce2ff2000002d67e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_FACTORY_RESET);
+        verifyFrame(
+            binary("7e810500010b3a73ce2ff2000003d77e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_MESSAGE);
+        command.set(Command.KEY_MESSAGE, "Test");
+        verifyFrame(
+            binary("7e830000050b3a73ce2ff200000454657374e57e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_VOICE_MESSAGE);
+        verifyFrame(
+            binary("7e830000050b3a73ce2ff200000854657374e97e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_REQUEST_PHOTO);
+        verifyFrame(
+            binary("7e8801000b0b3a73ce2ff200000001000000000000000000d27e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_SET_SPEED_LIMIT);
+        command.set(Command.KEY_DATA, 80);
+        verifyFrame(
+            binary("7e810300080b3a73ce2ff200000100000055020050dd7e"),
+            encodeCommand(encoder, decoder, command));
+
+        command.setType(Command.TYPE_OUTPUT_CONTROL);
+        command.set(Command.KEY_INDEX, 2);
+        verifyFrame(
+            binary("7e850000010b3a73ce2ff2000002d77e"),
+            encodeCommand(encoder, decoder, command));
+
+    }
+
 }


### PR DESCRIPTION
Add support for several standard JT808 downlink commands.

### New command types (JT808 message)
- `TYPE_SET_CONNECTION` -> 0x8103 (server ip/domain param 0x13 + tcp port param 0x18), enables switching between traccar servers over TCP
- `TYPE_POSITION_SINGLE` -> 0x8201 (query location)
- `TYPE_POSITION_STOP` -> 0x8202 (stop temporary tracking)
- `TYPE_ALARM_DISMISS` -> 0x8203 (acknowledge alarm message)
- `TYPE_POWER_OFF` -> 0x8105 terminal control (power off)
- `TYPE_FACTORY_RESET` -> 0x8105 terminal control (restore factory settings)
- `TYPE_MESSAGE` -> 0x8300 text message (display, GBK)
- `TYPE_VOICE_MESSAGE` -> 0x8300 text message (TTS broadcast, GBK)
- `TYPE_REQUEST_PHOTO` -> 0x8801 take photo immediately
- `TYPE_SET_SPEED_LIMIT` -> 0x8103 (overspeed threshold param 0x55)
- `TYPE_OUTPUT_CONTROL` -> 0x8500 vehicle control

### Files changed
- `Jt808Protocol.java` - register the new supported commands
- `Jt808ProtocolEncoder.java` - encode the new command types
- `Jt808ProtocolDecoder.java` - message constants used by the new commands
- `Jt808ProtocolEncoderTest.java` - tests for the new commands

This PR only contains the **encoder** changes. The decoder changes (0x0201 location query response) are in a separate PR: **#5992**.

Tested on a real device with the 6.15.2 build — `SET_CONNECTION` (switch server IP via TCP) works.
