### PR TITLE
Decode JT808 location query response (0x0201)

### DIFF
--- a/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Jt808ProtocolDecoder.java
@@ -73,6 +73,7 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_TERMINAL_AUTH = 0x0102;
     public static final int MSG_TERMINAL_ATTRIBUTES = 0x0107;
     public static final int MSG_LOCATION_REPORT = 0x0200;
+    public static final int MSG_LOCATION_QUERY_RESPONSE = 0x0201;
     public static final int MSG_LOCATION_BATCH_2 = 0x0210;
     public static final int MSG_ACCELERATION = 0x2070;
     public static final int MSG_LOCATION_REPORT_2 = 0x5501;
@@ -458,6 +459,14 @@ public class Jt808ProtocolDecoder extends BaseProtocolDecoder {
             Position position = decodeLocation(deviceSession, buf);
             requestAttachments(channel, remoteAddress, id, position);
             return position;
+
+        } else if (type == MSG_LOCATION_QUERY_RESPONSE) {
+
+            sendGeneralResponse(channel, remoteAddress, id, type, index);
+
+            buf.readUnsignedShort(); // response serial number
+
+            return decodeLocation(deviceSession, buf);
 
         } else if (type == MSG_LOCATION_REPORT_2 || type == MSG_LOCATION_REPORT_BLIND) {
 

--- a/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Jt808ProtocolDecoderTest.java
@@ -432,4 +432,15 @@ public class Jt808ProtocolDecoderTest extends ProtocolTest {
 
     }
 
+    @Test
+    public void testDecodeLocationQueryResponse() throws Exception {
+
+        var decoder = inject(new Jt808ProtocolDecoder(null));
+
+        verifyPosition(decoder, binary(
+                "7E0201001E000000000008000100010000000000000002015752A006CB8080000000000000260824153000517E"),
+                position("2026-08-24 07:30:00.000", true, 22.5, 114.0));
+
+    }
+
 }


### PR DESCRIPTION
Split out the decoder part from the JT808 command types PR.

### Changes
- Add `MSG_LOCATION_QUERY_RESPONSE` (0x0201) message constant
- Decode the 0x0201 location query response: send general response and parse the embedded location
- Add `Jt808ProtocolDecoderTest.testDecodeLocationQueryResponse` test

This PR only touches the decoder; the encoder side (new downlink command types) is kept in #5985.

All tests pass (`Jt808ProtocolDecoderTest`).
