### PR TITLE
Call REST API from MCP tools

### DIFF
--- a/src/main/java/org/traccar/web/McpServerHolder.java
+++ b/src/main/java/org/traccar/web/McpServerHolder.java
@@ -30,6 +30,10 @@ import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.jetty.util.URIUtil;
 import org.traccar.api.security.PermissionsService;
 import org.traccar.config.Config;
 import org.traccar.config.Keys;
@@ -43,6 +47,7 @@ import org.traccar.storage.query.Condition;
 import org.traccar.storage.query.Request;
 import reactor.core.publisher.Mono;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,23 +60,28 @@ public class McpServerHolder implements AutoCloseable {
     private static final McpSchema.ToolAnnotations READ_ONLY_ANNOTATIONS = new McpSchema.ToolAnnotations(
             null, true, false, true, false, null);
 
+    private final Client client;
     private final Storage storage;
     private final Provider<PermissionsService> permissionsService;
     private final Geocoder geocoder;
     private final boolean geocodeOnRequest;
+    private final String apiUrl;
 
     private final HttpServletStreamableServerTransportProvider transport;
     private final McpAsyncServer server;
 
     @Inject
     public McpServerHolder(
-            ObjectMapper objectMapper, Storage storage, Provider<PermissionsService> permissionsService,
-            Config config, @Nullable Geocoder geocoder) {
+            ObjectMapper objectMapper, Client client, Storage storage,
+            Provider<PermissionsService> permissionsService, Config config, @Nullable Geocoder geocoder) {
 
+        this.client = client;
         this.storage = storage;
         this.permissionsService = permissionsService;
         this.geocoder = geocoder;
         geocodeOnRequest = config.getBoolean(Keys.GEOCODER_ON_REQUEST);
+        apiUrl = URIUtil.newURI(
+                "http", config.getString(Keys.WEB_ADDRESS, "localhost"), config.getInteger(Keys.WEB_PORT)) + "/api/";
 
         transport = HttpServletStreamableServerTransportProvider.builder()
                 .mcpEndpoint(PATH)
@@ -88,7 +98,7 @@ public class McpServerHolder implements AutoCloseable {
         server = McpServer.async(transport)
                 .serverInfo("traccar-mcp", "1.0.0")
                 .capabilities(capabilities)
-                .tools(createVersionTool(), createDevicePositionTool())
+                .tools(createVersionTool(), createDevicePositionTool(), createReportSummaryTool())
                 .build();
     }
 
@@ -98,6 +108,7 @@ public class McpServerHolder implements AutoCloseable {
         if (userId != null) {
             contextData.put(McpAuthFilter.ATTRIBUTE_USER_ID, userId);
         }
+        contextData.put(HttpHeaders.AUTHORIZATION, request.getHeader(HttpHeaders.AUTHORIZATION));
         if (contextData.isEmpty()) {
             return McpTransportContext.EMPTY;
         }
@@ -151,6 +162,30 @@ public class McpServerHolder implements AutoCloseable {
                 .build();
     }
 
+    private McpServerFeatures.AsyncToolSpecification createReportSummaryTool() {
+
+        var inputSchema = new McpSchema.JsonSchema(
+                "object",
+                Map.of(
+                        "deviceId", Map.of("type", "array", "items", Map.of("type", "number")),
+                        "from", Map.of("type", "string"),
+                        "to", Map.of("type", "string")),
+                List.of("deviceId", "from", "to"),
+                null, null, null);
+
+        var toolSchema = McpSchema.Tool.builder()
+                .name("reports-summary")
+                .title("Returns summary report for devices over a time range")
+                .inputSchema(inputSchema)
+                .annotations(READ_ONLY_ANNOTATIONS)
+                .build();
+
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(toolSchema)
+                .callHandler((context, request) -> callApi(context, request, "reports/summary"))
+                .build();
+    }
+
     private McpSchema.CallToolResult errorResult(String message) {
         return McpSchema.CallToolResult.builder()
                 .addTextContent(message)
@@ -193,6 +228,28 @@ public class McpServerHolder implements AutoCloseable {
                     .build());
         } catch (StorageException | SecurityException e) {
             return Mono.just(errorResult(e.getMessage()));
+        }
+    }
+
+    private Mono<McpSchema.CallToolResult> callApi(
+            McpAsyncServerExchange context, McpSchema.CallToolRequest request, String path) {
+
+        var target = client.target(apiUrl).path(path);
+        for (var entry : request.arguments().entrySet()) {
+            if (entry.getValue() instanceof Collection<?> values) {
+                target = target.queryParam(entry.getKey(), values.toArray());
+            } else {
+                target = target.queryParam(entry.getKey(), entry.getValue());
+            }
+        }
+
+        try (var response = target.request(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, context.transportContext().get(HttpHeaders.AUTHORIZATION))
+                .get()) {
+            return Mono.just(McpSchema.CallToolResult.builder()
+                    .addTextContent(response.readEntity(String.class))
+                    .isError(response.getStatus() / 100 != 2)
+                    .build());
         }
     }
 


### PR DESCRIPTION
Alternative to #6009 for the MCP and REST unification discussed in #5976. The MCP tool reuses the REST endpoint, but the call goes over HTTP to the server's own API using the JAX-RS Client that is already injected. The tool passes the caller's bearer token through, so authentication, permission checks, date parsing, error mapping and action logging are the normal REST path.

I've tried to simplify it and clean it up - this is my last go - if not right I'm not sure if I'm up to this.
