### PR TITLE
Skip empty T800x 0x2626 cell towers

### DIFF
--- a/src/main/java/org/traccar/protocol/T800xProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/T800xProtocolDecoder.java
@@ -445,6 +445,8 @@ public class T800xProtocolDecoder extends BaseProtocolDecoder {
                             mcc, mnc, buf.readUnsignedShortLE(), buf.readUnsignedShortLE()));
                 }
                 position.setNetwork(network);
+            } else if (header == 0x2626) {
+                buf.skipBytes(12); // cell towers
             }
 
         }

--- a/src/test/java/org/traccar/protocol/T800xProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/T800xProtocolDecoderTest.java
@@ -11,6 +11,10 @@ public class T800xProtocolDecoderTest extends ProtocolTest {
 
         var decoder = inject(new T800xProtocolDecoder(null));
 
+        verifyAttribute(decoder, binary(
+                "262604005330c40863257069370825001902581e0000003f80c0200505000000041600001b5b2800260908230233ffffffffffffffffffffffffffffffff1212000000000000ffffffffffffffffffffffffff"),
+                Position.KEY_POWER, 12.12);
+
         verifyPositions(decoder, false, binary(
                 "26260500400406086961606257315205250513182132ffffffffffffffffffffffff0000ffff0000250513182137ffffffffffffffffffffffff0770ffff0aec"));
 


### PR DESCRIPTION
Follow-up to #6024.

When a TopFlyTech `0x2626` position has no GNSS fix, bytes 47–62 carry MCC, MNC and three LAC/CI pairs. If MCC and MNC are `0xFFFF` the decoder doesn't build the network, but it also doesn't consume the three pairs, so the rest of the message is read 12 bytes early.

In the [TOPFLYtech 0x26 0x26 Protocol 2023-08-02](https://github.com/user-attachments/files/32117883/TOPFLYtech.0x260x26.Protocol.2023-08-02.TorchX.100.TLD2-D.TLD1-DA.or.DE.xlsx) document (the same one attached to #6024), sheet `0x260x260x02`, the block is a fixed 16 bytes, filled with `0xFF` when there is no cell information.

A TLD2-D sends these frames when it has neither a fix nor cell data — 4 of the 429 position and alarm messages from one unit over a day. The fixture is one of them, an ignition-off alarm with the external supply at 12.12 V. On master it decodes as `power=166.65`, a speed of 1666.5 km/h, `rpm=4626` and `coolantTemp=-40`; with this change `power=12.12` and speed 0.

The skip is limited to `0x2626`, the only variant I could verify. The T880X (`0x2323`) specification has the same fixed block, but nothing follows it there, so it makes no difference. If `0x2525` and `0x2727` also always include the block, the condition can go — you'd know better than me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)