### PR TITLE
Dispatch MCP tool calls through the REST API

### DIFF
--- a/src/main/java/org/traccar/web/McpServerHolder.java
+++ b/src/main/java/org/traccar/web/McpServerHolder.java
@@ -30,6 +30,13 @@ import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import org.glassfish.jersey.internal.MapPropertiesDelegate;
+import org.glassfish.jersey.internal.util.collection.Ref;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
 import org.traccar.api.security.PermissionsService;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
@@ -43,18 +50,29 @@ import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Request;
 import reactor.core.publisher.Mono;
 
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @Singleton
 public class McpServerHolder implements AutoCloseable {
 
     public static final String PATH = "/api/mcp";
 
+    private static final String ATTRIBUTE_REQUEST = "request";
+    private static final Type REQUEST_REF_TYPE = new GenericType<Ref<HttpServletRequest>>() { }.getType();
+
     private static final McpSchema.ToolAnnotations READ_ONLY_ANNOTATIONS = new McpSchema.ToolAnnotations(
             null, true, false, true, false, null);
 
+    private final ObjectMapper objectMapper;
     private final Storage storage;
     private final Provider<PermissionsService> permissionsService;
     private final Geocoder geocoder;
@@ -63,11 +81,14 @@ public class McpServerHolder implements AutoCloseable {
     private final HttpServletStreamableServerTransportProvider transport;
     private final McpAsyncServer server;
 
+    private Supplier<ApplicationHandler> apiHandler;
+
     @Inject
     public McpServerHolder(
             ObjectMapper objectMapper, Storage storage, Provider<PermissionsService> permissionsService,
             Config config, @Nullable Geocoder geocoder) {
 
+        this.objectMapper = objectMapper;
         this.storage = storage;
         this.permissionsService = permissionsService;
         this.geocoder = geocoder;
@@ -88,8 +109,12 @@ public class McpServerHolder implements AutoCloseable {
         server = McpServer.async(transport)
                 .serverInfo("traccar-mcp", "1.0.0")
                 .capabilities(capabilities)
-                .tools(createVersionTool(), createDevicePositionTool())
+                .tools(createVersionTool(), createDevicePositionTool(), createSummaryReportTool())
                 .build();
+    }
+
+    public void setApiHandler(Supplier<ApplicationHandler> apiHandler) {
+        this.apiHandler = apiHandler;
     }
 
     private McpTransportContext extractTransportContext(HttpServletRequest request) {
@@ -98,6 +123,7 @@ public class McpServerHolder implements AutoCloseable {
         if (userId != null) {
             contextData.put(McpAuthFilter.ATTRIBUTE_USER_ID, userId);
         }
+        contextData.put(ATTRIBUTE_REQUEST, request);
         if (contextData.isEmpty()) {
             return McpTransportContext.EMPTY;
         }
@@ -193,6 +219,73 @@ public class McpServerHolder implements AutoCloseable {
                     .build());
         } catch (StorageException | SecurityException e) {
             return Mono.just(errorResult(e.getMessage()));
+        }
+    }
+
+
+    private McpServerFeatures.AsyncToolSpecification createSummaryReportTool() {
+
+        var inputSchema = new McpSchema.JsonSchema(
+                "object",
+                Map.of(
+                        "deviceId", Map.of("type", "array", "items", Map.of("type", "integer")),
+                        "from", Map.of("type", "string"),
+                        "to", Map.of("type", "string")),
+                List.of("deviceId", "from", "to"),
+                null, null, null);
+
+        var toolSchema = McpSchema.Tool.builder()
+                .name("reports-summary")
+                .title("Returns summary report for devices over a time range")
+                .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
+                .build();
+
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(toolSchema)
+                .callHandler((context, request) -> callApi(context, request, "reports/summary"))
+                .build();
+    }
+
+    private Mono<McpSchema.CallToolResult> callApi(
+            McpAsyncServerExchange context, McpSchema.CallToolRequest request, String path) {
+
+        var servletRequest = (HttpServletRequest) context.transportContext().get(ATTRIBUTE_REQUEST);
+        if (servletRequest == null) {
+            return Mono.just(errorResult("Request context is missing"));
+        }
+
+        var query = new StringBuilder();
+        request.arguments().forEach((key, value) -> {
+            var values = value instanceof Collection<?> collection ? collection : List.of(value);
+            for (Object item : values) {
+                query.append(query.isEmpty() ? '?' : '&').append(key).append('=')
+                        .append(URLEncoder.encode(String.valueOf(item), StandardCharsets.UTF_8));
+            }
+        });
+
+        URI baseUri = URI.create("http://localhost/api/");
+        var apiRequest = new ContainerRequest(
+                baseUri, baseUri.resolve(path + query), "GET", null, new MapPropertiesDelegate());
+        apiRequest.header("Authorization", servletRequest.getHeader("Authorization"));
+        apiRequest.header("Accept", MediaType.APPLICATION_JSON);
+        apiRequest.setRequestScopedInitializer(injectionManager ->
+                injectionManager.<Ref<HttpServletRequest>>getInstance(REQUEST_REF_TYPE).set(servletRequest));
+
+        try {
+            var output = new ByteArrayOutputStream();
+            ContainerResponse response = apiHandler.get().apply(apiRequest, output).get();
+            String body = output.toString(StandardCharsets.UTF_8);
+            if (response.getStatus() >= 400) {
+                return Mono.just(errorResult(
+                        "HTTP " + response.getStatus() + " " + body.lines().findFirst().orElse("")));
+            }
+            Object result = body.isEmpty() ? Map.of() : objectMapper.readValue(body, Object.class);
+            return Mono.just(McpSchema.CallToolResult.builder()
+                    .structuredContent(result instanceof List<?> ? Map.of("items", result) : result)
+                    .build());
+        } catch (Exception e) {
+            return Mono.just(errorResult(e.toString()));
         }
     }
 

--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -176,16 +176,6 @@ public class WebServer implements LifecycleObject {
             servletHandler.addServlet(servletHolder, "/api/media/*");
         }
 
-        if (config.getBoolean(Keys.WEB_MCP_ENABLE)) {
-            mcpServerHolder = injector.getInstance(McpServerHolder.class);
-            var mcpServletHolder = new ServletHolder(mcpServerHolder.getServlet());
-            mcpServletHolder.setAsyncSupported(true);
-            servletHandler.addServlet(mcpServletHolder, McpServerHolder.PATH);
-            servletHandler.addFilter(
-                    new FilterHolder(new McpAuthFilter(injector.getInstance(LoginService.class))),
-                    McpServerHolder.PATH + "/*", EnumSet.of(DispatcherType.REQUEST));
-        }
-
         ResourceConfig resourceConfig = new ResourceConfig();
         resourceConfig.property("jersey.config.server.wadl.disableWadl", true);
         resourceConfig.registerClasses(
@@ -200,7 +190,19 @@ public class WebServer implements LifecycleObject {
         if (resourceConfig.getClasses().stream().filter(ServerResource.class::equals).findAny().isEmpty()) {
             LOGGER.warn("Failed to load API resources");
         }
-        servletHandler.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/api/*");
+        var apiContainer = new ServletContainer(resourceConfig);
+        servletHandler.addServlet(new ServletHolder(apiContainer), "/api/*");
+
+        if (config.getBoolean(Keys.WEB_MCP_ENABLE)) {
+            mcpServerHolder = injector.getInstance(McpServerHolder.class);
+            mcpServerHolder.setApiHandler(apiContainer::getApplicationHandler);
+            var mcpServletHolder = new ServletHolder(mcpServerHolder.getServlet());
+            mcpServletHolder.setAsyncSupported(true);
+            servletHandler.addServlet(mcpServletHolder, McpServerHolder.PATH);
+            servletHandler.addFilter(
+                    new FilterHolder(new McpAuthFilter(injector.getInstance(LoginService.class))),
+                    McpServerHolder.PATH + "/*", EnumSet.of(DispatcherType.REQUEST));
+        }
     }
 
     private void initSessionConfig(ServletContextHandler servletHandler) {


### PR DESCRIPTION
Draft prototype for the MCP and REST unification discussed in #5976, kept to the minimum needed to show the wiring. One tool, reports-summary, builds a ContainerRequest from the tool arguments and runs it through the API application handler in process, so authentication, permission checks, date parsing, error mapping and action logging all stay in the REST layer.

Tested locally against H2 with a device feeding OsmAnd positions. The summary result matches the REST endpoint, a bad date returns the same 404, and a non-admin user with disableReports is refused the same way.
