### PR TITLE
Fix MariaDB stream fetch size

### DIFF
--- a/src/main/java/org/traccar/storage/QueryBuilder.java
+++ b/src/main/java/org/traccar/storage/QueryBuilder.java
@@ -244,7 +244,7 @@ public final class QueryBuilder implements AutoCloseable {
             connection.setAutoCommit(false);
             streamingTransaction = true;
             statement.setFetchSize(switch (databaseType) {
-                case "MySQL", "MariaDB" -> Integer.MIN_VALUE;
+                case "MySQL" -> Integer.MIN_VALUE;
                 default -> config.getInteger(Keys.DATABASE_STREAM_FETCH_SIZE);
             });
 


### PR DESCRIPTION
MariaDB Connector/J rejects Integer.MIN_VALUE as an invalid fetch size.

Traccar currently uses the MySQL-specific Integer.MIN_VALUE streaming
behavior for both MySQL and MariaDB.

Use the configured database.streamFetchSize for MariaDB instead, while
keeping Integer.MIN_VALUE for MySQL.

Reproduced with:
- Traccar 6.15.0
- MariaDB Connector/J 3.5.10

The startup failure is:

SQLSyntaxErrorException: invalid fetch size