### PR TITLE
Fix LTE cell decoding for Topin protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/TopinProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/TopinProtocolDecoder.java
@@ -252,8 +252,15 @@ public class TopinProtocolDecoder extends BaseProtocolDecoder {
             int mcc = buf.readUnsignedShort();
             int mnc = buf.readUnsignedByte();
             for (int i = 0; i < cellCount; i++) {
-                network.addCellTower(CellTower.from(
-                        mcc, mnc, buf.readUnsignedShort(), buf.readUnsignedShort(), buf.readUnsignedByte()));
+                if (type == MSG_LBS_WIFI_2) {
+                    int tac = buf.readInt();
+                    long eci = buf.readUnsignedInt();
+                    int signal = buf.readUnsignedByte();
+                    network.addCellTower(CellTower.from(mcc, mnc, tac, eci, signal));
+                } else {
+                    network.addCellTower(CellTower.from(
+                            mcc, mnc, buf.readUnsignedShort(), buf.readUnsignedShort(), buf.readUnsignedByte()));
+                }
             }
 
             if (buf.readableBytes() > 2) {

--- a/src/test/java/org/traccar/protocol/TopinProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/TopinProtocolDecoderTest.java
@@ -2,6 +2,8 @@ package org.traccar.protocol;
 
 import org.junit.jupiter.api.Test;
 import org.traccar.ProtocolTest;
+import org.traccar.model.CellTower;
+import org.traccar.model.Network;
 import org.traccar.model.Position;
 
 public class TopinProtocolDecoderTest extends ProtocolTest {
@@ -19,6 +21,10 @@ public class TopinProtocolDecoderTest extends ProtocolTest {
 
         verifyNotNull(decoder, binary(
                 "787803181604130318491475905bd30e25001e10bbf7635d14759006e626560401cc00000028660090df425f000028660090df576c00002866009487566700002866009ca15667000d0a"));
+
+        verifyAttribute(decoder, binary(
+                "7878001a260902194422030106010000119f01e911056f0000119f01e911056f0000119f01e911056f000d0a"),
+                "network", new Network(CellTower.from(262, 1, 0x119f, 0x01e91105L, 0x6f)));
 
         verifyAttribute(decoder, binary(
                 "7878006921120412565802010601071e4a9764071e4a9864010d0a"),


### PR DESCRIPTION
The `MSG_LBS_WIFI_2` message uses 32-bit TAC and ECI fields for LTE cells, while the current decoder reads both values as 16-bit fields.

This causes the cell data to become misaligned and produces incorrect network information. Remaining bytes can also be interpreted as an alarm.

This change decodes LTE cells using a 32-bit TAC, unsigned 32-bit ECI and signal byte, while keeping the existing format for the other LBS message types.

Added a regression test using a packet captured from a Topin ZX909 device.