### PR TITLE
Gl200: GL320M battery level from GTINF, charge on EPN/EPF

### DIFF
--- a/src/main/java/org/traccar/protocol/Gl200TextProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gl200TextProtocolDecoder.java
@@ -1721,8 +1721,16 @@ public class Gl200TextProtocolDecoder extends BaseProtocolDecoder {
             case "IDL" -> position.addAlarm(Position.ALARM_IDLE);
             case "PNA" -> position.addAlarm(Position.ALARM_POWER_ON);
             case "PFA" -> position.addAlarm(Position.ALARM_POWER_OFF);
-            case "EPN", "MPN" -> position.addAlarm(Position.ALARM_POWER_RESTORED);
-            case "EPF", "MPF" -> position.addAlarm(Position.ALARM_POWER_CUT);
+            case "EPN" -> {
+                position.addAlarm(Position.ALARM_POWER_RESTORED);
+                position.set(Position.KEY_CHARGE, true);
+            }
+            case "MPN" -> position.addAlarm(Position.ALARM_POWER_RESTORED);
+            case "EPF" -> {
+                position.addAlarm(Position.ALARM_POWER_CUT);
+                position.set(Position.KEY_CHARGE, false);
+            }
+            case "MPF" -> position.addAlarm(Position.ALARM_POWER_CUT);
             case "BPL" -> position.addAlarm(Position.ALARM_LOW_BATTERY);
             case "STT" -> position.addAlarm(Position.ALARM_MOVEMENT);
             case "SWG" -> position.addAlarm(Position.ALARM_GEOFENCE);

--- a/src/main/java/org/traccar/protocol/Gl200TextProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/Gl200TextProtocolDecoder.java
@@ -263,6 +263,18 @@ public class Gl200TextProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_CHARGE, Integer.parseInt(v[index - 1]) == 1 ? true : null);
         }
 
+        if (model.equals("GL320M")) {
+            index += 1; // led on
+            index += 1; // gps on need
+            index += 1; // gps antenna type
+            index += 1; // gps antenna state
+            index += 1; // last gps fix time
+            if (v[index].matches("\\d{1,3}")) {
+                position.set(Position.KEY_BATTERY_LEVEL, Integer.parseInt(v[index]));
+            }
+            index += 1; // battery percentage
+        }
+
         if (model.equals("GV310LAU")) {
             index += 1; // led state
             index += 1; // power saving mode

--- a/src/test/java/org/traccar/protocol/Gl200TextProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gl200TextProtocolDecoderTest.java
@@ -19,6 +19,14 @@ public class Gl200TextProtocolDecoderTest extends ProtocolTest {
                 "+RESP:GTINF,C30302,860201067023286,,41,89880000000000000000,20,99,1,0.0,,3.82,1,1,2,,,20260904120120,51,,31.2,,,20260907110117,3E70$"),
                 Position.KEY_BATTERY_LEVEL, 51);
 
+        verifyAttribute(decoder, buffer(
+                "+RESP:GTEPN,C30302,860201067023286,,0,0.0,0,449.0,8.711147,47.507113,20260904120120,0228,0002,9D08,013D9905,,20260907103231,3E6B$"),
+                Position.KEY_CHARGE, true);
+
+        verifyAttribute(decoder, buffer(
+                "+RESP:GTEPF,C30302,860201067023286,,0,0.0,0,449.0,8.711147,47.507113,20260904120120,0228,0002,9D08,013D9905,,20260907112626,3E76$"),
+                Position.KEY_CHARGE, false);
+
         verifyPositions(decoder, buffer(
                 "+RESP:GTFRI,DF0200,868487004353181,cv100,14051,10,1,0,0.0,0,264.1,114.015515,22.537178,20210608064328,0460,0001,25F8,061A7D02,,0.0,,,,100,21,,,,20210608144354,32DB$"));
 

--- a/src/test/java/org/traccar/protocol/Gl200TextProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/Gl200TextProtocolDecoderTest.java
@@ -15,6 +15,10 @@ public class Gl200TextProtocolDecoderTest extends ProtocolTest {
                 "+RESP:GTINF,C30302,860201067023286,,41,89880000000000000000,14,99,0,0.0,,3.77,0,1,2,,,20260908143011,30,,25.9,,,20260909020028,46B4$"),
                 Position.KEY_CHARGE, null);
 
+        verifyAttribute(decoder, buffer(
+                "+RESP:GTINF,C30302,860201067023286,,41,89880000000000000000,20,99,1,0.0,,3.82,1,1,2,,,20260904120120,51,,31.2,,,20260907110117,3E70$"),
+                Position.KEY_BATTERY_LEVEL, 51);
+
         verifyPositions(decoder, buffer(
                 "+RESP:GTFRI,DF0200,868487004353181,cv100,14051,10,1,0,0.0,0,264.1,114.015515,22.537178,20210608064328,0460,0001,25F8,061A7D02,,0.0,,,,100,21,,,,20210608144354,32DB$"));
 


### PR DESCRIPTION
Two additions for battery-powered Queclink devices, verified on a GL320MG (protocol
version prefix C3).

**GTINF carries the battery percentage** after the last GPS fix time. Only FRI and NMR
frames set `batteryLevel` today, so a device that stops moving has none for as long as it
stays still — its latest position is an hourly GTINF. Parsed for model GL320M, gated like
the existing GL320M branches.

**GTEPN / GTEPF** (external power connected / disconnected) now also set `charge` true /
false on the position, so the cable state lives on the position and can be carried
forward with `processing.copyAttributes`. MPN/MPF are vehicle main power and are
unchanged.

Now rebased on master, so the diff is just these two commits; the charge-index fix went
in as #6021.

Protocol documentation and logs in the comment below.
