### PR TITLE
Decode T800x 0x2626 alarm codes

### DIFF
--- a/src/main/java/org/traccar/protocol/T800xProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/T800xProtocolDecoder.java
@@ -112,6 +112,24 @@ public class T800xProtocolDecoder extends BaseProtocolDecoder {
         };
     }
 
+    private String decodeAlarm3(int value) {
+        return switch (value) {
+            case 0x01 -> Position.ALARM_POWER_CUT;
+            case 0x02 -> Position.ALARM_LOW_BATTERY;
+            case 0x03 -> Position.ALARM_SOS;
+            case 0x04 -> Position.ALARM_OVERSPEED;
+            case 0x05 -> Position.ALARM_GEOFENCE_ENTER;
+            case 0x06 -> Position.ALARM_GEOFENCE_EXIT;
+            case 0x07 -> Position.ALARM_TOW;
+            case 0x08 -> Position.ALARM_VIBRATION;
+            case 0x19 -> Position.ALARM_IDLE;
+            case 0x21 -> Position.ALARM_JAMMING;
+            case 0x23 -> Position.ALARM_POWER_RESTORED;
+            case 0x24 -> Position.ALARM_LOW_POWER;
+            default -> null;
+        };
+    }
+
     private Date readDate(ByteBuf buf) {
         return new DateBuilder()
                 .setYear(BcdUtil.readInteger(buf, 2))
@@ -403,7 +421,11 @@ public class T800xProtocolDecoder extends BaseProtocolDecoder {
         }
 
         int alarm = buf.readUnsignedByte();
-        position.addAlarm(header != 0x2727 ? decodeAlarm1(alarm) : decodeAlarm2(alarm));
+        position.addAlarm(switch (header) {
+            case 0x2626 -> decodeAlarm3(alarm);
+            case 0x2727 -> decodeAlarm2(alarm);
+            default -> decodeAlarm1(alarm);
+        });
         position.set("alarmCode", alarm);
 
         if (header != 0x2727) {

--- a/src/test/java/org/traccar/protocol/T800xProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/T800xProtocolDecoderTest.java
@@ -15,6 +15,14 @@ public class T800xProtocolDecoderTest extends ProtocolTest {
                 "262604005330c40863257069370825001902581e0000003f80c0200505000000041600001b5b2800260908230233ffffffffffffffffffffffffffffffff1212000000000000ffffffffffffffffffffffffff"),
                 Position.KEY_POWER, 12.12);
 
+        verifyAttribute(decoder, binary(
+                "262604005330c50863257069370825001902581e00000045e4c0000500000000042400001b5b280026090900544700000000921d74c2a9010cc2000001231208000000000000ffffffffffffffffffffffffff"),
+                Position.KEY_ALARM, Position.ALARM_LOW_POWER);
+
+        verifyAttribute(decoder, binary(
+                "262604005330c70863257069370825001902581e0000001ed0c0000505000000002300001b5b280026090901122800000000921d74c2a9010cc2000001231274000000000000ffffffffffffffffffffffffff"),
+                Position.KEY_ALARM, Position.ALARM_POWER_RESTORED);
+
         verifyPositions(decoder, false, binary(
                 "26260500400406086961606257315205250513182132ffffffffffffffffffffffff0000ffff0000250513182137ffffffffffffffffffffffff0770ffff0aec"));
 


### PR DESCRIPTION
The TopFlyTech `0x2626` alarm codes are documented in hexadecimal: the attached *TOPFLYtech 0x26 0x26 Command List 2021-11-01*, sheet `Alarm Code List`, lists them in two explicit columns, `Alarm Code(HEX)` and `Alarm Code(DEC)`, so HEX 15 is DEC 21 (ignition on), HEX 23 is DEC 35 (external power recover) and HEX 24 is DEC 36 (external power below threshold). `decodeAlarm1` matches on the decimal values, so:

- `0x15` (21, ignition on) is reported as `jamming`;
- `0x21` (jamming), `0x23` (external power recovered) and `0x24` (external power below threshold) never match.

Across 1761 `0x2626` position and alarm messages captured from three TLD2-D units, only five distinct alarm codes appear, and each one lands on a documented entry when the table is read as hexadecimal: `0x15` (ignition on) ×77, `0x16` (ignition off) ×75, `0x24` (external power below threshold) ×10, `0x23` (external power recovered) ×2 and `0x01` (external power disconnected) ×1. The near-equal ignition on/off counts are what you would expect from real driving, which is a good check that the reading is right.

On master the byte `0x15` is 21, so all 77 ignition-on events are reported as `jamming`, while `0x23` (35) and `0x24` (36) match nothing and are dropped.

This adds `decodeAlarm3` for `0x2626` and leaves `decodeAlarm1` untouched. `0x2525` needs its own change rather than being folded in here: two device generations share that header and they do not share an alarm table, so the right discriminator there is the message type (`0x02` for the older units, `0x13`/`0x14` for TLW2 and PioneerX), not the header. I have devices and the vendor document for that variant too and will send it as a follow-up.

| Code | Meaning | Alarm |
|---|---|---|
| `0x01` | external power disconnected | `powerCut` |
| `0x02` | internal battery low | `lowBattery` |
| `0x03` | SOS | `sos` |
| `0x04` | overspeed | `overspeed` |
| `0x05` / `0x06` | geofence in / out | `geofenceEnter` / `geofenceExit` |
| `0x07` | towing | `tow` |
| `0x08` | vibration | `vibration` |
| `0x19` | idling start | `idle` |
| `0x21` | jamming start | `jamming` |
| `0x23` | external power recovered | `powerRestored` |
| `0x24` | external power below threshold | `lowPower` |

Ignition on and off (`0x15`/`0x16`) are left out because they are already reported through `ignition`, and the "end" codes (`0x20`, `0x22`, `0x29`) have no equivalent. Anti-theft (`0x10`) is left out too: the document doesn't say what triggers it, so there is nothing to map it to.

The two fixtures are a `0x24` and a `0x23` alarm, both real captures: `lowPower` and `powerRestored` with this change, no alarm at all on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TOPFLYtech-0x260x26-Command-List-20211101.xlsx](https://github.com/user-attachments/files/32147557/TOPFLYtech-0x260x26-Command-List-20211101.xlsx)