### PR TITLE
Add frame decoding for Topin protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/TopinProtocol.java
+++ b/src/main/java/org/traccar/protocol/TopinProtocol.java
@@ -16,6 +16,7 @@
 package org.traccar.protocol;
 
 import org.traccar.BaseProtocol;
+import org.traccar.CharacterDelimiterFrameDecoder;
 import org.traccar.PipelineBuilder;
 import org.traccar.TrackerServer;
 import org.traccar.config.Config;
@@ -35,6 +36,7 @@ public class TopinProtocol extends BaseProtocol {
         addServer(new TrackerServer(config, getName(), false) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline, Config config) {
+                pipeline.addLast(new CharacterDelimiterFrameDecoder(MAX_FRAME_LENGTH, false, "\r\n"));
                 pipeline.addLast(new TopinProtocolEncoder(TopinProtocol.this));
                 pipeline.addLast(new TopinProtocolDecoder(TopinProtocol.this));
             }

--- a/src/test/java/org/traccar/protocol/TopinFrameDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/TopinFrameDecoderTest.java
@@ -1,0 +1,34 @@
+package org.traccar.protocol;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+import org.traccar.CharacterDelimiterFrameDecoder;
+import org.traccar.ProtocolTest;
+
+public class TopinFrameDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testMultipleFrames() throws Exception {
+
+        var decoder = new EmbeddedChannel(
+                new CharacterDelimiterFrameDecoder(1024, false, "\r\n"));
+
+        decoder.writeInbound(binary(
+                "787801300d0a"
+                + "787801570d0a"
+                + "787816136407020534000000000000009500181a09021527000d0a"));
+
+        verifyFrame(
+                binary("787801300d0a"),
+                decoder.readInbound());
+
+        verifyFrame(
+                binary("787801570d0a"),
+                decoder.readInbound());
+
+        verifyFrame(
+                binary("787816136407020534000000000000009500181a09021527000d0a"),
+                decoder.readInbound());
+    }
+
+}


### PR DESCRIPTION
The Topin protocol can send multiple CRLF-terminated messages in a single TCP read.

Without a frame decoder, `TopinProtocolDecoder` processes only the first message from the received buffer. Any additional complete messages in the same buffer are discarded.

This change adds a `CharacterDelimiterFrameDecoder` using the protocol's CRLF delimiter while preserving the delimiter expected by the existing decoder.

Added a regression test with three concatenated Topin messages captured from a real device.