### PR TITLE
Gl200: read the GTINF charge flag from the Charging field

### DIFF
--- a/src/main/java/org/traccar/protocol/Gl200TextProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gl200TextProtocolDecoder.java
@@ -260,7 +260,7 @@ public class Gl200TextProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_BATTERY, Double.parseDouble(v[index - 1]));
         }
         if (!v[index++].isEmpty()) {
-            position.set(Position.KEY_CHARGE, Integer.parseInt(v[index++]) == 1 ? true : null);
+            position.set(Position.KEY_CHARGE, Integer.parseInt(v[index - 1]) == 1 ? true : null);
         }
 
         if (model.equals("GV310LAU")) {

--- a/src/test/java/org/traccar/protocol/Gl200TextProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gl200TextProtocolDecoderTest.java
@@ -11,6 +11,10 @@ public class Gl200TextProtocolDecoderTest extends ProtocolTest {
 
         var decoder = inject(new Gl200TextProtocolDecoder(null));
 
+        verifyAttribute(decoder, buffer(
+                "+RESP:GTINF,C30302,860201067023286,,41,89880000000000000000,14,99,0,0.0,,3.77,0,1,2,,,20260908143011,30,,25.9,,,20260909020028,46B4$"),
+                Position.KEY_CHARGE, null);
+
         verifyPositions(decoder, buffer(
                 "+RESP:GTFRI,DF0200,868487004353181,cv100,14051,10,1,0,0.0,0,264.1,114.015515,22.537178,20210608064328,0460,0001,25F8,061A7D02,,0.0,,,,100,21,,,,20210608144354,32DB$"));
 


### PR DESCRIPTION
`decodeInf` consumes the Charging field in the `if` and then parses the *next* field
(LED on) as the charge flag, so `charge` is true whenever the LED is on, and the index
runs one field ahead for everything after it.

The GL300 @Track Air Interface Protocol (rev 6.00, §3.3.2 Device Information Report)
lists the GTINF tail in this order:

```
... Battery voltage, Charging, LED on, GPS on need, GPS antenna type,
    GPS antenna state, Last GPS fix UTC time, battery percentage, ...
```

Observed on a GL320MG (protocol version prefix C3): 286 GTINF frames between
2026-08-27 and 2026-09-09 all report LED on = 1, and 280 of them report Charging = 0.
Traccar stored `charge: true` for all 286.

Fix: parse `v[index - 1]`. The fixture is one of those frames, asserting `charge` is
absent; on master the same frame decodes as `charge: true`.

On the GV310LAU block right after this: its skips start with `// led state`, which only
lines up if `index` points at LED on — which is what this patch produces. On master the
index is one further along, so the ADC reads there look like they were already one field
late. I don't have that device's protocol document, so please confirm.
