### PR TITLE
feat: handshake decoding and test for tk103 protocol

### DIFF
--- a/src/main/java/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -156,6 +156,16 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             .text(")")
             .compile();
 
+    private static final Pattern PATTERN_HANDSHAKE = new PatternBuilder()
+            .text("(")
+            .expression("(.{12})")               // device id
+            .text("BP00")
+            .number("d*")                        // imei
+            .text("HSOP")
+            .number("(xx)")                      // battery level
+            .text(")")
+            .compile();
+
     private String decodeAlarm(int value) {
         return switch (value) {
             case 1 -> Position.ALARM_ACCIDENT;
@@ -380,6 +390,27 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
         return position;
     }
 
+    private Position decodeHandshake(Channel channel, SocketAddress remoteAddress, String sentence) {
+        Parser parser = new Parser(PATTERN_HANDSHAKE, sentence);
+        if (!parser.matches()) {
+            return null;
+        }
+
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, parser.next());
+        if (deviceSession == null) {
+            return null;
+        }
+
+        Position position = new Position(getProtocolName());
+        position.setDeviceId(deviceSession.getDeviceId());
+
+        getLastLocation(position, null);
+
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextHexInt());
+
+        return position;
+    }
+
     private Position decodeBms(Channel channel, SocketAddress remoteAddress, String sentence) {
         String id = sentence.substring(1, 13);
         DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, id);
@@ -489,7 +520,6 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             String type = sentence.substring(13, 17);
             if (type.equals("BP00")) {
                 channel.writeAndFlush(new NetworkMessage("(" + id + "AP01HSO)", remoteAddress));
-                return null;
             } else if (type.equals("BP05")) {
                 channel.writeAndFlush(new NetworkMessage("(" + id + "AP05)", remoteAddress));
             }
@@ -509,6 +539,8 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             return decodeVin(channel, remoteAddress, sentence);
         } else if (sentence.contains("BS50") || sentence.contains("BS51")) {
             return decodeBms(channel, remoteAddress, sentence);
+        } else if (sentence.contains("BP00")) {
+            return decodeHandshake(channel, remoteAddress, sentence);
         }
 
         Parser parser = new Parser(PATTERN, sentence);

--- a/src/main/java/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -160,7 +160,7 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             .text("(")
             .expression("(.{12})")               // device id
             .text("BP00")
-            .number("d*")                        // imei
+            .number("(?:d{15})?")                // imei
             .text("HSOP")
             .number("(xx)")                      // battery level
             .text(")")

--- a/src/test/java/org/traccar/protocol/Tk103ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Tk103ProtocolDecoderTest.java
@@ -11,6 +11,10 @@ public class Tk103ProtocolDecoderTest extends ProtocolTest {
 
         var decoder = inject(new Tk103ProtocolDecoder(null));
 
+        verifyAttribute(decoder, text(
+                "(072105039432BP00352672105039432HSOP4B)"),
+                Position.KEY_BATTERY_LEVEL, 75);
+
         verifyAttributes(decoder, text(
                 "(007030201454BS5190:02150000753001DC,91:0EE8060EDC0A01DC,92:42014201DC0A01DC,93:00010127000037C8,94:0E01000002000000,95:020EE10EE20EE800030EE40EE00EE700040EDD0EE40EE400050EDC0EDF0EE400,96:0142000000000000,97:0000000000000000,98:0000000000000000)"));
 

--- a/src/test/java/org/traccar/protocol/Tk103ProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Tk103ProtocolDecoderTest.java
@@ -12,6 +12,10 @@ public class Tk103ProtocolDecoderTest extends ProtocolTest {
         var decoder = inject(new Tk103ProtocolDecoder(null));
 
         verifyAttribute(decoder, text(
+                "(087075108195BP00HSOP55)"),
+                Position.KEY_BATTERY_LEVEL, 85);
+
+        verifyAttribute(decoder, text(
                 "(072105039432BP00352672105039432HSOP4B)"),
                 Position.KEY_BATTERY_LEVEL, 75);
 


### PR DESCRIPTION
### Description

I have a TK103 device (which may be a clone) that sends the battery level as a hexadecimal value after `HSOP`, for example:

`072105039432BP00352672105039432HSOP4B`

Traccar currently does not decode this value.

This PR detects this message pattern and decodes the hexadecimal value after `HSOP` to determine the battery level.

### Testing

Tested with my device and verified that the battery level is correctly decoded.